### PR TITLE
[Feat/#65] 노드 색상 데이터 enum으로 변경

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
@@ -2,6 +2,8 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.domain.node.entity.TagColor;
 import kr.flowmeet.domain.node.service.vo.CreateTagCommand;
 
 @Schema(description = "태그 생성 요청")
@@ -9,9 +11,9 @@ public record CreateTagRequest(
         @Schema(description = "태그 이름", example = "긴급")
         @NotBlank(message = "태그 이름은 필수입니다.")
         String name,
-        @Schema(description = "태그 색상(HEX)", example = "#FF5A5F")
-        @NotBlank(message = "태그 색상은 필수입니다.")
-        String color
+        @Schema(description = "태그 색상", example = "RED")
+        @NotNull(message = "태그 색상은 필수입니다.")
+        TagColor color
 ) {
 
     public CreateTagCommand toCommand() {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
@@ -2,6 +2,8 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.domain.node.entity.TagColor;
 import kr.flowmeet.domain.node.service.vo.UpdateTagCommand;
 
 @Schema(description = "태그 수정 요청")
@@ -9,9 +11,9 @@ public record UpdateTagRequest(
         @Schema(description = "변경할 태그 이름", example = "매우 긴급")
         @NotBlank(message = "태그 이름은 필수입니다.")
         String name,
-        @Schema(description = "변경할 태그 색상(HEX)", example = "#FF0000")
-        @NotBlank(message = "태그 색상은 필수입니다.")
-        String color
+        @Schema(description = "변경할 태그 색상", example = "RED")
+        @NotNull(message = "태그 색상은 필수입니다.")
+        TagColor color
 ) {
 
     public UpdateTagCommand toCommand() {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/TagItem.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/TagItem.java
@@ -2,6 +2,7 @@ package kr.flowmeet.api.node.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.domain.node.entity.Tag;
+import kr.flowmeet.domain.node.entity.TagColor;
 
 @Schema(description = "태그 정보")
 public record TagItem(
@@ -9,8 +10,8 @@ public record TagItem(
         Long tagId,
         @Schema(description = "태그 이름", example = "긴급")
         String name,
-        @Schema(description = "태그 색상(HEX)", example = "#FF5A5F")
-        String color
+        @Schema(description = "태그 색상", example = "RED")
+        TagColor color
 ) {
 
     public static TagItem from(final Tag tag) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/TagFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/TagFacade.java
@@ -1,25 +1,19 @@
 package kr.flowmeet.api.node.facade;
 
 import java.util.List;
-import kr.flowmeet.domain.node.exception.TagErrorCode;
 import kr.flowmeet.domain.node.service.NodeValidator;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import kr.flowmeet.api.common.exception.ApiException;
 import kr.flowmeet.api.node.dto.request.AddNodeTagRequest;
 import kr.flowmeet.api.node.dto.request.CreateTagRequest;
 import kr.flowmeet.api.node.dto.request.UpdateTagRequest;
 import kr.flowmeet.api.node.dto.response.GetAllTagsResponse;
 import kr.flowmeet.domain.node.entity.Tag;
-import kr.flowmeet.domain.node.exception.NodeErrorCode;
-import kr.flowmeet.domain.node.service.NodeService;
 import kr.flowmeet.domain.node.service.NodeTagService;
 import kr.flowmeet.domain.node.service.TagService;
-import kr.flowmeet.domain.project.entity.ProjectMember;
-import kr.flowmeet.domain.project.service.ProjectMemberService;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +22,6 @@ public class TagFacade {
 
     private final TagService tagService;
     private final NodeTagService nodeTagService;
-    private final NodeService nodeService;
     private final ProjectPermissionValidator projectPermissionValidator;
     private final NodeValidator nodeValidator;
 

--- a/backend/flowmeet-api/src/main/resources/db/migration/V4__add_tag_color_check.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V4__add_tag_color_check.sql
@@ -1,0 +1,39 @@
+-- =========================================================
+-- V4__add_tag_color_check.sql
+-- tags.color를 TagColor enum 값으로 제한
+-- =========================================================
+
+-- enum 값 외의 기존 데이터는 NEUTRAL로 정합화
+UPDATE tags
+SET color = 'NEUTRAL'
+WHERE color NOT IN (
+    'NEUTRAL',
+    'RED',
+    'RED_ORANGE',
+    'ORANGE',
+    'LIME',
+    'GREEN',
+    'CYAN',
+    'LIGHT_BLUE',
+    'BLUE',
+    'VIOLET',
+    'PURPLE',
+    'PINK'
+);
+
+ALTER TABLE tags
+    ADD CONSTRAINT ck_tags_color
+    CHECK (color IN (
+        'NEUTRAL',
+        'RED',
+        'RED_ORANGE',
+        'ORANGE',
+        'LIME',
+        'GREEN',
+        'CYAN',
+        'LIGHT_BLUE',
+        'BLUE',
+        'VIOLET',
+        'PURPLE',
+        'PINK'
+    ));

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Tag.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Tag.java
@@ -2,6 +2,8 @@ package kr.flowmeet.domain.node.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -51,17 +53,18 @@ public class Tag extends BaseTimeEntity {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false, length = 20)
-    private String color;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TagColor color;
 
     @Builder
-    public Tag(Long projectId, String name, String color) {
+    public Tag(Long projectId, String name, TagColor color) {
         this.projectId = projectId;
         this.name = name;
         this.color = color;
     }
 
-    public void update(final String name, final String color) {
+    public void update(final String name, final TagColor color) {
         this.name = name;
         this.color = color;
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/TagColor.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/TagColor.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.domain.node.entity;
+
+public enum TagColor {
+    NEUTRAL,
+    RED,
+    RED_ORANGE,
+    ORANGE,
+    LIME,
+    GREEN,
+    CYAN,
+    LIGHT_BLUE,
+    BLUE,
+    VIOLET,
+    PURPLE,
+    PINK
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/CreateTagCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/CreateTagCommand.java
@@ -1,7 +1,9 @@
 package kr.flowmeet.domain.node.service.vo;
 
+import kr.flowmeet.domain.node.entity.TagColor;
+
 public record CreateTagCommand(
         String name,
-        String color
+        TagColor color
 ) {
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/UpdateTagCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/UpdateTagCommand.java
@@ -1,7 +1,9 @@
 package kr.flowmeet.domain.node.service.vo;
 
+import kr.flowmeet.domain.node.entity.TagColor;
+
 public record UpdateTagCommand(
         String name,
-        String color
+        TagColor color
 ) {
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #65 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

태그 색상을 자유 문자열에서 enum으로 제한해 타입 안전성을 확보하고, DB 레벨에서도 허용 값을 강제하도록 변경했습니다.

### 1. `TagColor` enum 도입 (`refactor`)

- `kr.flowmeet.domain.node.entity.TagColor` 추가
  - 값: `NEUTRAL`, `RED`, `RED_ORANGE`, `ORANGE`, `LIME`, `GREEN`, `CYAN`, `LIGHT_BLUE`, `BLUE`, `VIOLET`, `PURPLE`, `PINK`
- `Tag` 엔티티의 `color` 필드를 `String` → `TagColor`로 변경
  - `@Enumerated(EnumType.STRING)`으로 매핑 (DB에는 enum 이름 그대로 저장)
- 호출 계층 일괄 전파
  - `CreateTagCommand`, `UpdateTagCommand` (VO)
  - `CreateTagRequest`, `UpdateTagRequest` (요청 DTO)
    - 검증을 `@NotBlank` → `@NotNull`로 교체 (enum에는 `@NotBlank` 적용 불가)
    - Swagger `example`을 enum 값(`"RED"`)으로 갱신
  - `TagItem` (응답 DTO)

### 2. Flyway 마이그레이션 추가 (`feat`)

- `V4__add_tag_color_check.sql`
  - 기존 데이터 중 enum 외 값은 `NEUTRAL`로 정합화
  - `tags.color`에 `CHECK` 제약을 걸어 12개 enum 값만 허용
- 컬럼 타입(`VARCHAR(20)`)은 그대로 유지
  - 가장 긴 enum 이름(`LIGHT_BLUE`, `RED_ORANGE`)이 10자라 충분

### 3. `TagFacade` 정리 (`chore`)

- 미사용 import 5개 제거 (`TagErrorCode`, `ApiException`, `NodeErrorCode`, `NodeService`, `ProjectMember`, `ProjectMemberService`)
- 미사용 의존성 필드 `nodeService` 제거

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

이게 더 간단한 PR이라 먼저 머지될 거라서 알림 발송 PR flyway 번호 수정해서 머지해주세요~
