### PR TITLE
[Docs/#47] 스웨거 명세 API 예시 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
@@ -1,12 +1,18 @@
 package kr.flowmeet.api.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
+@Schema(description = "공통 응답 형식")
 public record CommonResponse<T>(
+        @Schema(description = "HTTP 상태 코드", example = "200")
         int status,
+        @Schema(description = "응답 코드", example = "OK")
         String code,
+        @Schema(description = "응답 메시지", example = "요청에 성공했습니다.")
         String message,
+        @Schema(description = "응답 데이터")
         T data
 ) {
     private static final String SUCCESS_CODE = "OK";

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CursorSliceResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CursorSliceResponse.java
@@ -1,13 +1,20 @@
 package kr.flowmeet.api.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.function.Function;
 
+@Schema(description = "커서 기반 페이지 응답")
 public record CursorSliceResponse<T>(
+        @Schema(description = "조회된 데이터 목록")
         List<T> content,
+        @Schema(description = "요청한 페이지 크기", example = "20")
         int size,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
         boolean hasNext,
+        @Schema(description = "다음 페이지 조회용 커서 ID", example = "42")
         Long nextCursorId,
+        @Schema(description = "다음 페이지 조회용 커서 값(정렬 기준 값)", example = "2026-04-19T10:00:00")
         String nextCursorValue
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
@@ -1,18 +1,25 @@
 package kr.flowmeet.api.file.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import kr.flowmeet.domain.file.service.vo.CreateFileInformationCommand;
 
+@Schema(description = "파일 업로드 완료 확인 요청")
 public record ConfirmFileUploadRequest(
+        @Schema(description = "Presigned URL 발급 시 받은 파일 키", example = "node/20260419/abc123-meeting-notes.pdf")
         @NotBlank(message = "파일 키는 필수로 입력해 주세요.")
         String fileKey,
+        @Schema(description = "원본 파일 이름", example = "meeting-notes.pdf")
         @NotBlank(message = "파일 이름은 필수로 입력해 주세요.")
         String fileName,
+        @Schema(description = "파일 크기(바이트)", example = "204800")
         @Positive(message = "파일 크기는 0보다 커야 해요.")
         long fileSize,
+        @Schema(description = "파일 확장자", example = "pdf")
         @NotBlank(message = "확장자는 필수로 입력해 주세요.")
         String extension,
+        @Schema(description = "콘텐츠 타입(MIME)", example = "application/pdf")
         @NotBlank(message = "콘텐츠 타입은 필수로 입력해 주세요.")
         String contentType
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/CreatePresignedUrlRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/CreatePresignedUrlRequest.java
@@ -1,13 +1,18 @@
 package kr.flowmeet.api.file.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "S3 업로드용 Presigned URL 발급 요청")
 public record CreatePresignedUrlRequest(
+        @Schema(description = "원본 파일 이름", example = "meeting-notes.pdf")
         @NotBlank(message = "파일 이름은 필수로 입력해 주세요.")
         String fileName,
+        @Schema(description = "파일 크기(바이트)", example = "204800")
         @Positive(message = "파일 크기는 0보다 커야 해요.")
         long fileSize,
+        @Schema(description = "콘텐츠 타입(MIME)", example = "application/pdf")
         @NotBlank(message = "콘텐츠 타입은 필수로 입력해 주세요.")
         String contentType
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/response/CreatePresignedUrlResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/response/CreatePresignedUrlResponse.java
@@ -1,8 +1,14 @@
 package kr.flowmeet.api.file.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Presigned URL 발급 응답")
 public record CreatePresignedUrlResponse(
+        @Schema(description = "파일 식별용 키", example = "node/20260419/abc123-meeting-notes.pdf")
         String fileKey,
+        @Schema(description = "업로드에 사용할 Presigned URL", example = "https://flowmeet-bucket.s3.amazonaws.com/node/20260419/abc123-meeting-notes.pdf?X-Amz-Signature=...")
         String presignedUrl,
+        @Schema(description = "업로드 완료 후 접근 가능한 최종 URL", example = "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf")
         String uploadUrl
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/response/FileInformationResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/response/FileInformationResponse.java
@@ -1,15 +1,24 @@
 package kr.flowmeet.api.file.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.file.entity.FileInformation;
 
+@Schema(description = "파일 정보 응답")
 public record FileInformationResponse(
+        @Schema(description = "파일 식별용 키", example = "node/20260419/abc123-meeting-notes.pdf")
         String fileKey,
+        @Schema(description = "원본 파일 이름", example = "meeting-notes.pdf")
         String name,
+        @Schema(description = "파일 확장자", example = "pdf")
         String extension,
+        @Schema(description = "파일 크기(바이트)", example = "204800")
         long size,
+        @Schema(description = "파일이 속한 도메인 타입", example = "NODE_ATTACHMENT")
         FileDomainType domainType,
+        @Schema(description = "파일이 속한 엔티티 ID", example = "128")
         Long entityId,
+        @Schema(description = "접근 가능한 최종 URL", example = "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf")
         String uploadUrl
 ) {
     public static FileInformationResponse from(final FileInformation fileInformation) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AddNodeTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AddNodeTagRequest.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "노드 태그 추가 요청")
 public record AddNodeTagRequest(
+        @Schema(description = "추가할 태그 ID", example = "5")
         @NotNull(message = "태그 ID는 필수입니다.")
         Long tagId
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AiSummaryRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AiSummaryRequest.java
@@ -1,9 +1,12 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
+@Schema(description = "AI 노드 요약 요청")
 public record AiSummaryRequest(
+        @Schema(description = "요약할 노드 ID 목록", example = "[101, 102, 103]")
         @NotEmpty(message = "요약할 노드를 선택해 주세요.")
         List<Long> nodeIds
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateAssigneeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateAssigneeRequest.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "노드 담당자 지정 요청")
 public record CreateAssigneeRequest(
+        @Schema(description = "담당자로 지정할 사용자 ID", example = "91")
         @NotNull(message = "사용자 ID는 필수입니다.")
         Long userId
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateEdgeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateEdgeRequest.java
@@ -1,13 +1,18 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kr.flowmeet.domain.node.service.vo.CreateEdgeCommand;
 
+@Schema(description = "노드 간 엣지 생성 요청")
 public record CreateEdgeRequest(
+        @Schema(description = "엣지의 시작 노드 ID", example = "101")
         @NotNull(message = "시작 노드 ID는 필수입니다.")
         Long startNodeId,
+        @Schema(description = "엣지의 종료 노드 ID", example = "102")
         @NotNull(message = "종료 노드 ID는 필수입니다.")
         Long endNodeId,
+        @Schema(description = "엣지에 대한 설명", example = "로그인 성공 시 대시보드로 이동")
         String comment
 ) {
     public CreateEdgeCommand toCommand() {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateNodeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateNodeRequest.java
@@ -1,14 +1,20 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.flowmeet.domain.node.entity.NodeType;
 import kr.flowmeet.domain.node.service.vo.CreateNodeCommand;
 
+@Schema(description = "노드 생성 요청")
 public record CreateNodeRequest(
+        @Schema(description = "노드 제목", example = "로그인 화면 기획")
         @NotBlank(message = "노드 제목은 필수로 입력해 주세요.")
         String title,
+        @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
         String description,
+        @Schema(description = "노드 유형", example = "MAIN", allowableValues = {"MAIN", "SUB"})
         NodeType type,
+        @Schema(description = "상위 노드 ID (루트인 경우 null)", example = "100")
         Long parentId
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
@@ -1,11 +1,15 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.flowmeet.domain.node.service.vo.CreateTagCommand;
 
+@Schema(description = "태그 생성 요청")
 public record CreateTagRequest(
+        @Schema(description = "태그 이름", example = "긴급")
         @NotBlank(message = "태그 이름은 필수입니다.")
         String name,
+        @Schema(description = "태그 색상(HEX)", example = "#FF5A5F")
         @NotBlank(message = "태그 색상은 필수입니다.")
         String color
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateEdgeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateEdgeRequest.java
@@ -1,10 +1,14 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "노드 간 엣지 수정 요청")
 public record UpdateEdgeRequest(
+        @Schema(description = "엣지의 시작 노드 ID", example = "101")
         @NotNull(message = "시작 노드 ID는 필수입니다.")
         Long startNodeId,
+        @Schema(description = "엣지의 종료 노드 ID", example = "102")
         @NotNull(message = "종료 노드 ID는 필수입니다.")
         Long endNodeId
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeRequest.java
@@ -1,13 +1,20 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeCommand;
 
+@Schema(description = "노드 수정 요청 (변경할 필드만 전달)")
 public record UpdateNodeRequest(
+        @Schema(description = "변경할 제목", example = "로그인 화면 기획 (v2)")
         String title,
+        @Schema(description = "변경할 설명", example = "OAuth2 로그인 플로우 정리 및 와이어프레임 첨부")
         String description,
+        @Schema(description = "변경할 노트 내용(마크다운)", example = "## 로그인 시나리오\n- Google OAuth ...")
         String noteContent,
+        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
         NodeStatus status,
+        @Schema(description = "칸반 내 정렬 순서", example = "1024")
         Integer sortOrder
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
@@ -1,12 +1,16 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
 
+@Schema(description = "노드 상태 변경(드래그 앤 드롭) 요청")
 public record UpdateNodeStatusRequest(
+        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
         @NotNull(message = "상태는 필수로 입력해 주세요.")
         NodeStatus status,
+        @Schema(description = "칸반 내 정렬 순서", example = "1024")
         @NotNull(message = "정렬 순서는 필수로 입력해 주세요.")
         Integer sortOrder
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
@@ -1,11 +1,15 @@
 package kr.flowmeet.api.node.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.flowmeet.domain.node.service.vo.UpdateTagCommand;
 
+@Schema(description = "태그 수정 요청")
 public record UpdateTagRequest(
+        @Schema(description = "변경할 태그 이름", example = "매우 긴급")
         @NotBlank(message = "태그 이름은 필수입니다.")
         String name,
+        @Schema(description = "변경할 태그 색상(HEX)", example = "#FF0000")
         @NotBlank(message = "태그 색상은 필수입니다.")
         String color
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AssigneeItem.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AssigneeItem.java
@@ -1,11 +1,17 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "노드 담당자 정보")
 public record AssigneeItem(
+        @Schema(description = "사용자 ID", example = "91")
         Long userId,
+        @Schema(description = "닉네임", example = "플로우민")
         String nickname,
+        @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
         String email,
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
         String profileImageUrl
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetAllTagsResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetAllTagsResponse.java
@@ -1,9 +1,14 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import kr.flowmeet.domain.node.entity.Tag;
 
-public record GetAllTagsResponse(List<TagItem> tags) {
+@Schema(description = "프로젝트 태그 전체 조회 응답")
+public record GetAllTagsResponse(
+        @Schema(description = "태그 목록")
+        List<TagItem> tags
+) {
 
     public static GetAllTagsResponse from(final List<Tag> tags) {
         return new GetAllTagsResponse(tags.stream().map(TagItem::from).toList());

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
@@ -1,5 +1,6 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -8,11 +9,13 @@ import kr.flowmeet.domain.node.entity.Edge;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.node.entity.NodeTag;
-import kr.flowmeet.domain.node.entity.Tag;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "플로우차트 조회 응답 (노드와 엣지)")
 public record GetFlowchartResponse(
+        @Schema(description = "노드 목록")
         List<NodeItem> nodes,
+        @Schema(description = "노드 간 엣지 목록")
         List<EdgeItem> edges
 ) {
 
@@ -41,17 +44,29 @@ public record GetFlowchartResponse(
         return new GetFlowchartResponse(nodeItems, edgeItems);
     }
 
+    @Schema(description = "플로우차트의 노드 항목")
     public record NodeItem(
+            @Schema(description = "노드 ID", example = "101")
             Long nodeId,
+            @Schema(description = "상위 노드 ID (루트인 경우 null)", example = "100")
             Long parentId,
+            @Schema(description = "노드 제목", example = "로그인 화면 기획")
             String title,
+            @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
             String description,
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
             String status,
+            @Schema(description = "같은 상태 내 정렬 순서", example = "1024")
             int sortOrder,
+            @Schema(description = "부여된 태그 목록")
             List<TagItem> tags,
+            @Schema(description = "담당자 목록")
             List<AssigneeItem> assignees,
+            @Schema(description = "연결된 회의 존재 여부", example = "true")
             boolean hasMeeting,
+            @Schema(description = "하위 노드 ID 목록", example = "[110, 111]")
             List<Long> childNodeIds,
+            @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
             LocalDateTime updatedAt
     ) {
 
@@ -78,11 +93,17 @@ public record GetFlowchartResponse(
         }
     }
 
+    @Schema(description = "노드 간 엣지 항목")
     public record EdgeItem(
+            @Schema(description = "엣지 ID", example = "9001")
             Long edgeId,
+            @Schema(description = "시작 노드 ID", example = "101")
             Long startNodeId,
+            @Schema(description = "종료 노드 ID", example = "102")
             Long endNodeId,
+            @Schema(description = "엣지를 생성한 사용자 정보")
             EdgeCreatorItem createdBy,
+            @Schema(description = "엣지 설명", example = "로그인 성공 시 대시보드로 이동")
             String comment
     ) {
 
@@ -96,10 +117,15 @@ public record GetFlowchartResponse(
             );
         }
 
+        @Schema(description = "엣지 생성자 정보")
         public record EdgeCreatorItem(
+                @Schema(description = "사용자 ID", example = "91")
                 Long userId,
+                @Schema(description = "닉네임", example = "플로우민")
                 String nickname,
+                @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
                 String email,
+                @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
                 String profileImageUrl
         ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
@@ -1,17 +1,20 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.entity.NodeTag;
-import kr.flowmeet.domain.node.entity.Tag;
-import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "칸반 보드 조회 응답 (상태별 그룹핑)")
 public record GetKanbanResponse(
+        @Schema(description = "대기 상태의 노드 목록")
         List<KanbanItem> waiting,
+        @Schema(description = "진행 중 상태의 노드 목록")
         List<KanbanItem> inProgress,
+        @Schema(description = "완료 상태의 노드 목록")
         List<KanbanItem> done
 ) {
 
@@ -41,11 +44,17 @@ public record GetKanbanResponse(
                 .toList();
     }
 
+    @Schema(description = "칸반 보드의 개별 노드 카드")
     public record KanbanItem(
+            @Schema(description = "노드 ID", example = "101")
             Long nodeId,
+            @Schema(description = "노드 제목", example = "로그인 화면 기획")
             String title,
+            @Schema(description = "같은 상태 내 정렬 순서", example = "1024")
             int sortOrder,
+            @Schema(description = "부여된 태그 목록")
             List<TagItem> tags,
+            @Schema(description = "담당자 목록")
             List<AssigneeItem> assignees
     ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
@@ -1,5 +1,6 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -7,10 +8,10 @@ import java.util.Set;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.node.entity.NodeTag;
-import kr.flowmeet.domain.node.entity.Tag;
-import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "노드 목록 조회 응답")
 public record GetNodeListResponse(
+        @Schema(description = "노드 목록")
         List<NodeListItem> nodes
 ) {
 
@@ -32,14 +33,23 @@ public record GetNodeListResponse(
         return new GetNodeListResponse(items);
     }
 
+    @Schema(description = "노드 목록의 개별 항목")
     public record NodeListItem(
+            @Schema(description = "노드 ID", example = "101")
             Long nodeId,
+            @Schema(description = "노드 제목", example = "로그인 화면 기획")
             String title,
+            @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
             String description,
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
             String status,
+            @Schema(description = "부여된 태그 목록")
             List<TagItem> tags,
+            @Schema(description = "담당자 목록")
             List<AssigneeItem> assignees,
+            @Schema(description = "연결된 회의 존재 여부", example = "true")
             boolean hasMeeting,
+            @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
             LocalDateTime updatedAt
     ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
@@ -1,5 +1,6 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import kr.flowmeet.domain.meeting.entity.Meeting;
@@ -7,19 +8,33 @@ import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.Tag;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "노드 상세 조회 응답")
 public record GetNodeResponse(
+        @Schema(description = "노드 ID", example = "101")
         Long nodeId,
+        @Schema(description = "프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "상위 노드 ID (루트인 경우 null)", example = "100")
         Long parentId,
+        @Schema(description = "노드 제목", example = "로그인 화면 기획")
         String title,
+        @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
         String description,
+        @Schema(description = "노트 내용(마크다운)", example = "## 로그인 시나리오\n- Google OAuth ...")
         String noteContent,
+        @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
         String status,
+        @Schema(description = "같은 상태 내 정렬 순서", example = "1024")
         int sortOrder,
+        @Schema(description = "부여된 태그 목록")
         List<TagItem> tags,
+        @Schema(description = "담당자 목록")
         List<AssigneeItem> assignees,
+        @Schema(description = "연결된 회의 정보 (없으면 null)")
         MeetingItem meeting,
+        @Schema(description = "생성 시각", example = "2026-03-01T09:00:00")
         LocalDateTime createdAt,
+        @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
         LocalDateTime updatedAt
 ) {
 
@@ -42,11 +57,17 @@ public record GetNodeResponse(
         );
     }
 
+    @Schema(description = "노드에 연결된 회의 정보")
     public record MeetingItem(
+            @Schema(description = "회의 ID", example = "57")
             Long meetingId,
+            @Schema(description = "회의 상태", example = "SCHEDULED")
             String status,
+            @Schema(description = "회의 시작 시각", example = "2026-04-20T14:00:00")
             LocalDateTime startedAt,
+            @Schema(description = "회의 시작 푸시 알림 사용 여부", example = "true")
             boolean isPushEnabled,
+            @Schema(description = "푸시 알림 예약 시각", example = "2026-04-20T13:50:00")
             LocalDateTime pushNotifyAt
     ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
@@ -1,12 +1,14 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.NodeTag;
-import kr.flowmeet.domain.node.entity.Tag;
 
+@Schema(description = "노드 검색 응답")
 public record SearchNodeResponse(
+        @Schema(description = "검색된 노드 목록")
         List<SearchItem> nodes
 ) {
 
@@ -24,10 +26,15 @@ public record SearchNodeResponse(
         return new SearchNodeResponse(items);
     }
 
+    @Schema(description = "검색된 노드 항목")
     public record SearchItem(
+            @Schema(description = "노드 ID", example = "101")
             Long nodeId,
+            @Schema(description = "노드 제목", example = "로그인 화면 기획")
             String title,
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
             String status,
+            @Schema(description = "부여된 태그 목록")
             List<TagItem> tags
     ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/TagItem.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/TagItem.java
@@ -1,8 +1,17 @@
 package kr.flowmeet.api.node.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.node.entity.Tag;
 
-public record TagItem(Long tagId, String name, String color) {
+@Schema(description = "태그 정보")
+public record TagItem(
+        @Schema(description = "태그 ID", example = "5")
+        Long tagId,
+        @Schema(description = "태그 이름", example = "긴급")
+        String name,
+        @Schema(description = "태그 색상(HEX)", example = "#FF5A5F")
+        String color
+) {
 
     public static TagItem from(final Tag tag) {
         return new TagItem(tag.getId(), tag.getName(), tag.getColor());

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/request/UpdateNotificationSettingRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/request/UpdateNotificationSettingRequest.java
@@ -1,9 +1,16 @@
 package kr.flowmeet.api.notification.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로젝트 알림 설정 수정 요청")
 public record UpdateNotificationSettingRequest(
+        @Schema(description = "회의 관련 알림 수신 여부", example = "true")
         boolean meetingEnabled,
+        @Schema(description = "노드 관련 알림 수신 여부", example = "true")
         boolean nodeEnabled,
+        @Schema(description = "데스크톱 푸시 알림 수신 여부", example = "false")
         boolean desktopEnabled,
+        @Schema(description = "이메일 알림 수신 여부", example = "true")
         boolean emailEnabled
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/GetNotificationSettingResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/GetNotificationSettingResponse.java
@@ -1,12 +1,19 @@
 package kr.flowmeet.api.notification.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.notification.entity.NotificationSetting;
 
+@Schema(description = "프로젝트 알림 설정 조회 응답")
 public record GetNotificationSettingResponse(
+        @Schema(description = "프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "회의 관련 알림 수신 여부", example = "true")
         boolean meetingEnabled,
+        @Schema(description = "노드 관련 알림 수신 여부", example = "true")
         boolean nodeEnabled,
+        @Schema(description = "데스크톱 푸시 알림 수신 여부", example = "false")
         boolean desktopEnabled,
+        @Schema(description = "이메일 알림 수신 여부", example = "true")
         boolean emailEnabled
 ) {
     public static GetNotificationSettingResponse from(final NotificationSetting setting) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/GetUnreadCountResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/GetUnreadCountResponse.java
@@ -1,6 +1,10 @@
 package kr.flowmeet.api.notification.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "읽지 않은 알림 개수 응답")
 public record GetUnreadCountResponse(
+        @Schema(description = "읽지 않은 알림 개수", example = "5")
         long unreadCount
 ) {
     public static GetUnreadCountResponse from(final long unreadCount) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/NotificationSummaryResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/NotificationSummaryResponse.java
@@ -1,18 +1,29 @@
 package kr.flowmeet.api.notification.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import kr.flowmeet.domain.notification.entity.Notification;
 import kr.flowmeet.domain.notification.entity.NotificationType;
 
+@Schema(description = "알림 요약 응답")
 public record NotificationSummaryResponse(
+        @Schema(description = "알림 ID", example = "4821")
         Long notificationId,
+        @Schema(description = "알림 유형", example = "MEETING_CREATED")
         NotificationType type,
+        @Schema(description = "알림 제목", example = "새 회의")
         String title,
+        @Schema(description = "알림 본문", example = "FlowMeet 프로젝트에 새 회의가 만들어졌어요")
         String content,
+        @Schema(description = "관련 프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "관련 프로젝트 이름", example = "FlowMeet")
         String projectName,
+        @Schema(description = "관련 노드 ID", example = "128")
         Long nodeId,
+        @Schema(description = "읽음 여부", example = "false")
         boolean isRead,
+        @Schema(description = "알림 생성 시각", example = "2026-04-19T10:15:30")
         LocalDateTime createdAt
 ) {
     public static NotificationSummaryResponse from(final Notification notification) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/CreateProjectRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/CreateProjectRequest.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.project.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "프로젝트 생성 요청")
 public record CreateProjectRequest(
+        @Schema(description = "프로젝트 이름", example = "FlowMeet 리뉴얼")
         @NotBlank(message = "프로젝트 이름은 필수로 입력해 주세요.")
         String name
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/InviteProjectMemberRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/InviteProjectMemberRequest.java
@@ -1,9 +1,12 @@
 package kr.flowmeet.api.project.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "프로젝트 멤버 초대 요청")
 public record InviteProjectMemberRequest(
+        @Schema(description = "초대할 사용자 이메일", example = "teammate@flowmeet.kr")
         @NotBlank(message = "이메일은 필수로 입력해 주세요.")
         @Email(message = "유효하지 않은 이메일 형식입니다.")
         String email

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.project.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "프로젝트 URL 등록/수정 요청")
 public record ProjectUrlRequest(
+        @Schema(description = "프로젝트에 연결할 URL", example = "https://github.com/kookmin-sw/2026-capstone-09")
         @NotBlank(message = "URL은 필수로 입력해 주세요.")
         String url
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectMemberRoleRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectMemberRoleRequest.java
@@ -1,9 +1,12 @@
 package kr.flowmeet.api.project.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 
+@Schema(description = "프로젝트 멤버 권한 변경 요청")
 public record UpdateProjectMemberRoleRequest(
+        @Schema(description = "변경할 권한", example = "MEMBER", allowableValues = {"VIEWER", "MEMBER", "OWNER"})
         @NotNull(message = "역할은 필수로 입력해 주세요.")
         ProjectMemberRole role
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectRequest.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.project.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "프로젝트 수정 요청")
 public record UpdateProjectRequest(
+        @Schema(description = "변경할 프로젝트 이름", example = "FlowMeet v2")
         @NotBlank(message = "프로젝트 이름은 필수로 입력해 주세요.")
         String name
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/CreateProjectResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/CreateProjectResponse.java
@@ -1,11 +1,16 @@
 package kr.flowmeet.api.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import kr.flowmeet.domain.project.entity.Project;
 
+@Schema(description = "프로젝트 생성 응답")
 public record CreateProjectResponse(
+        @Schema(description = "생성된 프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "프로젝트 이름", example = "FlowMeet 리뉴얼")
         String name,
+        @Schema(description = "생성 시각", example = "2026-04-19T10:15:30")
         LocalDateTime createdAt
 ) {
     public static CreateProjectResponse from(final Project project) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetAllProjectMembersResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetAllProjectMembersResponse.java
@@ -1,12 +1,15 @@
 
 package kr.flowmeet.api.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import kr.flowmeet.domain.project.entity.ProjectMember;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "프로젝트 멤버 전체 조회 응답")
 public record GetAllProjectMembersResponse(
+        @Schema(description = "프로젝트 멤버 목록")
         List<ProjectMemberInfo> members
 ) {
     public static GetAllProjectMembersResponse of(final List<ProjectMember> members) {
@@ -16,12 +19,19 @@ public record GetAllProjectMembersResponse(
         return new GetAllProjectMembersResponse(memberInfos);
     }
 
+    @Schema(description = "프로젝트 멤버 정보")
     public record ProjectMemberInfo(
+            @Schema(description = "프로젝트 멤버 ID", example = "42")
             Long memberId,
+            @Schema(description = "사용자 ID", example = "91")
             Long userId,
+            @Schema(description = "닉네임", example = "플로우민")
             String nickname,
+            @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
             String email,
+            @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
             String profileImageUrl,
+            @Schema(description = "프로젝트 내 권한", example = "MEMBER", allowableValues = {"VIEWER", "MEMBER", "OWNER"})
             ProjectMemberRole role
     ) {
         public static ProjectMemberInfo of(final ProjectMember member, final User user) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetProjectResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetProjectResponse.java
@@ -1,18 +1,27 @@
 package kr.flowmeet.api.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import kr.flowmeet.domain.project.entity.Project;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import kr.flowmeet.domain.project.entity.ProjectUrl;
 
+@Schema(description = "프로젝트 상세 조회 응답")
 public record GetProjectResponse(
+        @Schema(description = "프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "프로젝트 이름", example = "FlowMeet 리뉴얼")
         String name,
+        @Schema(description = "내 권한", example = "OWNER", allowableValues = {"VIEWER", "MEMBER", "OWNER"})
         ProjectMemberRole myRole,
+        @Schema(description = "프로젝트 멤버 수", example = "8")
         int memberCount,
+        @Schema(description = "프로젝트에 등록된 URL 목록")
         List<UrlItem> urls,
+        @Schema(description = "생성 시각", example = "2026-03-01T09:00:00")
         LocalDateTime createdAt,
+        @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
         LocalDateTime updatedAt
 ) {
     public static GetProjectResponse of(final Project project, final ProjectMemberRole myRole,
@@ -28,8 +37,11 @@ public record GetProjectResponse(
         );
     }
 
+    @Schema(description = "프로젝트에 등록된 URL 항목")
     public record UrlItem(
+            @Schema(description = "URL ID", example = "3")
             Long urlId,
+            @Schema(description = "URL 값", example = "https://github.com/kookmin-sw/2026-capstone-09")
             String url
     ) {
         public static UrlItem from(final ProjectUrl projectUrl) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectSummaryResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectSummaryResponse.java
@@ -1,13 +1,19 @@
 package kr.flowmeet.api.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import kr.flowmeet.domain.project.entity.Project;
 import kr.flowmeet.domain.project.repository.projection.ProjectWithMemberCountProjection;
 
+@Schema(description = "프로젝트 목록 요약 응답")
 public record ProjectSummaryResponse(
+        @Schema(description = "프로젝트 ID", example = "17")
         Long projectId,
+        @Schema(description = "프로젝트 이름", example = "FlowMeet 리뉴얼")
         String name,
+        @Schema(description = "프로젝트 멤버 수", example = "8")
         int memberCount,
+        @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
         LocalDateTime updatedAt
 ) {
     public static ProjectSummaryResponse from(final ProjectWithMemberCountProjection projection) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectUrlResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectUrlResponse.java
@@ -1,9 +1,13 @@
 package kr.flowmeet.api.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.project.entity.ProjectUrl;
 
+@Schema(description = "프로젝트 URL 응답")
 public record ProjectUrlResponse(
+        @Schema(description = "URL ID", example = "3")
         Long urlId,
+        @Schema(description = "URL 값", example = "https://github.com/kookmin-sw/2026-capstone-09")
         String url
 ) {
     public static ProjectUrlResponse from(final ProjectUrl projectUrl) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/UpdateUserRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/UpdateUserRequest.java
@@ -1,13 +1,17 @@
 package kr.flowmeet.api.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "내 정보 수정 요청")
 public record UpdateUserRequest(
+        @Schema(description = "닉네임(최대 20자)", example = "플로우민", maxLength = 20)
         @Size(max = 20, message = "닉네임은 최대 20자까지 입력할 수 있습니다.")
         @NotBlank(message = "닉네임은 필수로 입력해 주세요.")
         String nickname,
+        @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
         @Email(message = "유효하지 않은 이메일 형식입니다.")
         String email
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/response/GetUserResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/response/GetUserResponse.java
@@ -1,12 +1,18 @@
 package kr.flowmeet.api.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "내 정보 조회 응답")
 public record GetUserResponse(
+        @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
         String email,
+        @Schema(description = "닉네임", example = "플로우민")
         String nickname,
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
         String profileImageUrl,
+        @Schema(description = "가입 시각", example = "2026-03-01T09:00:00")
         LocalDateTime createdAt
 ) {
     public static GetUserResponse from(final User user) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/response/UpdateUserResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/response/UpdateUserResponse.java
@@ -1,11 +1,17 @@
 package kr.flowmeet.api.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.user.entity.User;
 
+@Schema(description = "내 정보 수정 응답")
 public record UpdateUserResponse(
+        @Schema(description = "사용자 ID", example = "91")
         Long userId,
+        @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
         String email,
+        @Schema(description = "닉네임", example = "플로우민")
         String nickname,
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
         String profileImageUrl
 ) {
     public static UpdateUserResponse from(final User user) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #47 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## Summary
- flowmeet-api 모듈의 모든 DTO(33개 파일 / 36개 record)에 `@Schema` 어노테이션을 추가해 Swagger 문서 가독성 개선
- 클래스 레벨에는 DTO 용도 설명, 필드 레벨에는 `description`/`example`을 지정
- `NodeStatus`, `NodeType`, `ProjectMemberRole` 등 enum 필드에는 `allowableValues`로 허용값 명시
- `UpdateUserRequest.nickname`에는 `maxLength`를 `@Size`와 일치시켜 명시

## 변경 범위
| 모듈 | 파일 수 |
|---|---|
| common | 2 (CommonResponse, CursorSliceResponse) |
| file | 4 |
| notification | 4 |
| project | 9 |
| user | 3 |
| node | 14 |

## 예시
- 날짜: `2026-04-19T10:15:30`
- HEX 색상: `#FF5A5F`
- 파일 키, Presigned URL, 프로필 이미지 URL 등 실제 포맷에 맞춰 예시 작성
- 중첩 record(`KanbanItem`, `UrlItem`, `MeetingItem`, `EdgeItem`, `EdgeCreatorItem` 등)도 동일하게 처리


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

단순 스웨거 예시 작성만 한 브랜치라서 빠르게 머지하겠습니다!
