### PR TITLE
[Feat/#56] 노드에 번호 데이터 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -37,6 +37,7 @@ import kr.flowmeet.domain.node.service.NodeAssigneeService;
 import kr.flowmeet.domain.node.service.NodeService;
 import kr.flowmeet.domain.node.service.NodeTagService;
 import kr.flowmeet.domain.project.service.ProjectMemberService;
+import kr.flowmeet.domain.project.service.ProjectService;
 import kr.flowmeet.domain.user.entity.User;
 import kr.flowmeet.domain.user.service.UserService;
 
@@ -50,6 +51,7 @@ public class NodeFacade {
     private final NodeTagService nodeTagService;
     private final NodeAssigneeService nodeAssigneeService;
     private final MeetingService meetingService;
+    private final ProjectService projectService;
     private final ProjectPermissionValidator projectPermissionValidator;
     private final NodeValidator nodeValidator;
 
@@ -86,11 +88,16 @@ public class NodeFacade {
     public void createNode(final Long userId, final Long projectId, final CreateNodeRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
+        String number;
+
         if (request.parentId() != null) {
             nodeValidator.validateIsIn(request.parentId(), projectId);
+            number = nodeService.issueChildNumber(request.parentId(), projectId);
+        } else {
+            number = String.valueOf(projectService.issueRootNodeSeq(projectId));
         }
 
-        nodeService.create(projectId, request.toCommand());
+        nodeService.create(projectId, number, request.toCommand());
     }
 
     @Transactional

--- a/backend/flowmeet-api/src/main/resources/db/migration/V2__add_node_number.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V2__add_node_number.sql
@@ -1,0 +1,78 @@
+-- =========================================================
+-- V2__add_node_number.sql
+-- 노드 계층 번호(#1.2.3 형태) 부여를 위한 컬럼 추가
+-- =========================================================
+
+-- nodes.number: materialized path 형태의 노드 번호
+-- nodes.child_seq: 다음 자식에게 부여할 시퀀스 (1부터 증가)
+ALTER TABLE nodes
+    ADD COLUMN number    VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN child_seq INTEGER      NOT NULL DEFAULT 0;
+
+-- projects.root_node_seq: 프로젝트 내 루트 노드에 부여할 다음 시퀀스
+ALTER TABLE projects
+    ADD COLUMN root_node_seq INTEGER NOT NULL DEFAULT 0;
+
+-- ---------------------------------------------------------
+-- 기존 데이터 백필
+-- ---------------------------------------------------------
+
+-- 노드별 형제 내 순번을 미리 계산
+WITH ranked AS (
+    SELECT
+        node_id,
+        project_id,
+        parent_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY project_id, COALESCE(parent_id, 0)
+            ORDER BY node_id
+        ) AS seq
+    FROM nodes
+    WHERE deleted_at IS NULL
+),
+-- 루트부터 재귀적으로 number 조립
+numbered AS (
+    SELECT
+        r.node_id,
+        r.project_id,
+        r.parent_id,
+        CAST(r.seq AS VARCHAR) AS number
+    FROM ranked r
+    WHERE r.parent_id IS NULL
+
+    UNION ALL
+
+    SELECT
+        c.node_id,
+        c.project_id,
+        c.parent_id,
+        p.number || '.' || c.seq
+    FROM ranked c
+    INNER JOIN numbered p ON c.parent_id = p.node_id
+)
+UPDATE nodes
+SET number = numbered.number
+FROM numbered
+WHERE nodes.node_id = numbered.node_id;
+
+-- 각 노드의 child_seq를 현재 살아있는 자식 수로 세팅
+UPDATE nodes p
+SET child_seq = sub.cnt
+FROM (
+    SELECT parent_id, COUNT(*) AS cnt
+    FROM nodes
+    WHERE parent_id IS NOT NULL AND deleted_at IS NULL
+    GROUP BY parent_id
+) sub
+WHERE p.node_id = sub.parent_id;
+
+-- 각 프로젝트의 root_node_seq를 현재 살아있는 루트 수로 세팅
+UPDATE projects p
+SET root_node_seq = sub.cnt
+FROM (
+    SELECT project_id, COUNT(*) AS cnt
+    FROM nodes
+    WHERE parent_id IS NULL AND deleted_at IS NULL
+    GROUP BY project_id
+) sub
+WHERE p.project_id = sub.project_id;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
@@ -55,6 +55,12 @@ public class Node extends BaseTimeEntity {
     private Node parent;
 
     @Column(nullable = false)
+    private String number;
+
+    @Column(name = "child_seq", nullable = false)
+    private int childSeq;
+
+    @Column(nullable = false)
     private String title;
 
     private String description;
@@ -74,16 +80,23 @@ public class Node extends BaseTimeEntity {
     private int sortOrder;
 
     @Builder
-    public Node(Long projectId, Long parentId, String title, String description, NodeType type,
-                String noteContent, NodeStatus status, int sortOrder) {
+    public Node(Long projectId, Long parentId, String number, String title, String description,
+                NodeType type, String noteContent, NodeStatus status, int sortOrder) {
         this.projectId = projectId;
         this.parentId = parentId;
+        this.number = number;
+        this.childSeq = 0;
         this.title = title;
         this.description = description;
         this.type = type;
         this.noteContent = noteContent;
         this.status = status;
         this.sortOrder = sortOrder;
+    }
+
+    public int issueChildSeq() {
+        this.childSeq += 1;
+        return this.childSeq;
     }
 
     public void update(final String title, final String description, final String noteContent,

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepository.java
@@ -1,8 +1,10 @@
 package kr.flowmeet.domain.node.repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,10 @@ public interface NodeRepository extends JpaRepository<Node, Long>, NodeRepositor
     List<Node> findAllByProjectId(Long projectId);
 
     Optional<Node> findByIdAndProjectId(Long id, Long projectId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT n FROM Node n WHERE n.id = :id AND n.projectId = :projectId")
+    Optional<Node> findByIdAndProjectIdWithLock(@Param("id") Long id, @Param("projectId") Long projectId);
 
     List<Node> findAllByParentId(Long parentId);
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
@@ -69,7 +69,14 @@ public class NodeService {
     }
 
     @Transactional
-    public void create(final Long projectId, final CreateNodeCommand command) {
+    public String issueChildNumber(final Long parentId, final Long projectId) {
+        Node parent = nodeRepository.findByIdAndProjectIdWithLock(parentId, projectId)
+                .orElseThrow(() -> new BusinessException(NodeErrorCode.NODE_NOT_FOUND));
+        return parent.getNumber() + "." + parent.issueChildSeq();
+    }
+
+    @Transactional
+    public void create(final Long projectId, final String number, final CreateNodeCommand command) {
 
         Long parentId = command.parentId();
         int sortOrder = parentId != null ? countChildNodes(parentId)
@@ -78,6 +85,7 @@ public class NodeService {
         Node node = Node.builder()
                 .projectId(projectId)
                 .parentId(parentId)
+                .number(number)
                 .title(command.title())
                 .description(command.description())
                 .status(NodeStatus.WAITING)

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/Project.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/Project.java
@@ -33,10 +33,14 @@ public class Project extends BaseTimeEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Column(name = "root_node_seq", nullable = false)
+    private int rootNodeSeq;
+
     @Builder
     public Project(String name, String profileImageUrl) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+        this.rootNodeSeq = 0;
     }
 
     public void updateName(final String name) {
@@ -45,5 +49,10 @@ public class Project extends BaseTimeEntity {
 
     public void updateProfileImageUrl(final String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public int issueRootNodeSeq() {
+        this.rootNodeSeq += 1;
+        return this.rootNodeSeq;
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectRepository.java
@@ -1,7 +1,16 @@
 package kr.flowmeet.domain.project.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import kr.flowmeet.domain.project.entity.Project;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Project p WHERE p.id = :id")
+    Optional<Project> findByIdWithLock(@Param("id") Long id);
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectService.java
@@ -63,6 +63,13 @@ public class ProjectService {
     }
 
     @Transactional
+    public int issueRootNodeSeq(final Long projectId) {
+        Project project = projectRepository.findByIdWithLock(projectId)
+                .orElseThrow(() -> new BusinessException(ProjectErrorCode.PROJECT_NOT_FOUND));
+        return project.issueRootNodeSeq();
+    }
+
+    @Transactional
     public void invite(String email, Long projectId, User inviter) {
         Project project = findById(projectId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #56 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 스키마 (`V2__add_node_number.sql`)

| 테이블 | 컬럼 | 타입 | 용도 |
|---|---|---|---|
| `nodes` | `number` | `VARCHAR(255)` | 조립된 계층 번호 (예: `"1.2.3"`) |
| `nodes` | `child_seq` | `INTEGER` | 이 노드 하위에 다음 자식이 받을 시퀀스 |
| `projects` | `root_node_seq` | `INTEGER` | 이 프로젝트 내 다음 루트 노드가 받을 시퀀스 |

materialized path 방식으로 `number`를 저장한다. 부모를 따라 올라가며 조립하지 않고도 번호 자체를 즉시 읽을 수 있고, 노드 트리 조회 시 추가 연산이 필요 없다.

#### 기존 데이터 백필

마이그레이션에 재귀 CTE 기반 백필을 포함한다.
- `ROW_NUMBER()`로 형제 내 순서를 매기고 (`parent_id` 기준 `PARTITION`, `node_id` 기준 `ORDER`)
- 루트부터 재귀적으로 `parent.number || '.' || seq`를 조립해 `nodes.number`를 채움
- `nodes.child_seq`와 `projects.root_node_seq`는 현재 살아있는 하위 노드 수(`deleted_at IS NULL`)로 초기화

### 2. 엔티티

#### `Node`
- `number`, `childSeq` 필드 추가
- `issueChildSeq()` — 자신의 `childSeq`를 1 증가시키고 반환

#### `Project`
- `rootNodeSeq` 필드 추가
- `issueRootNodeSeq()` — 자신의 `rootNodeSeq`를 1 증가시키고 반환

### 3. 채번 로직 (`NodeFacade#createNode`)

```
parentId == null  →  projectService.issueRootNodeSeq(projectId)      → "1", "2", ...
parentId != null  →  nodeService.issueChildNumber(parentId, ...)     → parent.number + "." + seq
```

- 루트 노드: 프로젝트 행을 `PESSIMISTIC_WRITE`로 잠그고 `rootNodeSeq`를 증가
- 자식 노드: 부모 노드 행을 `PESSIMISTIC_WRITE`로 잠그고 `childSeq`를 증가

### 4. 동시성

동일 부모 아래 자식 노드가 동시에 생성될 때 `childSeq` 경쟁을 막기 위해 부모 행에 비관적 락을 건다.
프로젝트 루트도 동일한 이유로 `projects` 행에 락을 건다.

- `NodeRepository#findByIdAndProjectIdWithLock`
- `ProjectRepository#findByIdWithLock`

낙관적 락이 아닌 비관적 락을 택한 이유: 충돌 시 재시도 비용이 불필요하며, 락 구간이 단일 UPDATE 수준으로 짧다.

## 변경 파일

```
flowmeet-api/.../node/facade/NodeFacade.java            (자식/루트 번호 채번 분기)
flowmeet-api/.../db/migration/V2__add_node_number.sql   (신규)
flowmeet-domain/.../node/entity/Node.java               (number, childSeq, issueChildSeq)
flowmeet-domain/.../node/repository/NodeRepository.java (findByIdAndProjectIdWithLock)
flowmeet-domain/.../node/service/NodeService.java       (issueChildNumber, create 시그니처)
flowmeet-domain/.../project/entity/Project.java         (rootNodeSeq, issueRootNodeSeq)
flowmeet-domain/.../project/repository/ProjectRepository.java (findByIdWithLock)
flowmeet-domain/.../project/service/ProjectService.java (issueRootNodeSeq)
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

디자인에 있는 `#1.1.1` 같은 노드 번호가 기존 노드 스키마에 누락되어 있어서 추가하였습니다!