### PR TITLE
[Feat/#6] Toast 위치 커스텀 유틸리티 추가

### DIFF
--- a/frontend/src/app/design-system-test/page.tsx
+++ b/frontend/src/app/design-system-test/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { RegionConfig, Button, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
+import { useState } from 'react';
+import { PositionedToast } from '@/components/commons/toast/PositionedToast';
+import { usePositionedToast } from '@/components/commons/toast/usePositionedToast';
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+  const toast = usePositionedToast('bottom-center');
+
+  const handleClick = () => {
+    toast({
+      variant: 'normal',
+      content: '우측 아래',
+      placement: 'bottom-left',
+    });
+  };
+
+  return (
+    <>
+      <PositionedToast open={open} onOpenChange={setOpen} duration="short" placement="top-right">
+        <ToastContainer>
+          <ToastIcon />
+          <ToastContent>Content</ToastContent>
+        </ToastContainer>
+      </PositionedToast>
+
+      <Button onClick={() => setOpen(true)}>토스트 메시지 테스트</Button>
+      <Button onClick={handleClick}>훅으로 테스트하기</Button>
+
+      <RegionConfig viewportBottom={`800px`} />
+    </>
+  );
+};
+
+export default Demo;

--- a/frontend/src/app/design-system-test/page.tsx
+++ b/frontend/src/app/design-system-test/page.tsx
@@ -1,19 +1,19 @@
 'use client';
 
-import { RegionConfig, Button, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
+import { Button, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
 import { useState } from 'react';
 import { PositionedToast } from '@/components/commons/toast/PositionedToast';
 import { usePositionedToast } from '@/components/commons/toast/usePositionedToast';
 
 const Demo = () => {
   const [open, setOpen] = useState(false);
-  const toast = usePositionedToast('bottom-center');
+  const toast = usePositionedToast();
 
   const handleClick = () => {
     toast({
       variant: 'normal',
       content: '우측 아래',
-      placement: 'bottom-left',
+      placement: 'bottom-right',
     });
   };
 
@@ -26,10 +26,8 @@ const Demo = () => {
         </ToastContainer>
       </PositionedToast>
 
-      <Button onClick={() => setOpen(true)}>토스트 메시지 테스트</Button>
-      <Button onClick={handleClick}>훅으로 테스트하기</Button>
-
-      <RegionConfig viewportBottom={`800px`} />
+      <Button onClick={() => setOpen(true)}>JSX 테스트</Button>
+      <Button onClick={handleClick}>훅 테스트</Button>
     </>
   );
 };

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -4,11 +4,14 @@ import { ThemeProvider } from '@wanteddev/wds';
 import { AppRouterCacheProvider } from '@wanteddev/wds-nextjs';
 
 import '@wanteddev/wds/global.css';
+import { ToastProvider } from './commons/toast/ToastProvider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
-      <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+      <ToastProvider>
+        <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/commons/toast/PositionedToast.tsx
+++ b/frontend/src/components/commons/toast/PositionedToast.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Toast, type ToastProps } from '@wanteddev/wds';
+import type { ToastPlacement } from './toast.types';
+import { getOrCreateContainer } from './toastContainerMap';
+
+interface PositionedToastProps extends ToastProps {
+  placement?: ToastPlacement;
+}
+
+export function PositionedToast({ placement = 'bottom-center', ...props }: PositionedToastProps) {
+  const container = typeof window !== 'undefined' ? getOrCreateContainer(placement) : undefined;
+
+  return <Toast container={container} {...props} />;
+}

--- a/frontend/src/components/commons/toast/PositionedToast.tsx
+++ b/frontend/src/components/commons/toast/PositionedToast.tsx
@@ -8,6 +8,14 @@ interface PositionedToastProps extends ToastProps {
   placement?: ToastPlacement;
 }
 
+/**
+ * 선언적 방식으로 토스트를 표시할 때 사용합니다.
+ * `placement` 속성에 따라 적절한 위치의 컨테이너 안에 자동으로 렌더링됩니다.
+ * * @example
+ * <PositionedToast open={open} onOpenChange={setOpen} placement="top-right">
+ * <ToastContainer>...</ToastContainer>
+ * </PositionedToast>
+ */
 export function PositionedToast({ placement = 'bottom-center', ...props }: PositionedToastProps) {
   const container = typeof window !== 'undefined' ? getOrCreateContainer(placement) : undefined;
 

--- a/frontend/src/components/commons/toast/ToastProvider.tsx
+++ b/frontend/src/components/commons/toast/ToastProvider.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ToastRenderer } from './ToastRenderer';
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <ToastRenderer />
+    </>
+  );
+}

--- a/frontend/src/components/commons/toast/ToastRenderer.tsx
+++ b/frontend/src/components/commons/toast/ToastRenderer.tsx
@@ -3,29 +3,14 @@
 import { Toast, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
 import { useEffect, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
-import styles from './toast.module.css';
 import type { ToastPlacement } from './toast.types';
+import { getOrCreateContainer } from './toastContainerMap';
 import { toastStore } from './toastStore';
 import type { ToastItem } from './toastStore';
 
 // placement별로 컨테이너를 동적 생성 -> toastStore를 구독하면서 placement별로 그룹핑 후 각 컨테이너 DOM에 createPortal로 렌더링
 
 const containerMap = new Map<ToastPlacement, HTMLDivElement>();
-
-function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
-  if (containerMap.has(placement)) return containerMap.get(placement)!;
-
-  const [vertical, horizontal] = placement.split('-') as [
-    'top' | 'bottom',
-    'left' | 'center' | 'right',
-  ];
-
-  const el = document.createElement('div');
-  el.className = [styles.container, styles[vertical], styles[horizontal]].join(' ');
-  document.body.appendChild(el);
-  containerMap.set(placement, el);
-  return el;
-}
 
 function cleanupUnusedContainers(usedPlacements: Set<ToastPlacement>) {
   containerMap.forEach((el, placement) => {

--- a/frontend/src/components/commons/toast/ToastRenderer.tsx
+++ b/frontend/src/components/commons/toast/ToastRenderer.tsx
@@ -57,13 +57,16 @@ export function ToastRenderer() {
           items.map((t) => (
             <Toast
               key={t.id}
-              open
+              open={!t.closing}
               variant={t.variant}
               duration={t.duration}
               onOpenChange={(open) => {
-                if (!open) toastStore.remove(t.id);
+                if (!open) toastStore.startClose(t.id); // 바로 remove 대신 closing 상태로
               }}
-              onAnimationEnd={t.onAnimationEnd}
+              onAnimationEnd={(type) => {
+                if (type === 'hide') toastStore.remove(t.id); // 애니메이션 끝난 후 제거
+                t.onAnimationEnd?.(type);
+              }}
               disablePortal
             >
               <ToastContainer>

--- a/frontend/src/components/commons/toast/ToastRenderer.tsx
+++ b/frontend/src/components/commons/toast/ToastRenderer.tsx
@@ -4,22 +4,11 @@ import { Toast, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
 import { useEffect, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import type { ToastPlacement } from './toast.types';
-import { getOrCreateContainer } from './toastContainerMap';
+import { getOrCreateContainer, cleanupUnusedContainers, containerMap } from './toastContainerMap';
 import { toastStore } from './toastStore';
 import type { ToastItem } from './toastStore';
 
 // placement별로 컨테이너를 동적 생성 -> toastStore를 구독하면서 placement별로 그룹핑 후 각 컨테이너 DOM에 createPortal로 렌더링
-
-const containerMap = new Map<ToastPlacement, HTMLDivElement>();
-
-function cleanupUnusedContainers(usedPlacements: Set<ToastPlacement>) {
-  containerMap.forEach((el, placement) => {
-    if (!usedPlacements.has(placement)) {
-      document.body.removeChild(el);
-      containerMap.delete(placement);
-    }
-  });
-}
 
 export function ToastRenderer() {
   const toasts = useSyncExternalStore<ToastItem[]>(

--- a/frontend/src/components/commons/toast/ToastRenderer.tsx
+++ b/frontend/src/components/commons/toast/ToastRenderer.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Toast, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
+import { useEffect, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './toast.module.css';
+import type { ToastPlacement } from './toast.types';
+import { toastStore } from './toastStore';
+import type { ToastItem } from './toastStore';
+
+const containerMap = new Map<ToastPlacement, HTMLDivElement>();
+
+function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
+  if (containerMap.has(placement)) return containerMap.get(placement)!;
+
+  const [vertical, horizontal] = placement.split('-') as [
+    'top' | 'bottom',
+    'left' | 'center' | 'right',
+  ];
+
+  const el = document.createElement('div');
+  el.className = [styles.container, styles[vertical], styles[horizontal]].join(' ');
+  document.body.appendChild(el);
+  containerMap.set(placement, el);
+  return el;
+}
+
+function cleanupUnusedContainers(usedPlacements: Set<ToastPlacement>) {
+  containerMap.forEach((el, placement) => {
+    if (!usedPlacements.has(placement)) {
+      document.body.removeChild(el);
+      containerMap.delete(placement);
+    }
+  });
+}
+
+export function ToastRenderer() {
+  const toasts = useSyncExternalStore<ToastItem[]>(
+    toastStore.subscribe,
+    () => toastStore.getSnapshot(),
+    () => [],
+  );
+
+  useEffect(() => {
+    const usedPlacements = new Set(toasts.map((t) => t.placement));
+    cleanupUnusedContainers(usedPlacements);
+  }, [toasts]);
+
+  useEffect(() => {
+    return () => {
+      containerMap.forEach((el) => document.body.removeChild(el));
+      containerMap.clear();
+    };
+  }, []);
+
+  if (typeof window === 'undefined') return null;
+
+  const grouped = toasts.reduce<Map<ToastPlacement, ToastItem[]>>((acc, toast) => {
+    const list = acc.get(toast.placement) ?? [];
+    acc.set(toast.placement, [...list, toast]);
+    return acc;
+  }, new Map());
+
+  return (
+    <>
+      {Array.from(grouped.entries()).map(([placement, items]) => {
+        const container = getOrCreateContainer(placement);
+
+        return createPortal(
+          items.map((t) => (
+            <Toast
+              key={t.id}
+              open
+              variant={t.variant}
+              duration={t.duration}
+              onOpenChange={(open) => {
+                if (!open) toastStore.remove(t.id);
+              }}
+              onAnimationEnd={t.onAnimationEnd}
+            >
+              <ToastContainer>
+                {t.icon !== undefined ? (
+                  <ToastIcon>{t.icon}</ToastIcon>
+                ) : (
+                  t.variant !== 'normal' && <ToastIcon />
+                )}
+                <ToastContent>{t.content}</ToastContent>
+              </ToastContainer>
+            </Toast>
+          )),
+          container,
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/commons/toast/ToastRenderer.tsx
+++ b/frontend/src/components/commons/toast/ToastRenderer.tsx
@@ -8,6 +8,8 @@ import type { ToastPlacement } from './toast.types';
 import { toastStore } from './toastStore';
 import type { ToastItem } from './toastStore';
 
+// placement별로 컨테이너를 동적 생성 -> toastStore를 구독하면서 placement별로 그룹핑 후 각 컨테이너 DOM에 createPortal로 렌더링
+
 const containerMap = new Map<ToastPlacement, HTMLDivElement>();
 
 function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
@@ -37,8 +39,8 @@ function cleanupUnusedContainers(usedPlacements: Set<ToastPlacement>) {
 export function ToastRenderer() {
   const toasts = useSyncExternalStore<ToastItem[]>(
     toastStore.subscribe,
-    () => toastStore.getSnapshot(),
-    () => [],
+    toastStore.getSnapshot,
+    toastStore.getServerSnapshot,
   );
 
   useEffect(() => {
@@ -77,6 +79,7 @@ export function ToastRenderer() {
                 if (!open) toastStore.remove(t.id);
               }}
               onAnimationEnd={t.onAnimationEnd}
+              disablePortal
             >
               <ToastContainer>
                 {t.icon !== undefined ? (

--- a/frontend/src/components/commons/toast/toast.module.css
+++ b/frontend/src/components/commons/toast/toast.module.css
@@ -10,9 +10,11 @@
 /* 수직 */
 .top {
   top: 16px;
+  flex-direction: column; /* top은 토스트가 아래로 쌓이도록 */
 }
 .bottom {
   bottom: 16px;
+  flex-direction: column-reverse; /* bottom은 토스트가 위로 쌓이도록 */
 }
 
 /* 수평 */
@@ -27,11 +29,3 @@
   right: 16px;
 }
 
-/* top은 토스트가 아래로 쌓이도록 */
-.top {
-  flex-direction: column;
-}
-/* bottom은 토스트가 위로 쌓이도록 */
-.bottom {
-  flex-direction: column-reverse;
-}

--- a/frontend/src/components/commons/toast/toast.module.css
+++ b/frontend/src/components/commons/toast/toast.module.css
@@ -1,0 +1,37 @@
+.container {
+  position: fixed;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+/* 수직 */
+.top {
+  top: 16px;
+}
+.bottom {
+  bottom: 16px;
+}
+
+/* 수평 */
+.left {
+  left: 16px;
+}
+.center {
+  left: 50%;
+  transform: translateX(-50%);
+}
+.right {
+  right: 16px;
+}
+
+/* top은 토스트가 아래로 쌓이도록 */
+.top {
+  flex-direction: column;
+}
+/* bottom은 토스트가 위로 쌓이도록 */
+.bottom {
+  flex-direction: column-reverse;
+}

--- a/frontend/src/components/commons/toast/toast.types.ts
+++ b/frontend/src/components/commons/toast/toast.types.ts
@@ -5,3 +5,5 @@ export type ToastPlacement =
   | 'bottom-left'
   | 'bottom-center'
   | 'bottom-right';
+
+export type Variant = 'normal' | 'positive' | 'cautionary' | 'negative';

--- a/frontend/src/components/commons/toast/toast.types.ts
+++ b/frontend/src/components/commons/toast/toast.types.ts
@@ -1,0 +1,7 @@
+export type ToastPlacement =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';

--- a/frontend/src/components/commons/toast/toastContainerMap.ts
+++ b/frontend/src/components/commons/toast/toastContainerMap.ts
@@ -2,7 +2,7 @@
 import styles from './toast.module.css';
 import type { ToastPlacement } from './toast.types';
 
-const containerMap = new Map<ToastPlacement, HTMLDivElement>();
+export const containerMap = new Map<ToastPlacement, HTMLDivElement>();
 
 export function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
   const cached = containerMap.get(placement);
@@ -18,4 +18,13 @@ export function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement 
   document.body.appendChild(el);
   containerMap.set(placement, el);
   return el;
+}
+
+export function cleanupUnusedContainers(usedPlacements: Set<ToastPlacement>) {
+  containerMap.forEach((el, placement) => {
+    if (!usedPlacements.has(placement)) {
+      document.body.removeChild(el);
+      containerMap.delete(placement);
+    }
+  });
 }

--- a/frontend/src/components/commons/toast/toastContainerMap.ts
+++ b/frontend/src/components/commons/toast/toastContainerMap.ts
@@ -5,7 +5,8 @@ import type { ToastPlacement } from './toast.types';
 const containerMap = new Map<ToastPlacement, HTMLDivElement>();
 
 export function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
-  if (containerMap.has(placement)) return containerMap.get(placement)!;
+  const cached = containerMap.get(placement);
+  if (cached) return cached;
 
   const [vertical, horizontal] = placement.split('-') as [
     'top' | 'bottom',

--- a/frontend/src/components/commons/toast/toastContainerMap.ts
+++ b/frontend/src/components/commons/toast/toastContainerMap.ts
@@ -1,0 +1,20 @@
+// toastContainerMap.ts
+import styles from './toast.module.css';
+import type { ToastPlacement } from './toast.types';
+
+const containerMap = new Map<ToastPlacement, HTMLDivElement>();
+
+export function getOrCreateContainer(placement: ToastPlacement): HTMLDivElement {
+  if (containerMap.has(placement)) return containerMap.get(placement)!;
+
+  const [vertical, horizontal] = placement.split('-') as [
+    'top' | 'bottom',
+    'left' | 'center' | 'right',
+  ];
+
+  const el = document.createElement('div');
+  el.className = [styles.container, styles[vertical], styles[horizontal]].join(' ');
+  document.body.appendChild(el);
+  containerMap.set(placement, el);
+  return el;
+}

--- a/frontend/src/components/commons/toast/toastContainerMap.ts
+++ b/frontend/src/components/commons/toast/toastContainerMap.ts
@@ -1,4 +1,4 @@
-// toastContainerMap.ts
+// placement마다 DOM <div>를 하나씩 만들어 document.body에 붙이기 위해 사용
 import styles from './toast.module.css';
 import type { ToastPlacement } from './toast.types';
 

--- a/frontend/src/components/commons/toast/toastStore.ts
+++ b/frontend/src/components/commons/toast/toastStore.ts
@@ -9,6 +9,7 @@ export interface ToastItem {
   duration?: number | 'short' | 'long';
   onAnimationEnd?: (type: 'show' | 'hide') => void;
   placement: ToastPlacement;
+  closing?: boolean;
 }
 
 type Listener = () => void;
@@ -25,6 +26,10 @@ function notify() {
 export const toastStore = {
   add(item: ToastItem) {
     items = [...items, item];
+    notify();
+  },
+  startClose(id: string) {
+    items = items.map((i) => (i.id === id ? { ...i, closing: true } : i));
     notify();
   },
   remove(id: string) {

--- a/frontend/src/components/commons/toast/toastStore.ts
+++ b/frontend/src/components/commons/toast/toastStore.ts
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
-import type { ToastPlacement } from './toast.types';
-
-type Variant = 'normal' | 'positive' | 'cautionary' | 'negative';
+import type { ToastPlacement, Variant } from './toast.types';
 
 export interface ToastItem {
   id: string;

--- a/frontend/src/components/commons/toast/toastStore.ts
+++ b/frontend/src/components/commons/toast/toastStore.ts
@@ -13,12 +13,15 @@ export interface ToastItem {
   placement: ToastPlacement;
 }
 
-type Listener = (items: ToastItem[]) => void;
+type Listener = () => void;
+
 let items: ToastItem[] = [];
 const listeners = new Set<Listener>();
 
+const EMPTY: ToastItem[] = [];
+
 function notify() {
-  listeners.forEach((l) => l([...items]));
+  listeners.forEach((l) => l());
 }
 
 export const toastStore = {
@@ -36,5 +39,8 @@ export const toastStore = {
   },
   getSnapshot(): ToastItem[] {
     return items;
+  },
+  getServerSnapshot(): ToastItem[] {
+    return EMPTY;
   },
 };

--- a/frontend/src/components/commons/toast/toastStore.ts
+++ b/frontend/src/components/commons/toast/toastStore.ts
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import type { ToastPlacement } from './toast.types';
+
+type Variant = 'normal' | 'positive' | 'cautionary' | 'negative';
+
+export interface ToastItem {
+  id: string;
+  content: ReactNode;
+  variant?: Variant;
+  icon?: ReactNode;
+  duration?: number | 'short' | 'long';
+  onAnimationEnd?: (type: 'show' | 'hide') => void;
+  placement: ToastPlacement;
+}
+
+type Listener = (items: ToastItem[]) => void;
+let items: ToastItem[] = [];
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((l) => l([...items]));
+}
+
+export const toastStore = {
+  add(item: ToastItem) {
+    items = [...items, item];
+    notify();
+  },
+  remove(id: string) {
+    items = items.filter((i) => i.id !== id);
+    notify();
+  },
+  subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): ToastItem[] {
+    return items;
+  },
+};

--- a/frontend/src/components/commons/toast/usePositionedToast.ts
+++ b/frontend/src/components/commons/toast/usePositionedToast.ts
@@ -1,9 +1,7 @@
 import { useCallback } from 'react';
 import type { ReactNode } from 'react';
-import type { ToastPlacement } from './toast.types';
+import type { ToastPlacement, Variant } from './toast.types';
 import { toastStore } from './toastStore';
-
-type Variant = 'normal' | 'positive' | 'cautionary' | 'negative';
 
 interface ToastOptions {
   id?: string;

--- a/frontend/src/components/commons/toast/usePositionedToast.ts
+++ b/frontend/src/components/commons/toast/usePositionedToast.ts
@@ -4,21 +4,38 @@ import type { ToastPlacement, Variant } from './toast.types';
 import { toastStore } from './toastStore';
 
 interface ToastOptions {
+  /** 토스트의 고유 ID (미지정 시 자동 생성) */
   id?: string;
+  /** 토스트에 표시할 내용 (텍스트 또는 React 노드) */
   content: ReactNode;
+  /** 토스트의 스타일 변형 */
   variant?: Variant;
+  /** 표시할 아이콘 노드 */
   icon?: ReactNode;
+  /** * 토스트 유지 시간
+   * @default 'short'
+   */
   duration?: number | 'short' | 'long';
+  /** 애니메이션이 끝났을 때 실행될 콜백 */
   onAnimationEnd?: (type: 'show' | 'hide') => void;
+  /** * 토스트가 표시될 위치
+   * @default 'bottom-center'
+   */
   placement?: ToastPlacement;
 }
 
-// id값 생성
 let toastCount = 0;
 function generateId() {
   return `toast-${++toastCount}`;
 }
 
+/**
+ * 명령형(Imperative) 방식으로 특정 위치에 토스트를 호출할 수 있는 기능을 제공합니다.
+ * * @example
+ * const toast = usePositionedToast();
+ * toast({ content: '성공했습니다!', variant: 'normal', placement: 'top-right' });
+ * * @returns {Function} 토스트 실행 함수
+ */
 export function usePositionedToast() {
   return useCallback(({ id, placement, ...options }: ToastOptions) => {
     toastStore.add({

--- a/frontend/src/components/commons/toast/usePositionedToast.tsx
+++ b/frontend/src/components/commons/toast/usePositionedToast.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useId } from 'react';
+import type { ReactNode } from 'react';
+import type { ToastPlacement } from './toast.types';
+import { toastStore } from './toastStore';
+
+type Variant = 'normal' | 'positive' | 'cautionary' | 'negative';
+
+interface ToastOptions {
+  id?: string;
+  content: ReactNode;
+  variant?: Variant;
+  icon?: ReactNode;
+  duration?: number | 'short' | 'long';
+  onAnimationEnd?: (type: 'show' | 'hide') => void;
+  placement?: ToastPlacement;
+}
+
+export function usePositionedToast(defaultPlacement: ToastPlacement = 'bottom-center') {
+  const defaultId = useId();
+
+  return useCallback(
+    ({ id, placement, ...options }: ToastOptions) => {
+      toastStore.add({
+        id: id ?? defaultId,
+        placement: placement ?? defaultPlacement,
+        ...options,
+      });
+    },
+    [defaultId, defaultPlacement],
+  );
+}

--- a/frontend/src/components/commons/toast/usePositionedToast.tsx
+++ b/frontend/src/components/commons/toast/usePositionedToast.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId } from 'react';
+import { useCallback } from 'react';
 import type { ReactNode } from 'react';
 import type { ToastPlacement } from './toast.types';
 import { toastStore } from './toastStore';
@@ -15,17 +15,18 @@ interface ToastOptions {
   placement?: ToastPlacement;
 }
 
-export function usePositionedToast(defaultPlacement: ToastPlacement = 'bottom-center') {
-  const defaultId = useId();
+// id값 생성
+let toastCount = 0;
+function generateId() {
+  return `toast-${++toastCount}`;
+}
 
-  return useCallback(
-    ({ id, placement, ...options }: ToastOptions) => {
-      toastStore.add({
-        id: id ?? defaultId,
-        placement: placement ?? defaultPlacement,
-        ...options,
-      });
-    },
-    [defaultId, defaultPlacement],
-  );
+export function usePositionedToast() {
+  return useCallback(({ id, placement, ...options }: ToastOptions) => {
+    toastStore.add({
+      id: id ?? generateId(),
+      placement: placement ?? 'bottom-center',
+      ...options,
+    });
+  }, []);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
closes #6 

## 📝작업 내용
- Toast 위치 커스텀하였습니다~
- 기본적으로 WDS에서 `Toast`, `useToast`가 구현되어 있으나 하단 중앙에 고정되어 있어 상단/좌측/우측 배치가 불가능해 수정하였습니다!   

### 파일 구조
```
src/components/commons/toast/
  toast.types.ts          — ToastPlacement 타입 정의
  toast.module.css        — 위치별 CSS 클래스
  toastStore.ts           — 전역 토스트 상태 관리
  toastContainerMap.ts    — placement별 DOM 컨테이너 관리
  ToastRenderer.tsx       — toastStore 구독 후 실제 렌더링
  ToastProvider.tsx       — ToastRenderer를 앱에 주입
  usePositionedToast.ts   — 훅 방식 사용
  PositionedToast.tsx     — JSX 방식 사용
```

### 파일 구조가 워낙 복잡한 거 같아서 간단하게 설명하면... 
  - `toastStore.ts` : 토스트 목록을 모듈 레벨 변수로 관리. `useSyncExternalStore`와 함께 쓰기 위해 `subscribe` / `getSnapshot` / `getServerSnapshot`을 제공
  - `toastContainerMap.ts` : placement마다 `<div>`를 하나씩 `document.body`에 추가하고 Map으로 관리. 같은 placement를 요청하면 기존 엘리먼트를 재사용. 모듈 레벨 변수로 관리해서 `useRef` 없이 render 함수 안에서 자유롭게 호출할 수 있도록 구현하였습니다.
  - `ToastRenderer.tsx` : `toastStore`를 구독하면서 placement 별로 그룹핑한 후 각 컨테이너 DOM에 `createPortal`로 렌더링

### 동작 원리
#### 훅 방식 (`usePositionedToast`)
 
```
toast() 호출
  → toastStore.add({ placement, ...options })
    → 구독 중인 리스너에 notify()
      → useSyncExternalStore가 변경 감지
        → ToastRenderer 리렌더링
          → placement별로 토스트 그룹핑
            → getOrCreateContainer(placement)로 컨테이너 DOM 가져오기
              → createPortal(Toast, container)로 해당 위치에 렌더링
```
 
#### JSX 방식 (`PositionedToast`)
 
```
<PositionedToast placement="top-right" open={open}>
  → getOrCreateContainer('top-right')로 컨테이너 DOM 가져오기
    → WDS <Toast container={container}>에 주입
      → Toast가 해당 컨테이너 DOM 위치에 직접 렌더링
```
 
### 사용법
#### `usePositionedToast` — 훅 방식
 
버튼 클릭, API 응답 처리 등 이벤트에 반응해서 토스트를 띄울 때 사용
 
```tsx
'use client';
 
import { usePositionedToast } from '@/components/commons/toast/usePositionedToast';
 
export function SaveButton() {
  const toast = usePositionedToast();
 
  const handleSave = async () => {
    try {
      await saveData();
      toast({ content: '저장되었습니다.', variant: 'positive' });
    } catch {
      // placement를 지정하지 않으면 기본값 'bottom-center'
      // 호출할 때 placement 지정
      toast({ content: '저장에 실패했습니다.', variant: 'negative', placement: 'top-center' });
    }
  };
 
  return <button onClick={handleSave}>저장</button>;
}
```
 
**지원하는 모든 옵션(문서 보고 다 구현한다고 했는데 혹시 빠진 거 있으면 알려주세요):**
 
| 옵션 | 타입 | 기본값 | 설명 |
|---|---|---|---|
| `content` | `ReactNode` | **(필수)** | 토스트에 표시할 내용 |
| `placement` | `ToastPlacement` | `'bottom-center'` | 토스트 표시 위치 |
| `variant` | `'normal' \| 'positive' \| 'cautionary' \| 'negative'` | `'normal'` | 토스트 스타일 |
| `icon` | `ReactNode` | `-` | 커스텀 아이콘 |
| `duration` | `number \| 'short' \| 'long' \| Infinity` | `'short'` | 표시 시간 |
| `id` | `string` | 자동 생성 | 토스트 고유 ID |
| `onAnimationEnd` | `(type: 'show' \| 'hide') => void` | `-` | 애니메이션 종료 콜백 |
 
---
 
#### `PositionedToast` — JSX 방식
 
`open` 상태를 직접 제어해야 할 때, 또는 WDS Toast를 쓰던 방식 그대로 위치만 추가하고 싶을 때 사용
 
```tsx
'use client';
 
import { useState } from 'react';
import { ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
import { PositionedToast } from '@/components/commons/toast/PositionedToast';
 
export function MyComponent() {
  const [open, setOpen] = useState(false);
 
  return (
    <>
      {/* WDS Toast와 완전히 동일한 방식, placement만 추가 */}
      <PositionedToast
        open={open}
        onOpenChange={setOpen}
        duration="short"
        variant="positive"
        placement="top-right"
      >
        <ToastContainer>
          <ToastIcon />
          <ToastContent>저장되었습니다.</ToastContent>
        </ToastContainer>
      </PositionedToast>
 
      <button onClick={() => setOpen(true)}>저장</button>
    </>
  );
}
```
 
WDS `Toast`의 모든 props(`variant`, `duration`, `onOpenChange`, `onAnimationEnd`, `disableAnimation` 등)를 그대로 사용하도록 구현했어요~ - 

### 스크린샷 (선택)
<img width="2560" height="1397" alt="image" src="https://github.com/user-attachments/assets/8cf60298-39bc-4e1e-8df9-f0f8fc007fa4" />


 ## 배운 점!! 

- getSnapshot이 항상 같은 배열 참조를 반환해야 하는 이유 : 
`useSyncExternalStore`는 이전 스냅샷과 현재 스냅샷을 `Object.is`로 비교하기 때문에 변경이 없을 때 새 배열([])을 반환하면 매번 다른 참조로 판단해 무한 루프가 발생!! `items` 변수 자체를 반환하면 add / remove 때만 새 배열이 생성되고 그 외에는 항상 같은 참조를 유지하도록 개발했습니다~ 변경 없으면 같은 참조를 유지하고 `serverSnapshot`의 경우에는 고정된 빈 배열을 반환해요.

## 💬리뷰 요구사항
- 기본으로 사용(중앙 하단) 할 때는 WDS 기본으로 사용할 지, 모두 커스텀한 친구로 통일할 지 이야기 나눠봐야 할 것 같아요~ 어떻게 하면 좋을지 코멘트 남겨주세요!
- `/design-system-test` 페이지에서 테스트 가능합니다! 테스트 해 보고 안 되는 거 있으면 알려주세요...
- 약간 레전드 천방지축 코드가 된 같아서 코드리뷰 쪼금 빡빡하게 보고 해 주세용 나도 내가 불안해서...........  
  
  
