### PR TITLE
[Feat/#66] 프로젝트 OWNER 다중 부여 및 나가기 정책 개선

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
@@ -18,7 +18,7 @@ public interface ProjectMemberApi {
     @Operation(summary = "멤버 목록 조회")
     CommonResponse<GetAllProjectMembersResponse> getAllMembers(@UserId Long userId, @PathVariable Long projectId);
 
-    @Operation(summary = "멤버 권한 수정", description = "OWNER만 변경할 수 있습니다.")
+    @Operation(summary = "멤버 권한 수정", description = "- OWNER 부여: OWNER 권한 필요\n- OWNER 강등: 본인만 가능\n- VIEWER ↔ MEMBER 변경: MEMBER 이상 가능")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND", "PROJECT_ACCESS_DENIED", "MEMBER_CANNOT_CHANGE_OWNER"})
     CommonResponse<?> updateMemberRole(@UserId Long userId, @PathVariable Long projectId,
                                        @PathVariable Long memberId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectMemberFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectMemberFacade.java
@@ -30,9 +30,13 @@ public class ProjectMemberFacade {
     @Transactional
     public void updateMemberRole(final Long userId, final Long projectId, final Long memberId,
                                  final UpdateProjectMemberRoleRequest request) {
-        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+        if (request.role() == ProjectMemberRole.OWNER) {
+            projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.OWNER);
+        } else {
+            projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+        }
 
-        projectMemberService.updateRole(projectId, memberId, request.role());
+        projectMemberService.updateRole(projectId, userId, memberId, request.role());
     }
 
     @Transactional

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
@@ -1,8 +1,5 @@
 package kr.flowmeet.domain.project.exception;
 
-import kr.flowmeet.domain.common.exception.BusinessException;
-import kr.flowmeet.domain.project.entity.ProjectMember;
-import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,7 +10,7 @@ import kr.flowmeet.common.exception.ErrorCode;
 public enum ProjectErrorCode implements ErrorCode {
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다."),
     PROJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "프로젝트의 권한이 없습니다."),
-    PROJECT_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "OWNER는 프로젝트를 나갈 수 없습니다."),
+    PROJECT_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "프로젝트의 유일한 OWNER는 나갈 수 없습니다. 다른 멤버에게 OWNER 권한을 부여한 후 나가주세요."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트에 소속된 멤버입니다."),
     MEMBER_CANNOT_CHANGE_OWNER(HttpStatus.BAD_REQUEST, "OWNER 권한은 변경할 수 없습니다."),

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectMemberRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectMemberRepository.java
@@ -25,6 +25,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
     int countByProjectId(Long projectId);
 
+    int countByProjectIdAndRole(Long projectId, ProjectMemberRole role);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE ProjectMember pm SET pm.deletedAt = CURRENT_TIMESTAMP WHERE pm.projectId = :projectId")
     int softDeleteAllByProjectId(@Param("projectId") Long projectId);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
@@ -95,15 +95,19 @@ public class ProjectMemberService {
     public void leave(final Long projectId, final Long userId) {
         ProjectMember member = findByProjectIdAndUserId(projectId, userId);
         if (member.isOwner()) {
-            int totalMembers = projectMemberRepository.countByProjectId(projectId);
-            if (totalMembers > 1) {
-                int ownerCount = projectMemberRepository.countByProjectIdAndRole(projectId, ProjectMemberRole.OWNER);
-                if (ownerCount == 1) {
-                    throw new BusinessException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
-                }
-            }
+            validateSoleOwnerCannotLeave(projectId);
         }
         projectMemberRepository.delete(member);
+    }
+
+    private void validateSoleOwnerCannotLeave(final Long projectId) {
+        int totalMembers = projectMemberRepository.countByProjectId(projectId);
+        if (totalMembers > 1) {
+            int ownerCount = projectMemberRepository.countByProjectIdAndRole(projectId, ProjectMemberRole.OWNER);
+            if (ownerCount == 1) {
+                throw new BusinessException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
+            }
+        }
     }
 
     @Transactional

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectMemberService.java
@@ -71,9 +71,14 @@ public class ProjectMemberService {
     }
 
     @Transactional
-    public void updateRole(final Long projectId, final Long memberId, final ProjectMemberRole newRole) {
+    public void updateRole(final Long projectId, final Long requesterId, final Long memberId, final ProjectMemberRole newRole) {
         ProjectMember target = findByIdAndProjectId(memberId, projectId);
-        validateNotOwnerRoleChange(target, newRole);
+        if (target.isOwner() && newRole != ProjectMemberRole.OWNER) {
+            ProjectMember requester = findByProjectIdAndUserId(projectId, requesterId);
+            if (!requester.getId().equals(target.getId())) {
+                throw new BusinessException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
+            }
+        }
         target.updateRole(newRole);
     }
 
@@ -90,7 +95,13 @@ public class ProjectMemberService {
     public void leave(final Long projectId, final Long userId) {
         ProjectMember member = findByProjectIdAndUserId(projectId, userId);
         if (member.isOwner()) {
-            throw new BusinessException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
+            int totalMembers = projectMemberRepository.countByProjectId(projectId);
+            if (totalMembers > 1) {
+                int ownerCount = projectMemberRepository.countByProjectIdAndRole(projectId, ProjectMemberRole.OWNER);
+                if (ownerCount == 1) {
+                    throw new BusinessException(ProjectErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
+                }
+            }
         }
         projectMemberRepository.delete(member);
     }
@@ -98,12 +109,6 @@ public class ProjectMemberService {
     @Transactional
     public void delete(final ProjectMember projectMember) {
         projectMemberRepository.delete(projectMember);
-    }
-
-    private void validateNotOwnerRoleChange(final ProjectMember target, final ProjectMemberRole newRole) {
-        if (target.isOwner() || newRole == ProjectMemberRole.OWNER) {
-            throw new BusinessException(ProjectErrorCode.MEMBER_CANNOT_CHANGE_OWNER);
-        }
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #66

## 📝작업 내용

- OWNER 역할을 여러 명에게 부여할 수 있도록 변경
- OWNER가 다른 멤버에게 OWNER 권한 부여 가능
- OWNER가 자기 자신의 권한을 낮출 수 있음 (다른 OWNER 강등 불가)
- 프로젝트에 OWNER가 한 명이고 다른 멤버가 있는 경우 나가기 불가
  - 멤버가 본인 혼자인 경우 나가기 허용
- 프로젝트 삭제는 OWNER가 한 명이어도 가능하도록 유지

## 변경 파일

| 파일 | 변경 |
|------|------|
| `domain/.../project/repository/ProjectMemberRepository.java` | 수정 |
| `domain/.../project/service/ProjectMemberService.java` | 수정 |
| `domain/.../project/exception/ProjectErrorCode.java` | 수정 |
| `api/.../project/facade/ProjectMemberFacade.java` | 수정 |
| `api/.../project/controller/ProjectMemberApi.java` | 수정 |

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
