### PR TITLE
[Feat/#25] 다이얼로그(커스텀 Alert) 생성

### DIFF
--- a/frontend/src/app/design-system-test/page.tsx
+++ b/frontend/src/app/design-system-test/page.tsx
@@ -1,33 +1,41 @@
 'use client';
 
-import { Button, ToastContainer, ToastContent, ToastIcon } from '@wanteddev/wds';
+import {
+  Alert,
+  AlertActionArea,
+  AlertActionAreaButton,
+  AlertContainer,
+  AlertContent,
+  AlertDescription,
+  AlertHeading,
+  Button,
+} from '@wanteddev/wds';
 import { useState } from 'react';
-import { PositionedToast } from '@/components/commons/toast/PositionedToast';
-import { usePositionedToast } from '@/components/commons/toast/usePositionedToast';
 
 const Demo = () => {
   const [open, setOpen] = useState(false);
-  const toast = usePositionedToast();
-
-  const handleClick = () => {
-    toast({
-      variant: 'normal',
-      content: '우측 아래',
-      placement: 'bottom-right',
-    });
-  };
+  const [result, setResult] = useState<string | null>(null);
 
   return (
     <>
-      <PositionedToast open={open} onOpenChange={setOpen} duration="short" placement="top-right">
-        <ToastContainer>
-          <ToastIcon />
-          <ToastContent>Content</ToastContent>
-        </ToastContainer>
-      </PositionedToast>
+      <Alert open={open} onOpenChange={setOpen}>
+        <AlertContainer onDismiss={() => setResult('Dismissed')}>
+          <AlertContent>
+            <AlertHeading>Heading</AlertHeading>
+            <AlertDescription>Description</AlertDescription>
+          </AlertContent>
+          <AlertActionArea>
+            <AlertActionAreaButton variant="assistive" onClick={() => setResult('Cancel')}>
+              Cancel
+            </AlertActionAreaButton>
+            <AlertActionAreaButton variant="normal" onClick={() => setResult('Confirm')}>
+              Confirm
+            </AlertActionAreaButton>
+          </AlertActionArea>
+        </AlertContainer>
+      </Alert>
 
-      <Button onClick={() => setOpen(true)}>JSX 테스트</Button>
-      <Button onClick={handleClick}>훅 테스트</Button>
+      <Button onClick={() => setOpen(true)}>Alert 테스트</Button>
     </>
   );
 };

--- a/frontend/src/app/modal-test/page.tsx
+++ b/frontend/src/app/modal-test/page.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@wanteddev/wds';
 import { IconFolder, IconBell, IconPerson } from '@wanteddev/wds-icon';
+import { useDialog } from '@/components/commons/dialog/DialogContext';
 import { useModal } from '@/components/commons/modal/ModalContext';
 
 // ── 사이드바 예시 컴포넌트 ──────────────────────────────────
@@ -84,6 +85,7 @@ function ProjectSettingsContent({ onClose }: { onClose: () => void }) {
 // ── Demo Page ─────────────────────────────────────────────
 export default function DemoPage() {
   const { openModal, closeModal } = useModal()!;
+  const { openDialog } = useDialog();
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-50 p-8">
@@ -114,22 +116,28 @@ export default function DemoPage() {
 
         {/* ② compact 모달 */}
         <button
-          onClick={() =>
+          onClick={() => {
             openModal({
-              variant: 'compact',
+              variant: 'default',
               content: (
                 <p className="text-sm leading-relaxed text-gray-600">
-                  좌우 <strong>36px</strong>, 상하 <strong>24px</strong> 패딩의 컴팩트 모달입니다.
-                  검색 모달에 적합합니다.
+                  상하좌우 패딩이 모두 <strong>48px</strong>인 기본 모달입니다. 본문에는 어떤
+                  콘텐츠든 자유롭게 채울 수 있습니다.
                 </p>
               ),
-            })
-          }
+            });
+            openDialog({
+              content: (
+                <p className="text-sm leading-relaxed text-gray-600">
+                  좌우 <strong>20px</strong>, 상하 <strong>20-12px</strong> 다이얼로그 모달입니다.
+                </p>
+              ),
+            });
+          }}
           className="rounded-lg bg-teal-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-teal-500"
         >
-          Compact 모달 열기
+          다이얼로그 열기
         </button>
-
         {/* ③ sidebar 모달 */}
         <button
           onClick={() =>

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -5,6 +5,8 @@ import { AppRouterCacheProvider } from '@wanteddev/wds-nextjs';
 
 import Modal from '@/components/commons/modal/Modal';
 import { ModalProvider } from '@/components/commons/modal/ModalContext';
+import Dialog from './commons/dialog/Dialog';
+import { DialogProvider } from './commons/dialog/DialogContext';
 import { ToastProvider } from './commons/toast/ToastProvider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -13,8 +15,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <AppRouterCacheProvider>
         <ToastProvider>
           <ModalProvider>
-            {children}
-            <Modal />
+            <DialogProvider>
+              {children}
+              <Modal />
+              <Dialog />
+            </DialogProvider>
           </ModalProvider>
         </ToastProvider>
       </AppRouterCacheProvider>

--- a/frontend/src/components/commons/dialog/Dialog.tsx
+++ b/frontend/src/components/commons/dialog/Dialog.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useCallback, useRef, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useDialog } from '@/components/commons/dialog/DialogContext';
+
+function DefaultDialog({ content }: { content: ReactNode }) {
+  return (
+    <div className="relative w-full overflow-hidden rounded-xl bg-white px-5 pt-5 pb-3">
+      <div>{content}</div>
+    </div>
+  );
+}
+
+// Dialog Shell — 딤드 + 애니메이션 + variant 분기
+export default function Dialog() {
+  const { state, closeDialog } = useDialog()!;
+  const { isOpen, content, closeOnBackdrop = false, closeOnEsc = false } = state;
+
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  // ESC 키 처리
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (closeOnEsc && e.key === 'Escape') closeDialog();
+    },
+    [closeOnEsc, closeDialog],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  const DialogContent = (
+    <div className="fixed inset-0 z-9999 flex items-center justify-center px-4">
+      {/* 딤드 */}
+      <div
+        ref={backdropRef}
+        className="animate-in fade-in bg-label-alternative absolute inset-0 backdrop-blur-[2px] duration-200"
+        onClick={() => closeOnBackdrop && closeDialog()}
+        aria-hidden="true"
+      />
+
+      {/* 다이얼로그 카드 */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={`animate-in fade-in zoom-in-95 relative z-20 min-w-90 duration-200`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DefaultDialog content={content!} />
+      </div>
+    </div>
+  );
+
+  // Portal로 body에 직접 렌더링
+  return typeof document !== 'undefined' ? createPortal(DialogContent, document.body) : null;
+}

--- a/frontend/src/components/commons/dialog/DialogContext.tsx
+++ b/frontend/src/components/commons/dialog/DialogContext.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+/**
+ * 다이얼로그를 열 때 사용할 수 있는 옵션들입니다.
+ */
+export interface DialogOptions {
+  /** 백드롭(배경) 클릭 시 다이얼로그를 닫을지 여부 (기본값: false) */
+  closeOnBackdrop?: boolean;
+  /** ESC 키를 눌렀을 때 다이얼로그를 닫을지 여부 (기본값: false) */
+  closeOnEsc?: boolean;
+  /** 다이얼로그 본문에 렌더링할 내용 */
+  content: ReactNode;
+}
+
+interface DialogState extends DialogOptions {
+  isOpen: boolean;
+}
+
+interface DialogContextValue {
+  state: DialogState;
+  openDialog: (options: DialogOptions) => void;
+  closeDialog: () => void;
+}
+
+const defaultState: DialogState = {
+  isOpen: false,
+  content: null,
+  closeOnBackdrop: false,
+  closeOnEsc: false,
+};
+
+const DialogContext = createContext<DialogContextValue>({
+  state: { isOpen: false, content: null },
+  openDialog: () => {},
+  closeDialog: () => {},
+});
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<DialogState>(defaultState);
+
+  const openDialog = useCallback((options: DialogOptions) => {
+    setState({
+      ...defaultState,
+      ...options,
+      isOpen: true,
+    });
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    setState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  return (
+    <DialogContext.Provider value={{ state, openDialog, closeDialog }}>
+      {children}
+    </DialogContext.Provider>
+  );
+}
+
+/**
+ * 다이얼로그 제어를 위한 커스텀 훅입니다.
+ * @returns {DialogContextValue} openDialog, closeDialog 함수 및 state 객체
+ *
+ * useDialog의 parmas
+ * @params closeOnBackdrop?: boolean; - 배경 클릭 시 다이얼로그를 닫을지 여부
+ * @parmas closeOnEsc?: boolean; - ESC 키를 눌렀을 때 다이얼로그를 닫을지 여부
+ * @params conent: ReactNode; - 다이얼로그 본문에 렌더링할 내용
+ */
+export function useDialog() {
+  return useContext(DialogContext);
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -359,6 +359,11 @@
   }
 }
 
+/* WDS 내 primary FlowMeet 색상으로 변경 */
+:root {
+  --semantic-primary-normal: #03C98F;
+}
+
 body {
   font-family: var(--font-pretendard);
   background: var(--color-static-white);


### PR DESCRIPTION
## #️⃣연관된 이슈
close #25 

## 📝작업 내용
- WDS에 존재하는 alert 외에, 내부를 자유롭게 구성할 수 있는 커스텀 alert를 Dialog라는 이름으로 구현하였습니다. 

### 스크린샷 (선택)
<img width="1443" height="868" alt="image" src="https://github.com/user-attachments/assets/398d10c0-b30e-4300-a84a-a26a8028caa3" />


## 💬리뷰 요구사항(선택)
- Modal이랑 기본적으로 작동 방식은 같으나, 모달 위에 다이얼로그가 떠야 하는 상황이 있어 Store를 분리하였습니다.
- `/modal-test` 페이지에서 확인할 수 있습니다. 모달과 겹쳐 쓰는 상황을 테스트하기 위해서 
```typescript
            openModal({
              variant: 'default',
              content: (
                <p className="text-sm leading-relaxed text-gray-600">
                  상하좌우 패딩이 모두 <strong>48px</strong>인 기본 모달입니다. 본문에는 어떤
                  콘텐츠든 자유롭게 채울 수 있습니다.
                </p>
              ),
            });
```
지우면 모달이랑 안 겹친 형태의 다이얼로그도 확인 간으합니다~ 