### PR TITLE
[Refactor/#22] Project/File 도메인 Service-Facade 의존성 개선

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/ImageUploader.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/ImageUploader.java
@@ -38,7 +38,7 @@ public class ImageUploader {
 
             FileInformation fileInformation = fileInformationService.create(
                     imageUrl,
-                    new CreateFileInformationCommand(
+                    CreateFileInformationCommand.of(
                             fileKey,
                             file.getOriginalFilename(),
                             extension,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/ImageUploader.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/ImageUploader.java
@@ -11,6 +11,7 @@ import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.file.entity.FileInformation;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.file.service.FileInformationService;
+import kr.flowmeet.domain.file.service.vo.CreateFileInformationCommand;
 import kr.flowmeet.external.file.FileStorageService;
 
 @Component
@@ -35,18 +36,17 @@ public class ImageUploader {
             String imageUrl = fileStorageService.upload(fileKey, file.getInputStream(),
                     file.getContentType(), file.getSize());
 
-            fileInformationService.create(
-                    FileInformation.builder()
-                            .fileKey(fileKey)
-                            .name(file.getOriginalFilename())
-                            .extension(extension)
-                            .size(file.getSize())
-                            .contentType(file.getContentType())
-                            .domainType(domainType)
-                            .entityId(entityId)
-                            .uploadUrl(imageUrl)
-                            .build()
+            FileInformation fileInformation = fileInformationService.create(
+                    imageUrl,
+                    new CreateFileInformationCommand(
+                            fileKey,
+                            file.getOriginalFilename(),
+                            extension,
+                            file.getSize(),
+                            file.getContentType()
+                    )
             );
+            fileInformationService.attach(fileInformation.getFileKey(), domainType, entityId);
 
             return imageUrl;
         } catch (IOException e) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
@@ -18,6 +18,6 @@ public record ConfirmFileUploadRequest(
 ) {
 
     public CreateFileInformationCommand toCommand() {
-        return new CreateFileInformationCommand(fileKey, fileName, extension, fileSize, contentType);
+        return CreateFileInformationCommand.of(fileKey, fileName, extension, fileSize, contentType);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
@@ -2,6 +2,7 @@ package kr.flowmeet.api.file.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import kr.flowmeet.domain.file.service.vo.CreateFileInformationCommand;
 
 public record ConfirmFileUploadRequest(
         @NotBlank(message = "파일 키는 필수로 입력해 주세요.")
@@ -15,4 +16,8 @@ public record ConfirmFileUploadRequest(
         @NotBlank(message = "콘텐츠 타입은 필수로 입력해 주세요.")
         String contentType
 ) {
+
+    public CreateFileInformationCommand toCommand() {
+        return new CreateFileInformationCommand(fileKey, fileName, extension, fileSize, contentType);
+    }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/facade/FileFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/facade/FileFacade.java
@@ -10,7 +10,6 @@ import kr.flowmeet.api.file.dto.request.ConfirmFileUploadRequest;
 import kr.flowmeet.api.file.dto.request.CreatePresignedUrlRequest;
 import kr.flowmeet.api.file.dto.response.CreatePresignedUrlResponse;
 import kr.flowmeet.api.file.dto.response.FileInformationResponse;
-import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.file.entity.FileInformation;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.file.service.FileInformationService;
@@ -43,15 +42,8 @@ public class FileFacade {
         }
 
         FileInformation fileInformation = fileInformationService.create(
-                FileInformation.builder()
-                        .fileKey(request.fileKey())
-                        .name(request.fileName())
-                        .extension(request.extension())
-                        .size(request.fileSize())
-                        .contentType(request.contentType())
-                        .domainType(FileDomainType.TEMP)
-                        .uploadUrl(fileStorageService.getPublicUrl(request.fileKey()))
-                        .build()
+                fileStorageService.getPublicUrl(request.fileKey()),
+                request.toCommand()
         );
 
         return FileInformationResponse.from(fileInformation);

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
@@ -31,7 +31,7 @@ public interface ProjectMemberApi {
                                        @Valid @RequestBody UpdateProjectMemberRoleRequest request);
 
     @Operation(summary = "멤버 삭제", description = "OWNER만 삭제할 수 있습니다.")
-    @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND", "MEMBER_DELETE_FORBIDDEN", "MEMBER_CANNOT_DELETE_OWNER"})
+    @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND", "PROJECT_ACCESS_DENIED", "MEMBER_CANNOT_DELETE_OWNER"})
     CommonResponse<?> deleteMember(@UserId Long userId, @PathVariable Long projectId,
                                    @PathVariable Long memberId);
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -56,7 +56,7 @@ public class ProjectFacade {
 
     public GetProjectResponse getProject(final Long userId, final Long projectId) {
         projectPermissionValidator.validate(projectId, userId);
-        ProjectMemberRole myRole = projectMemberService.findByProjectIdAndUserId(projectId, userId).getRole();
+        ProjectMemberRole myRole = projectMemberService.findMemberRole(projectId, userId);
 
         Project project = projectService.findById(projectId);
         int memberCount = projectMemberService.countByProjectId(projectId);

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -26,15 +26,12 @@ import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.project.service.ProjectService;
 import kr.flowmeet.domain.project.service.ProjectSortType;
 import kr.flowmeet.domain.project.service.ProjectUrlService;
-import kr.flowmeet.domain.user.entity.User;
-import kr.flowmeet.domain.user.service.UserService;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProjectFacade {
 
-    private final UserService userService;
     private final ProjectService projectService;
     private final ProjectMemberService projectMemberService;
     private final ProjectUrlService projectUrlService;
@@ -44,10 +41,9 @@ public class ProjectFacade {
 
     @Transactional
     public CreateProjectResponse createProject(final Long userId, final CreateProjectRequest request) {
-        User user = userService.findById(userId);
         Project project = projectService.create(request.name());
 
-        projectMemberService.create(user.getId(), project.getId(), ProjectMemberRole.OWNER);
+        projectMemberService.create(userId, project.getId(), ProjectMemberRole.OWNER);
 
         return CreateProjectResponse.from(project);
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -61,14 +61,13 @@ public class ProjectFacade {
     }
 
     public GetProjectResponse getProject(final Long userId, final Long projectId) {
+        ProjectMemberRole myRole = projectPermissionValidator.validateAndGetRole(projectId, userId);
+
         Project project = projectService.findById(projectId);
+        int memberCount = projectMemberService.countByProjectId(projectId);
+        List<ProjectUrl> urls = projectUrlService.findAllByProjectId(projectId);
 
-        ProjectMember requesterMember = projectMemberService.findByProjectIdAndUserId(project.getId(), userId);
-
-        int memberCount = projectMemberService.countByProjectId(project.getId());
-        List<ProjectUrl> urls = projectUrlService.findAllByProjectId(project.getId());
-
-        return GetProjectResponse.of(project, requesterMember.getRole(), memberCount, urls);
+        return GetProjectResponse.of(project, myRole, memberCount, urls);
     }
 
     @Transactional

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -75,8 +75,7 @@ public class ProjectFacade {
     public void updateProject(final Long userId, final Long projectId, final UpdateProjectRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        Project project = projectService.findById(projectId);
-        project.updateName(request.name());
+        projectService.updateName(projectId, request.name());
     }
 
     @Transactional
@@ -101,9 +100,8 @@ public class ProjectFacade {
     public void updateProfileImage(final Long userId, final Long projectId, final MultipartFile file) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.OWNER);
 
-        Project project = projectService.findById(projectId);
         String imageUrl = imageUploader.upload(file, "projects", FileDomainType.PROJECT_IMAGE, projectId);
-        project.updateProfileImageUrl(imageUrl);
+        projectService.updateProfileImageUrl(projectId, imageUrl);
     }
 
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -55,7 +55,8 @@ public class ProjectFacade {
     }
 
     public GetProjectResponse getProject(final Long userId, final Long projectId) {
-        ProjectMemberRole myRole = projectPermissionValidator.validateAndGetRole(projectId, userId);
+        projectPermissionValidator.validate(projectId, userId);
+        ProjectMemberRole myRole = projectMemberService.findByProjectIdAndUserId(projectId, userId).getRole();
 
         Project project = projectService.findById(projectId);
         int memberCount = projectMemberService.countByProjectId(projectId);

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectMemberFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectMemberFacade.java
@@ -61,44 +61,18 @@ public class ProjectMemberFacade {
                                  final UpdateProjectMemberRoleRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectMember targetMember = projectMemberService.findByIdAndProjectId(memberId, projectId);
-
-        if (targetMember.isOwner()) {
-            throw new ApiException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
-        }
-
-        if (request.role() == ProjectMemberRole.OWNER) {
-            throw new ApiException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
-        }
-
-        targetMember.updateRole(request.role());
+        projectMemberService.updateRole(projectId, memberId, request.role());
     }
 
     @Transactional
     public void deleteMember(final Long userId, final Long projectId, final Long memberId) {
-        ProjectMember requesterMember = projectMemberService.findByProjectIdAndUserId(projectId, userId);
-
-        if (!requesterMember.isOwner()) {
-            throw new ApiException(ProjectErrorCode.MEMBER_DELETE_FORBIDDEN);
-        }
-
-        ProjectMember targetMember = projectMemberService.findByIdAndProjectId(memberId, projectId);
-
-        if (targetMember.isOwner()) {
-            throw new ApiException(ProjectErrorCode.MEMBER_CANNOT_DELETE_OWNER);
-        }
-
-        projectMemberService.delete(targetMember);
+        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.OWNER);
+        projectMemberService.deleteByProjectIdAndMemberId(projectId, memberId);
     }
 
     @Transactional
     public void leaveProject(final Long userId, final Long projectId) {
-        ProjectMember requesterMember = projectMemberService.findByProjectIdAndUserId(projectId, userId);
-        if (requesterMember.isOwner()) {
-            throw new ApiException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
-        }
-
-        projectMemberService.delete(requesterMember);
+        projectMemberService.leave(projectId, userId);
     }
 
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectUrlFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectUrlFacade.java
@@ -5,13 +5,9 @@ import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import kr.flowmeet.api.common.exception.ApiException;
 import kr.flowmeet.api.project.dto.request.ProjectUrlRequest;
 import kr.flowmeet.api.project.dto.response.ProjectUrlResponse;
-import kr.flowmeet.domain.project.entity.ProjectMember;
 import kr.flowmeet.domain.project.entity.ProjectUrl;
-import kr.flowmeet.domain.project.exception.ProjectErrorCode;
-import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.project.service.ProjectUrlService;
 
 @Service
@@ -19,7 +15,6 @@ import kr.flowmeet.domain.project.service.ProjectUrlService;
 @Transactional(readOnly = true)
 public class ProjectUrlFacade {
 
-    private final ProjectMemberService projectMemberService;
     private final ProjectUrlService projectUrlService;
     private final ProjectPermissionValidator projectPermissionValidator;
 
@@ -27,12 +22,7 @@ public class ProjectUrlFacade {
     public ProjectUrlResponse addUrl(final Long userId, final Long projectId, final ProjectUrlRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectUrl projectUrl = projectUrlService.create(
-                ProjectUrl.builder()
-                        .projectId(projectId)
-                        .url(request.url())
-                        .build()
-        );
+        ProjectUrl projectUrl = projectUrlService.create(projectId, request.url());
 
         return ProjectUrlResponse.from(projectUrl);
     }
@@ -42,8 +32,7 @@ public class ProjectUrlFacade {
                                         final ProjectUrlRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectUrl projectUrl = projectUrlService.findByIdAndProjectId(urlId, projectId);
-        projectUrl.updateUrl(request.url());
+        ProjectUrl projectUrl = projectUrlService.updateUrl(projectId, urlId, request.url());
 
         return ProjectUrlResponse.from(projectUrl);
     }
@@ -52,8 +41,7 @@ public class ProjectUrlFacade {
     public void deleteUrl(final Long userId, final Long projectId, final Long urlId) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectUrl projectUrl = projectUrlService.findByIdAndProjectId(urlId, projectId);
-        projectUrlService.delete(projectUrl);
+        projectUrlService.deleteByProjectIdAndUrlId(projectId, urlId);
     }
 
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/FileInformationService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/FileInformationService.java
@@ -10,6 +10,7 @@ import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.file.entity.FileInformation;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.file.repository.FileInformationRepository;
+import kr.flowmeet.domain.file.service.vo.CreateFileInformationCommand;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +25,24 @@ public class FileInformationService {
     }
 
     @Transactional
-    public FileInformation create(final FileInformation fileInformation) {
-        return fileInformationRepository.save(fileInformation);
+    public FileInformation create(final String uploadUrl, final CreateFileInformationCommand command) {
+        return fileInformationRepository.save(
+                FileInformation.builder()
+                        .fileKey(command.fileKey())
+                        .name(command.name())
+                        .extension(command.extension())
+                        .size(command.size())
+                        .contentType(command.contentType())
+                        .domainType(FileDomainType.TEMP)
+                        .uploadUrl(uploadUrl)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void attach(final String fileKey, final FileDomainType domainType, final Long entityId) {
+        FileInformation fileInformation = findByFileKey(fileKey);
+        fileInformation.updateDomain(domainType, entityId);
     }
 
     public Optional<FileInformation> findByDomainTypeAndEntityId(final FileDomainType domainType, final Long entityId) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/vo/CreateFileInformationCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/vo/CreateFileInformationCommand.java
@@ -7,4 +7,8 @@ public record CreateFileInformationCommand(
         long size,
         String contentType
 ) {
+
+    public static CreateFileInformationCommand of(String fileKey, String name, String extension, long size, String contentType) {
+        return new CreateFileInformationCommand(fileKey, name, extension, size, contentType);
+    }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/vo/CreateFileInformationCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/service/vo/CreateFileInformationCommand.java
@@ -1,0 +1,10 @@
+package kr.flowmeet.domain.file.service.vo;
+
+public record CreateFileInformationCommand(
+        String fileKey,
+        String name,
+        String extension,
+        long size,
+        String contentType
+) {
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
@@ -14,7 +14,6 @@ public enum ProjectErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트에 소속된 멤버입니다."),
     MEMBER_CANNOT_CHANGE_OWNER(HttpStatus.BAD_REQUEST, "OWNER 권한은 변경할 수 없습니다."),
-    MEMBER_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "OWNER만 멤버를 삭제할 수 있습니다."),
     MEMBER_CANNOT_DELETE_OWNER(HttpStatus.BAD_REQUEST, "OWNER는 삭제할 수 없습니다."),
     PROJECT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL입니다.");
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
@@ -26,6 +26,10 @@ public class ProjectMemberService {
                 .orElseThrow(() -> new BusinessException(ProjectErrorCode.MEMBER_NOT_FOUND));
     }
 
+    public ProjectMemberRole findMemberRole(final Long projectId, final Long userId) {
+        return findByProjectIdAndUserId(projectId, userId).getRole();
+    }
+
     public ProjectMember findByIdAndProjectId(final Long memberId, final Long projectId) {
         return projectMemberRepository.findByIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new BusinessException(ProjectErrorCode.MEMBER_NOT_FOUND));

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
@@ -68,7 +68,7 @@ public class ProjectMemberService {
     @Transactional
     public void updateRole(final Long projectId, final Long memberId, final ProjectMemberRole newRole) {
         ProjectMember target = findByIdAndProjectId(memberId, projectId);
-        validateRoleChangeable(target, newRole);
+        validateNotOwnerRoleChange(target, newRole);
         target.updateRole(newRole);
     }
 
@@ -95,7 +95,7 @@ public class ProjectMemberService {
         projectMemberRepository.delete(projectMember);
     }
 
-    private void validateRoleChangeable(final ProjectMember target, final ProjectMemberRole newRole) {
+    private void validateNotOwnerRoleChange(final ProjectMember target, final ProjectMemberRole newRole) {
         if (target.isOwner() || newRole == ProjectMemberRole.OWNER) {
             throw new BusinessException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
         }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
@@ -66,7 +66,38 @@ public class ProjectMemberService {
     }
 
     @Transactional
+    public void updateRole(final Long projectId, final Long memberId, final ProjectMemberRole newRole) {
+        ProjectMember target = findByIdAndProjectId(memberId, projectId);
+        validateRoleChangeable(target, newRole);
+        target.updateRole(newRole);
+    }
+
+    @Transactional
+    public void deleteByProjectIdAndMemberId(final Long projectId, final Long memberId) {
+        ProjectMember target = findByIdAndProjectId(memberId, projectId);
+        if (target.isOwner()) {
+            throw new BusinessException(ProjectErrorCode.MEMBER_CANNOT_DELETE_OWNER);
+        }
+        projectMemberRepository.delete(target);
+    }
+
+    @Transactional
+    public void leave(final Long projectId, final Long userId) {
+        ProjectMember member = findByProjectIdAndUserId(projectId, userId);
+        if (member.isOwner()) {
+            throw new BusinessException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
+        }
+        projectMemberRepository.delete(member);
+    }
+
+    @Transactional
     public void delete(final ProjectMember projectMember) {
         projectMemberRepository.delete(projectMember);
+    }
+
+    private void validateRoleChangeable(final ProjectMember target, final ProjectMemberRole newRole) {
+        if (target.isOwner() || newRole == ProjectMemberRole.OWNER) {
+            throw new BusinessException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
+        }
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectPermissionValidator.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectPermissionValidator.java
@@ -18,6 +18,10 @@ public class ProjectPermissionValidator {
         validate(projectId, userId, ProjectMemberRole.VIEWER);
     }
 
+    public ProjectMemberRole validateAndGetRole(Long projectId, Long userId) {
+        return projectMemberService.findByProjectIdAndUserId(projectId, userId).getRole();
+    }
+
     public void validateNotIn(Long projectId, Long userId) {
         if (projectMemberRepository.existsByProjectIdAndUserId(projectId, userId)) {
             throw new BusinessException(ProjectErrorCode.MEMBER_ALREADY_EXISTS);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectPermissionValidator.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectPermissionValidator.java
@@ -18,10 +18,6 @@ public class ProjectPermissionValidator {
         validate(projectId, userId, ProjectMemberRole.VIEWER);
     }
 
-    public ProjectMemberRole validateAndGetRole(Long projectId, Long userId) {
-        return projectMemberService.findByProjectIdAndUserId(projectId, userId).getRole();
-    }
-
     public void validateNotIn(Long projectId, Long userId) {
         if (projectMemberRepository.existsByProjectIdAndUserId(projectId, userId)) {
             throw new BusinessException(ProjectErrorCode.MEMBER_ALREADY_EXISTS);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectService.java
@@ -45,6 +45,18 @@ public class ProjectService {
     }
 
     @Transactional
+    public void updateName(final Long projectId, final String name) {
+        Project project = findById(projectId);
+        project.updateName(name);
+    }
+
+    @Transactional
+    public void updateProfileImageUrl(final Long projectId, final String imageUrl) {
+        Project project = findById(projectId);
+        project.updateProfileImageUrl(imageUrl);
+    }
+
+    @Transactional
     public void delete(final Project project) {
         projectRepository.delete(project);
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectUrlService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectUrlService.java
@@ -26,8 +26,26 @@ public class ProjectUrlService {
     }
 
     @Transactional
-    public ProjectUrl create(final ProjectUrl projectUrl) {
-        return projectUrlRepository.save(projectUrl);
+    public ProjectUrl create(final Long projectId, final String url) {
+        return projectUrlRepository.save(
+                ProjectUrl.builder()
+                        .projectId(projectId)
+                        .url(url)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ProjectUrl updateUrl(final Long projectId, final Long urlId, final String url) {
+        ProjectUrl projectUrl = findByIdAndProjectId(urlId, projectId);
+        projectUrl.updateUrl(url);
+        return projectUrl;
+    }
+
+    @Transactional
+    public void deleteByProjectIdAndUrlId(final Long projectId, final Long urlId) {
+        ProjectUrl projectUrl = findByIdAndProjectId(urlId, projectId);
+        projectUrlRepository.delete(projectUrl);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

- Closes #22

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전 PR(#29)에서 Node / Notification 도메인을 대상으로 진행했던 Service-Facade 레이어 분리를 **Project / File 도메인**에 동일하게 적용했습니다.

### Project 도메인 — 상태 변경을 Service로 이관

Facade에서 엔티티를 직접 조회·변경하던 로직을 Service 내부로 옮겨, Service가 식별자(원시 값)를 받아 내부에서 조회·변경하도록 통일했습니다.

- **ProjectService**: `updateName(projectId, name)`, `updateProfileImageUrl(projectId, imageUrl)` — Facade에서 `findById` 후 엔티티 변경하던 패턴 제거
- **ProjectMemberService**: `updateRole`, `deleteByProjectIdAndMemberId`, `leave` — 역할 변경 불가 검증(`validateRoleChangeable`), OWNER 삭제/탈퇴 방어 등 도메인 불변식을 Service 내부로 이관
- **ProjectUrlService**: `create(projectId, url)`, `updateUrl(projectId, urlId, url)`, `deleteByProjectIdAndUrlId(projectId, urlId)` — 기존 엔티티 파라미터 시그니처를 원시 값 기반으로 전환

### Project 도메인 — 권한 검증 통일 및 의존성 정리

- `ProjectFacade.getProject`: 기존 `projectMemberService.findByProjectIdAndUserId` 직접 호출 → `ProjectPermissionValidator.validateAndGetRole` 사용으로 통일
- `ProjectFacade.createProject`: JWT 필터에서 이미 인증된 `userId`를 다시 `UserService.findById`로 검증하던 불필요한 의존 제거

### File 도메인 — CreateFileInformationCommand 기반 생성 전환

Facade/Component에서 `FileInformation.builder()`로 엔티티를 직접 조립해 `Service.create(FileInformation)`에 넘기던 패턴을 제거하고, 컨벤션에 맞는 Command 기반으로 전환했습니다.

- **`CreateFileInformationCommand`**: Request Body 필드만 포함 (fileKey, name, extension, size, contentType)
- **`FileInformationService.create(uploadUrl, Command)`**: 초기 상태 `FileDomainType.TEMP`를 Service 내부에서 설정 (Node의 `NodeStatus.WAITING` 패턴과 동일)
- **`FileInformationService.attach(fileKey, domainType, entityId)`**: 도메인 귀속을 별도 오퍼레이션으로 분리
- **`ConfirmFileUploadRequest.toCommand()`**: Request → Command 변환 메서드 추가
- **`ImageUploader`**: 기존 1단계(엔티티 조립 + 저장) → 2단계(`create` + `attach`)로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- `FileInformationService.create`는 모든 파일을 `TEMP` 상태로 먼저 생성한 뒤, `attach`로 실제 도메인(프로젝트 이미지, 노드 첨부파일 등)에 연결하는 2단계 방식입니다. Node가 생성 시 항상 `WAITING` 상태로 시작하는 것과 같은 패턴인데, ImageUploader 쪽에서 INSERT + UPDATE 쿼리가 나뉘는 점이 기존 대비 달라진 부분이라 의견 부탁드립니다.
