### PR TITLE
[Refactor/#74] 클라이언트 문구 개선 및 스웨거 명칭 영문으로 변경

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -45,4 +45,6 @@ out/
 ### Docker / certbot ###
 docker/certbot/
 
-docs
+docs/
+
+.claude/UX_MESSAGE_GUIDE.md

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
@@ -1,0 +1,38 @@
+package kr.flowmeet.api.common.validation;
+
+public final class ValidationMessage {
+
+    private ValidationMessage() {
+    }
+
+    public static final String FILE_KEY_REQUIRED = "파일 키는 필수로 입력해 주세요.";
+    public static final String FILE_NAME_REQUIRED = "파일 이름은 필수로 입력해 주세요.";
+    public static final String FILE_SIZE_POSITIVE = "파일 크기는 0보다 커야 해요.";
+    public static final String FILE_EXTENSION_REQUIRED = "확장자는 필수로 입력해 주세요.";
+    public static final String FILE_CONTENT_TYPE_REQUIRED = "콘텐츠 타입은 필수로 입력해 주세요.";
+
+    public static final String NODE_TITLE_REQUIRED = "노드 제목은 필수로 입력해 주세요.";
+    public static final String NODE_STATUS_REQUIRED = "상태는 필수로 입력해 주세요.";
+    public static final String NODE_SORT_ORDER_REQUIRED = "정렬 순서는 필수로 입력해 주세요.";
+    public static final String NODE_SUMMARY_TARGETS_REQUIRED = "요약할 노드를 선택해 주세요.";
+
+    public static final String EDGE_START_NODE_ID_REQUIRED = "시작 노드 ID는 필수로 입력해 주세요.";
+    public static final String EDGE_END_NODE_ID_REQUIRED = "종료 노드 ID는 필수로 입력해 주세요.";
+
+    public static final String TAG_ID_REQUIRED = "태그 ID는 필수로 입력해 주세요.";
+    public static final String TAG_NAME_REQUIRED = "태그 이름은 필수로 입력해 주세요.";
+    public static final String TAG_COLOR_REQUIRED = "태그 색상은 필수로 입력해 주세요.";
+
+    public static final String ASSIGNEE_USER_ID_REQUIRED = "사용자 ID는 필수로 입력해 주세요.";
+
+    public static final String PROJECT_NAME_REQUIRED = "프로젝트 이름은 필수로 입력해 주세요.";
+    public static final String PROJECT_URL_REQUIRED = "URL은 필수로 입력해 주세요.";
+    public static final String PROJECT_MEMBER_ROLE_REQUIRED = "역할은 필수로 입력해 주세요.";
+    public static final String INVITATION_TOKEN_REQUIRED = "초대 토큰은 필수로 입력해 주세요.";
+
+    public static final String EMAIL_REQUIRED = "이메일은 필수로 입력해 주세요.";
+    public static final String EMAIL_INVALID = "이메일 형식을 다시 확인해 주세요.";
+
+    public static final String NICKNAME_REQUIRED = "닉네임은 필수로 입력해 주세요.";
+    public static final String NICKNAME_MAX_LENGTH = "닉네임은 최대 20자까지 입력할 수 있어요.";
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileApi.java
@@ -13,7 +13,7 @@ import kr.flowmeet.api.file.dto.response.CreatePresignedUrlResponse;
 import kr.flowmeet.api.file.dto.response.FileInformationResponse;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 
-@Tag(name = "파일")
+@Tag(name = "File", description = "파일")
 public interface FileApi {
 
     @Operation(summary = "Presigned URL 발급", description = "S3 직접 업로드를 위한 Presigned URL을 발급합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/ConfirmFileUploadRequest.java
@@ -3,24 +3,25 @@ package kr.flowmeet.api.file.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.file.service.vo.CreateFileInformationCommand;
 
 @Schema(description = "파일 업로드 완료 확인 요청")
 public record ConfirmFileUploadRequest(
         @Schema(description = "Presigned URL 발급 시 받은 파일 키", example = "node/20260419/abc123-meeting-notes.pdf")
-        @NotBlank(message = "파일 키는 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_KEY_REQUIRED)
         String fileKey,
         @Schema(description = "원본 파일 이름", example = "meeting-notes.pdf")
-        @NotBlank(message = "파일 이름은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_NAME_REQUIRED)
         String fileName,
         @Schema(description = "파일 크기(바이트)", example = "204800")
-        @Positive(message = "파일 크기는 0보다 커야 해요.")
+        @Positive(message = ValidationMessage.FILE_SIZE_POSITIVE)
         long fileSize,
         @Schema(description = "파일 확장자", example = "pdf")
-        @NotBlank(message = "확장자는 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_EXTENSION_REQUIRED)
         String extension,
         @Schema(description = "콘텐츠 타입(MIME)", example = "application/pdf")
-        @NotBlank(message = "콘텐츠 타입은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_CONTENT_TYPE_REQUIRED)
         String contentType
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/CreatePresignedUrlRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/dto/request/CreatePresignedUrlRequest.java
@@ -3,17 +3,18 @@ package kr.flowmeet.api.file.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "S3 업로드용 Presigned URL 발급 요청")
 public record CreatePresignedUrlRequest(
         @Schema(description = "원본 파일 이름", example = "meeting-notes.pdf")
-        @NotBlank(message = "파일 이름은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_NAME_REQUIRED)
         String fileName,
         @Schema(description = "파일 크기(바이트)", example = "204800")
-        @Positive(message = "파일 크기는 0보다 커야 해요.")
+        @Positive(message = ValidationMessage.FILE_SIZE_POSITIVE)
         long fileSize,
         @Schema(description = "콘텐츠 타입(MIME)", example = "application/pdf")
-        @NotBlank(message = "콘텐츠 타입은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.FILE_CONTENT_TYPE_REQUIRED)
         String contentType
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
@@ -13,7 +13,7 @@ import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.EdgeErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
 
-@Tag(name = "연결선")
+@Tag(name = "Edge", description = "연결선")
 public interface EdgeApi {
 
     @Operation(summary = "연결선 생성", description = "노드 간 연결선을 추가합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -20,7 +20,7 @@ import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.meeting.exception.MeetingErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
 
-@Tag(name = "노드")
+@Tag(name = "Node", description = "노드")
 public interface NodeApi {
 
     @Operation(summary = "플로우차트 조회", description = "프로젝트의 전체 노드 트리 + 엣지를 조회합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeApi.java
@@ -13,7 +13,7 @@ import kr.flowmeet.domain.node.exception.AssigneeErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 
-@Tag(name = "노드 담당자")
+@Tag(name = "NodeAssignee", description = "노드 담당자")
 public interface NodeAssigneeApi {
 
     @Operation(summary = "담당자 추가", description = "노드에 담당자를 추가합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagApi.java
@@ -14,7 +14,7 @@ import kr.flowmeet.api.node.dto.response.GetAllTagsResponse;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.TagErrorCode;
 
-@Tag(name = "태그")
+@Tag(name = "Tag", description = "태그")
 public interface TagApi {
 
     @Operation(summary = "태그 목록 조회", description = "프로젝트의 전체 태그 목록을 조회합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AddNodeTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AddNodeTagRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "노드 태그 추가 요청")
 public record AddNodeTagRequest(
         @Schema(description = "추가할 태그 ID", example = "5")
-        @NotNull(message = "태그 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.TAG_ID_REQUIRED)
         Long tagId
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AiSummaryRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AiSummaryRequest.java
@@ -3,11 +3,12 @@ package kr.flowmeet.api.node.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "AI 노드 요약 요청")
 public record AiSummaryRequest(
         @Schema(description = "요약할 노드 ID 목록", example = "[101, 102, 103]")
-        @NotEmpty(message = "요약할 노드를 선택해 주세요.")
+        @NotEmpty(message = ValidationMessage.NODE_SUMMARY_TARGETS_REQUIRED)
         List<Long> nodeIds
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateAssigneeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateAssigneeRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "노드 담당자 지정 요청")
 public record CreateAssigneeRequest(
         @Schema(description = "담당자로 지정할 사용자 ID", example = "91")
-        @NotNull(message = "사용자 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.ASSIGNEE_USER_ID_REQUIRED)
         Long userId
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateEdgeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateEdgeRequest.java
@@ -2,15 +2,16 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.service.vo.CreateEdgeCommand;
 
 @Schema(description = "노드 간 엣지 생성 요청")
 public record CreateEdgeRequest(
         @Schema(description = "엣지의 시작 노드 ID", example = "101")
-        @NotNull(message = "시작 노드 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.EDGE_START_NODE_ID_REQUIRED)
         Long startNodeId,
         @Schema(description = "엣지의 종료 노드 ID", example = "102")
-        @NotNull(message = "종료 노드 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.EDGE_END_NODE_ID_REQUIRED)
         Long endNodeId,
         @Schema(description = "엣지에 대한 설명", example = "로그인 성공 시 대시보드로 이동")
         String comment

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateNodeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateNodeRequest.java
@@ -2,13 +2,14 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.entity.NodeType;
 import kr.flowmeet.domain.node.service.vo.CreateNodeCommand;
 
 @Schema(description = "노드 생성 요청")
 public record CreateNodeRequest(
         @Schema(description = "노드 제목", example = "로그인 화면 기획")
-        @NotBlank(message = "노드 제목은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.NODE_TITLE_REQUIRED)
         String title,
         @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
         String description,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/CreateTagRequest.java
@@ -3,16 +3,17 @@ package kr.flowmeet.api.node.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.entity.TagColor;
 import kr.flowmeet.domain.node.service.vo.CreateTagCommand;
 
 @Schema(description = "태그 생성 요청")
 public record CreateTagRequest(
         @Schema(description = "태그 이름", example = "긴급")
-        @NotBlank(message = "태그 이름은 필수입니다.")
+        @NotBlank(message = ValidationMessage.TAG_NAME_REQUIRED)
         String name,
         @Schema(description = "태그 색상", example = "RED")
-        @NotNull(message = "태그 색상은 필수입니다.")
+        @NotNull(message = ValidationMessage.TAG_COLOR_REQUIRED)
         TagColor color
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateEdgeRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateEdgeRequest.java
@@ -2,14 +2,15 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "노드 간 엣지 수정 요청")
 public record UpdateEdgeRequest(
         @Schema(description = "엣지의 시작 노드 ID", example = "101")
-        @NotNull(message = "시작 노드 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.EDGE_START_NODE_ID_REQUIRED)
         Long startNodeId,
         @Schema(description = "엣지의 종료 노드 ID", example = "102")
-        @NotNull(message = "종료 노드 ID는 필수입니다.")
+        @NotNull(message = ValidationMessage.EDGE_END_NODE_ID_REQUIRED)
         Long endNodeId
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
@@ -2,16 +2,17 @@ package kr.flowmeet.api.node.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
 
 @Schema(description = "노드 상태 변경(드래그 앤 드롭) 요청")
 public record UpdateNodeStatusRequest(
         @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
-        @NotNull(message = "상태는 필수로 입력해 주세요.")
+        @NotNull(message = ValidationMessage.NODE_STATUS_REQUIRED)
         NodeStatus status,
         @Schema(description = "칸반 내 정렬 순서", example = "1024")
-        @NotNull(message = "정렬 순서는 필수로 입력해 주세요.")
+        @NotNull(message = ValidationMessage.NODE_SORT_ORDER_REQUIRED)
         Integer sortOrder
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateTagRequest.java
@@ -3,16 +3,17 @@ package kr.flowmeet.api.node.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.entity.TagColor;
 import kr.flowmeet.domain.node.service.vo.UpdateTagCommand;
 
 @Schema(description = "태그 수정 요청")
 public record UpdateTagRequest(
         @Schema(description = "변경할 태그 이름", example = "매우 긴급")
-        @NotBlank(message = "태그 이름은 필수입니다.")
+        @NotBlank(message = ValidationMessage.TAG_NAME_REQUIRED)
         String name,
         @Schema(description = "변경할 태그 색상", example = "RED")
-        @NotNull(message = "태그 색상은 필수입니다.")
+        @NotNull(message = ValidationMessage.TAG_COLOR_REQUIRED)
         TagColor color
 ) {
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
@@ -12,7 +12,7 @@ import kr.flowmeet.api.notification.dto.response.GetUnreadCountResponse;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.notification.exception.NotificationErrorCode;
 
-@Tag(name = "알림")
+@Tag(name = "Notification", description = "알림")
 public interface NotificationApi {
 
     @Operation(summary = "알림 목록 조회",

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingApi.java
@@ -11,7 +11,7 @@ import kr.flowmeet.api.notification.dto.response.GetNotificationSettingResponse;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.notification.exception.NotificationErrorCode;
 
-@Tag(name = "알림 설정")
+@Tag(name = "NotificationSetting", description = "알림 설정")
 public interface NotificationSettingApi {
 
     @Operation(summary = "프로젝트별 알림 설정 조회")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectApi.java
@@ -23,7 +23,7 @@ import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 import kr.flowmeet.domain.project.service.ProjectSortType;
 
-@Tag(name = "프로젝트")
+@Tag(name = "Project", description = "프로젝트")
 public interface ProjectApi {
 
     @Operation(summary = "프로젝트 생성")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
@@ -12,7 +12,7 @@ import kr.flowmeet.api.project.dto.request.UpdateProjectMemberRoleRequest;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 
-@Tag(name = "프로젝트 멤버")
+@Tag(name = "ProjectMember", description = "프로젝트 멤버")
 public interface ProjectMemberApi {
 
     @Operation(summary = "멤버 목록 조회")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlApi.java
@@ -12,7 +12,7 @@ import kr.flowmeet.api.project.dto.response.ProjectUrlResponse;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 
-@Tag(name = "프로젝트 URL")
+@Tag(name = "ProjectUrl", description = "프로젝트 URL")
 public interface ProjectUrlApi {
 
     @Operation(summary = "URL 추가")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/AcceptProjectInvitationRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/AcceptProjectInvitationRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "프로젝트 초대 수락 요청")
 public record AcceptProjectInvitationRequest(
         @Schema(description = "초대 메일 링크에 포함된 JWT 토큰")
-        @NotBlank(message = "초대 토큰은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.INVITATION_TOKEN_REQUIRED)
         String token
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/CreateProjectRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/CreateProjectRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "프로젝트 생성 요청")
 public record CreateProjectRequest(
         @Schema(description = "프로젝트 이름", example = "FlowMeet 리뉴얼")
-        @NotBlank(message = "프로젝트 이름은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.PROJECT_NAME_REQUIRED)
         String name
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/InviteProjectMemberRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/InviteProjectMemberRequest.java
@@ -3,12 +3,13 @@ package kr.flowmeet.api.project.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "프로젝트 멤버 초대 요청")
 public record InviteProjectMemberRequest(
         @Schema(description = "초대할 사용자 이메일", example = "teammate@flowmeet.kr")
-        @NotBlank(message = "이메일은 필수로 입력해 주세요.")
-        @Email(message = "유효하지 않은 이메일 형식입니다.")
+        @NotBlank(message = ValidationMessage.EMAIL_REQUIRED)
+        @Email(message = ValidationMessage.EMAIL_INVALID)
         String email
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "프로젝트 URL 등록/수정 요청")
 public record ProjectUrlRequest(
         @Schema(description = "프로젝트에 연결할 URL", example = "https://github.com/kookmin-sw/2026-capstone-09")
-        @NotBlank(message = "URL은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.PROJECT_URL_REQUIRED)
         String url
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectMemberRoleRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectMemberRoleRequest.java
@@ -2,12 +2,13 @@ package kr.flowmeet.api.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 
 @Schema(description = "프로젝트 멤버 권한 변경 요청")
 public record UpdateProjectMemberRoleRequest(
         @Schema(description = "변경할 권한", example = "MEMBER", allowableValues = {"VIEWER", "MEMBER", "OWNER"})
-        @NotNull(message = "역할은 필수로 입력해 주세요.")
+        @NotNull(message = ValidationMessage.PROJECT_MEMBER_ROLE_REQUIRED)
         ProjectMemberRole role
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/UpdateProjectRequest.java
@@ -2,11 +2,12 @@ package kr.flowmeet.api.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "프로젝트 수정 요청")
 public record UpdateProjectRequest(
         @Schema(description = "변경할 프로젝트 이름", example = "FlowMeet v2")
-        @NotBlank(message = "프로젝트 이름은 필수로 입력해 주세요.")
+        @NotBlank(message = ValidationMessage.PROJECT_NAME_REQUIRED)
         String name
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
@@ -14,7 +14,7 @@ import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.user.exception.UserErrorCode;
 
-@Tag(name = "사용자")
+@Tag(name = "User", description = "사용자")
 public interface UserApi {
 
     @Operation(summary = "내 정보 조회")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/UpdateUserRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/UpdateUserRequest.java
@@ -4,15 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import kr.flowmeet.api.common.validation.ValidationMessage;
 
 @Schema(description = "내 정보 수정 요청")
 public record UpdateUserRequest(
         @Schema(description = "닉네임(최대 20자)", example = "플로우민", maxLength = 20)
-        @Size(max = 20, message = "닉네임은 최대 20자까지 입력할 수 있습니다.")
-        @NotBlank(message = "닉네임은 필수로 입력해 주세요.")
+        @Size(max = 20, message = ValidationMessage.NICKNAME_MAX_LENGTH)
+        @NotBlank(message = ValidationMessage.NICKNAME_REQUIRED)
         String nickname,
         @Schema(description = "이메일", example = "flowmin@flowmeet.kr")
-        @Email(message = "유효하지 않은 이메일 형식입니다.")
+        @Email(message = ValidationMessage.EMAIL_INVALID)
         String email
 ) {
 }

--- a/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/exception/AuthErrorCode.java
+++ b/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/exception/AuthErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 AccessToken입니다."),
-    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "로그인 유효기간이 만료되었습니다.");
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 AccessToken이에요."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "로그인 유효기간이 만료됐어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/exception/FileErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/file/exception/FileErrorCode.java
@@ -8,12 +8,12 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum FileErrorCode implements ErrorCode {
-    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다."),
-    FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
-    FILE_UPLOAD_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "파일 업로드가 완료되지 않았습니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-    FILE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "파일 삭제 권한이 없습니다.");
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 파일이에요."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했어요."),
+    FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식이에요."),
+    FILE_UPLOAD_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "아직 파일 업로드가 완료되지 않았어요."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 업로드하지 못했어요."),
+    FILE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "파일을 삭제할 권한이 없어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/exception/MeetingErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/exception/MeetingErrorCode.java
@@ -8,7 +8,7 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum MeetingErrorCode implements ErrorCode {
-    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "회의 정보를 찾을 수 없습니다.");
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "회의 정보를 찾을 수 없어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/AssigneeErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/AssigneeErrorCode.java
@@ -8,8 +8,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum AssigneeErrorCode implements ErrorCode {
-    ASSIGNEE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 담당자로 등록된 멤버입니다."),
-    ASSIGNEE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 노드의 담당자가 아닙니다.");
+    ASSIGNEE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 담당자로 등록된 멤버예요."),
+    ASSIGNEE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 노드의 담당자가 아니에요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/EdgeErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/EdgeErrorCode.java
@@ -8,8 +8,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum EdgeErrorCode implements ErrorCode {
-    EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 연결선입니다."),
-    EDGE_DUPLICATE(HttpStatus.CONFLICT, "동일한 연결선이 이미 존재합니다."),
+    EDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 연결선이에요."),
+    EDGE_DUPLICATE(HttpStatus.CONFLICT, "동일한 연결선이 이미 있어요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
@@ -8,8 +8,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum NodeErrorCode implements ErrorCode {
-    NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 노드입니다."),
-    ACTIVE_MEETING_EXISTS(HttpStatus.CONFLICT, "진행 중인 회의가 있는 노드는 삭제할 수 없습니다.");
+    NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 노드예요."),
+    ACTIVE_MEETING_EXISTS(HttpStatus.CONFLICT, "진행 중인 회의가 있는 노드는 삭제할 수 없어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/TagErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/TagErrorCode.java
@@ -8,9 +8,9 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum TagErrorCode implements ErrorCode {
-    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 태그입니다."),
-    TAG_NAME_DUPLICATED(HttpStatus.CONFLICT, "동일한 이름의 태그가 이미 존재합니다."),
-    NODE_TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 연결된 태그입니다.");
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 태그예요."),
+    TAG_NAME_DUPLICATED(HttpStatus.CONFLICT, "동일한 이름의 태그가 이미 있어요."),
+    NODE_TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 연결된 태그예요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/notification/exception/NotificationErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/notification/exception/NotificationErrorCode.java
@@ -8,9 +8,9 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationErrorCode implements ErrorCode {
-    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
-    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 알림에 대한 접근 권한이 없습니다."),
-    NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 설정을 찾을 수 없습니다.");
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림이에요."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 알림에 접근할 권한이 없어요."),
+    NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 설정을 찾을 수 없어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/exception/ProjectErrorCode.java
@@ -8,17 +8,17 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum ProjectErrorCode implements ErrorCode {
-    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다."),
-    PROJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "프로젝트의 권한이 없습니다."),
-    PROJECT_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "프로젝트의 유일한 OWNER는 나갈 수 없습니다. 다른 멤버에게 OWNER 권한을 부여한 후 나가주세요."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트에 소속된 멤버입니다."),
-    MEMBER_CANNOT_CHANGE_OWNER(HttpStatus.BAD_REQUEST, "OWNER 권한은 변경할 수 없습니다."),
-    MEMBER_CANNOT_DELETE_OWNER(HttpStatus.BAD_REQUEST, "OWNER는 삭제할 수 없습니다."),
-    INVITATION_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 링크입니다."),
-    INVITATION_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 초대 링크입니다."),
-    INVITATION_EMAIL_MISMATCH(HttpStatus.FORBIDDEN, "초대받은 이메일과 로그인 계정이 일치하지 않습니다."),
-    PROJECT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL입니다.");
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트예요."),
+    PROJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "프로젝트에 접근할 권한이 없어요."),
+    PROJECT_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "프로젝트의 유일한 OWNER는 나갈 수 없어요. 다른 멤버에게 OWNER 권한을 넘긴 후 나가 주세요."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버예요."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로젝트에 소속된 멤버예요."),
+    MEMBER_CANNOT_CHANGE_OWNER(HttpStatus.BAD_REQUEST, "OWNER 권한은 변경할 수 없어요."),
+    MEMBER_CANNOT_DELETE_OWNER(HttpStatus.BAD_REQUEST, "OWNER는 삭제할 수 없어요."),
+    INVITATION_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 링크예요."),
+    INVITATION_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 초대 링크예요."),
+    INVITATION_EMAIL_MISMATCH(HttpStatus.FORBIDDEN, "초대받은 이메일과 로그인 계정이 일치하지 않아요."),
+    PROJECT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL이에요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
@@ -8,9 +8,9 @@ import kr.flowmeet.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
-    USER_IS_PROJECT_OWNER(HttpStatus.BAD_REQUEST, "소유 중인 프로젝트가 존재하여 탈퇴할 수 없습니다. 프로젝트 소유권을 이전하거나 프로젝트를 삭제한 후 다시 시도해 주세요.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없어요."),
+    USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임이에요."),
+    USER_IS_PROJECT_OWNER(HttpStatus.BAD_REQUEST, "소유 중인 프로젝트가 있어서 탈퇴할 수 없어요. 프로젝트 소유권을 넘기거나 프로젝트를 삭제한 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #74

## 📝작업 내용

사용자에게 노출되는 문구의 어투와 Swagger 태그 표기를 통일했습니다. [Toss UX 라이팅 가이드](https://developers-apps-in-toss.toss.im/design/ux-writing.html)를 기준으로 `~입니다/~습니다` 혼재를 해요체로 정리했고, 유효성 검증 메시지를 상수 클래스로 모았습니다. 마지막으로 프론트엔드 코드 제너레이터가 OpenAPI `Tag`의 `name`을 클래스 prefix로 사용하는 점을 반영해 `name`을 PascalCase 영문으로 바꾸고 한글은 `description`으로 옮겼습니다.

### 1. UX 라이팅 가이드에 맞춘 메시지 통일 (`refactor`)

#### 1-1. 해요체 전환

- `~입니다` → `~이에요/예요` (받침 유무에 따라)
- `~했습니다 / ~없습니다 / ~않습니다` → `~했어요 / ~없어요 / ~않아요`
- 전 도메인 `ErrorCode` enum, DTO Bean Validation 메시지에 일괄 적용

#### 1-2. 긍정형 / 능동형 / 명사 풀어쓰기

- 긍정형 (3-1): `이미 존재합니다` → `이미 있어요`
- 능동형 (2): `파일 업로드에 실패했습니다` → `파일을 업로드하지 못했어요`
- 명사+명사 풀어쓰기 (5): `파일 삭제 권한이 없습니다` → `파일을 삭제할 권한이 없어요`
- 한자어 풀어쓰기: `권한을 부여한 후` → `권한을 넘긴 후`, `소유권을 이전하거나` → `소유권을 넘기거나`
- 에러 메시지 (3-2): `유효하지 않은 이메일 형식입니다` → `이메일 형식을 다시 확인해 주세요`

#### 1-3. 예외 규칙 적용

- 수동형 허용 (A-1): 기간 만료는 수동형 유지 → `만료된 초대 링크예요`, `로그인 유효기간이 만료됐어요`
- `되어요` → `돼요` (A-4): 모바일 공간 고려한 토스 컨벤션
- 부정형 허용 (C-2): 정책상 불가한 동작은 `~할 수 없어요` 유지 → `OWNER 권한은 변경할 수 없어요`, `진행 중인 회의가 있는 노드는 삭제할 수 없어요`

#### 1-4. `ValidationMessage` 상수 클래스 도입

- `kr.flowmeet.api.common.validation.ValidationMessage` 추가 (`final class` + `private` 생성자)
- DTO 18개에 흩어져 있던 유효성 메시지를 `public static final String` 상수 23개로 정리
- 중복 메시지는 하나의 상수로 공유
  - `FILE_NAME_REQUIRED` — `ConfirmFileUploadRequest`, `CreatePresignedUrlRequest`
  - `TAG_NAME_REQUIRED` / `TAG_COLOR_REQUIRED` — `CreateTagRequest`, `UpdateTagRequest`
  - `EDGE_START_NODE_ID_REQUIRED` / `EDGE_END_NODE_ID_REQUIRED` — `CreateEdgeRequest`, `UpdateEdgeRequest`
  - `PROJECT_NAME_REQUIRED` — `CreateProjectRequest`, `UpdateProjectRequest`
  - `EMAIL_INVALID` — `InviteProjectMemberRequest`, `UpdateUserRequest`
- DTO의 `@NotBlank(message = "...")` 류 어노테이션을 `@NotBlank(message = ValidationMessage.XXX)` 형태로 교체

### 2. Swagger `@Tag` 명칭 영문화 (`chore`)

프론트엔드의 OpenAPI 코드 제너레이터가 `@Tag(name)`을 API 클래스 이름의 prefix로 사용하기 때문에, 한글이 들어가 타입 이름이 깨지던 문제를 해결했습니다.

- `name`: 컨트롤러 인터페이스명에서 `Api` 접미사를 뗀 PascalCase 영문으로 통일
- 기존 한글 표기는 `description` 필드로 이동 (Swagger UI 노출은 유지)

| 파일 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `FileApi` | `name = "파일"` | `name = "File", description = "파일"` |
| `NotificationApi` | `name = "알림"` | `name = "Notification", description = "알림"` |
| `NotificationSettingApi` | `name = "알림 설정"` | `name = "NotificationSetting", description = "알림 설정"` |
| `UserApi` | `name = "사용자"` | `name = "User", description = "사용자"` |
| `ProjectApi` | `name = "프로젝트"` | `name = "Project", description = "프로젝트"` |
| `ProjectMemberApi` | `name = "프로젝트 멤버"` | `name = "ProjectMember", description = "프로젝트 멤버"` |
| `ProjectUrlApi` | `name = "프로젝트 URL"` | `name = "ProjectUrl", description = "프로젝트 URL"` |
| `NodeApi` | `name = "노드"` | `name = "Node", description = "노드"` |
| `NodeAssigneeApi` | `name = "노드 담당자"` | `name = "NodeAssignee", description = "노드 담당자"` |
| `EdgeApi` | `name = "연결선"` | `name = "Edge", description = "연결선"` |
| `TagApi` | `name = "태그"` | `name = "Tag", description = "태그"` |

## 💬리뷰 요구사항(선택)

- 비즈니스 로직 변경 없이 문구/표기만 수정한 리팩토링 PR입니다. API 스펙은 그대로지만 에러 메시지 문구가 바뀌므로, 프론트에서 문구를 하드코딩해 두었다면 영향이 있을 수 있어요.