### PR TITLE
[Refactor/#76] 성공 상황별 메시지 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/config/SwaggerConfig.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/config/SwaggerConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import kr.flowmeet.api.common.swagger.ApiErrorCodeOperationCustomizer;
+import kr.flowmeet.api.common.swagger.ApiSuccessCodeOperationCustomizer;
 import kr.flowmeet.auth.annotation.UserId;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +39,11 @@ public class SwaggerConfig {
     @Bean
     public OperationCustomizer apiErrorCodeOperationCustomizer() {
         return new ApiErrorCodeOperationCustomizer();
+    }
+
+    @Bean
+    public OperationCustomizer apiSuccessCodeOperationCustomizer() {
+        return new ApiSuccessCodeOperationCustomizer();
     }
 
     @Bean

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
@@ -2,6 +2,7 @@ package kr.flowmeet.api.common.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.flowmeet.common.exception.ErrorCode;
+import kr.flowmeet.common.response.SuccessCode;
 import org.springframework.http.HttpStatus;
 
 @Schema(description = "공통 응답 형식")
@@ -24,6 +25,14 @@ public record CommonResponse<T>(
 
     public static <T> CommonResponse<T> ok(final T data) {
         return new CommonResponse<>(HttpStatus.OK.value(), SUCCESS_CODE, SUCCESS_MESSAGE, data);
+    }
+
+    public static CommonResponse<?> ok(final SuccessCode successCode) {
+        return ok(successCode, null);
+    }
+
+    public static <T> CommonResponse<T> ok(final SuccessCode successCode, final T data) {
+        return new CommonResponse<>(HttpStatus.OK.value(), successCode.name(), successCode.getMessage(), data);
     }
 
     public static CommonResponse<?> error(final ErrorCode errorCode) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/swagger/ApiSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/swagger/ApiSuccessCode.java
@@ -1,0 +1,17 @@
+package kr.flowmeet.api.common.swagger;
+
+import kr.flowmeet.common.response.SuccessCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiSuccessCode {
+
+    Class<? extends SuccessCode> code();
+
+    String name();
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/swagger/ApiSuccessCodeOperationCustomizer.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/swagger/ApiSuccessCodeOperationCustomizer.java
@@ -1,0 +1,97 @@
+package kr.flowmeet.api.common.swagger;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import kr.flowmeet.common.response.SuccessCode;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ApiSuccessCodeOperationCustomizer implements OperationCustomizer {
+
+    private static final String SUCCESS_STATUS_KEY = String.valueOf(HttpStatus.OK.value());
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        ApiSuccessCode annotation = handlerMethod.getMethodAnnotation(ApiSuccessCode.class);
+        if (annotation == null) {
+            return operation;
+        }
+
+        Class<? extends SuccessCode> codeClass = annotation.code();
+        if (!codeClass.isEnum()) {
+            return operation;
+        }
+
+        SuccessCode target = Arrays.stream(codeClass.getEnumConstants())
+                .filter(sc -> sc.name().equals(annotation.name()))
+                .findFirst()
+                .orElse(null);
+        if (target == null) {
+            return operation;
+        }
+
+        ApiResponses responses = operation.getResponses();
+        if (responses == null) {
+            responses = new ApiResponses();
+            operation.setResponses(responses);
+        }
+
+        ApiResponse apiResponse = resolveSuccessResponse(responses);
+        apiResponse.setDescription(HttpStatus.OK.getReasonPhrase());
+
+        Content content = apiResponse.getContent();
+        if (content == null) {
+            content = new Content();
+            apiResponse.setContent(content);
+        }
+
+        MediaType mediaType = content.get(org.springframework.http.MediaType.APPLICATION_JSON_VALUE);
+        if (mediaType == null) {
+            mediaType = new MediaType();
+            content.addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType);
+        }
+        mediaType.setExample(buildExampleValue(target));
+
+        return operation;
+    }
+
+    private ApiResponse resolveSuccessResponse(ApiResponses responses) {
+        ApiResponse existing = responses.get(SUCCESS_STATUS_KEY);
+        if (existing != null) {
+            return existing;
+        }
+
+        // springdoc이 생성한 2xx 슬롯이 다른 키(e.g. "default")로 있을 수 있어 재사용
+        ApiResponse fallback = responses.entrySet().stream()
+                .filter(e -> e.getKey().startsWith("2") || "default".equals(e.getKey()))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse(null);
+
+        if (fallback != null) {
+            responses.addApiResponse(SUCCESS_STATUS_KEY, fallback);
+            return fallback;
+        }
+
+        ApiResponse created = new ApiResponse();
+        responses.addApiResponse(SUCCESS_STATUS_KEY, created);
+        return created;
+    }
+
+    private Map<String, Object> buildExampleValue(SuccessCode successCode) {
+        Map<String, Object> example = new LinkedHashMap<>();
+        example.put("status", HttpStatus.OK.value());
+        example.put("code", successCode.name());
+        example.put("message", successCode.getMessage());
+        example.put("data", null);
+        return example;
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileApi.java
@@ -7,24 +7,29 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.file.dto.request.ConfirmFileUploadRequest;
 import kr.flowmeet.api.file.dto.request.CreatePresignedUrlRequest;
 import kr.flowmeet.api.file.dto.response.CreatePresignedUrlResponse;
 import kr.flowmeet.api.file.dto.response.FileInformationResponse;
+import kr.flowmeet.api.file.success.FileSuccessCode;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 
 @Tag(name = "File", description = "파일")
 public interface FileApi {
 
     @Operation(summary = "Presigned URL 발급", description = "S3 직접 업로드를 위한 Presigned URL을 발급합니다.")
+    @ApiSuccessCode(code = FileSuccessCode.class, name = "CREATE_PRESIGNED_URL")
     @ApiErrorCode(code = FileErrorCode.class, names = {"FILE_SIZE_EXCEEDED"})
     CommonResponse<CreatePresignedUrlResponse> createPresignedUrl(@Valid @RequestBody CreatePresignedUrlRequest request);
 
     @Operation(summary = "업로드 완료 등록", description = "클라이언트의 S3 업로드 완료 후 파일 정보를 등록합니다.")
+    @ApiSuccessCode(code = FileSuccessCode.class, name = "CONFIRM_UPLOAD")
     @ApiErrorCode(code = FileErrorCode.class, names = {"FILE_UPLOAD_NOT_COMPLETED"})
     CommonResponse<FileInformationResponse> confirmUpload(@Valid @RequestBody ConfirmFileUploadRequest request);
 
     @Operation(summary = "파일 삭제")
+    @ApiSuccessCode(code = FileSuccessCode.class, name = "DELETE_FILE")
     @ApiErrorCode(code = FileErrorCode.class, names = {"FILE_NOT_FOUND"})
     CommonResponse<?> deleteFile(@RequestParam String fileKey);
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/controller/FileController.java
@@ -14,6 +14,7 @@ import kr.flowmeet.api.file.dto.request.CreatePresignedUrlRequest;
 import kr.flowmeet.api.file.dto.response.CreatePresignedUrlResponse;
 import kr.flowmeet.api.file.dto.response.FileInformationResponse;
 import kr.flowmeet.api.file.facade.FileFacade;
+import kr.flowmeet.api.file.success.FileSuccessCode;
 
 @RestController
 @RequestMapping("/v1/files")
@@ -26,20 +27,20 @@ public class FileController implements FileApi {
     @PostMapping("/presigned-url")
     public CommonResponse<CreatePresignedUrlResponse> createPresignedUrl(
             @Valid @RequestBody final CreatePresignedUrlRequest request) {
-        return CommonResponse.ok(fileFacade.createPresignedUrl(request));
+        return CommonResponse.ok(FileSuccessCode.CREATE_PRESIGNED_URL, fileFacade.createPresignedUrl(request));
     }
 
     @Override
     @PostMapping
     public CommonResponse<FileInformationResponse> confirmUpload(
             @Valid @RequestBody final ConfirmFileUploadRequest request) {
-        return CommonResponse.ok(fileFacade.confirmUpload(request));
+        return CommonResponse.ok(FileSuccessCode.CONFIRM_UPLOAD, fileFacade.confirmUpload(request));
     }
 
     @Override
     @DeleteMapping
     public CommonResponse<?> deleteFile(@RequestParam final String fileKey) {
         fileFacade.deleteFile(fileKey);
-        return CommonResponse.ok();
+        return CommonResponse.ok(FileSuccessCode.DELETE_FILE);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/success/FileSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/success/FileSuccessCode.java
@@ -1,0 +1,15 @@
+package kr.flowmeet.api.file.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileSuccessCode implements SuccessCode {
+    CREATE_PRESIGNED_URL("업로드 URL을 발급했어요."),
+    CONFIRM_UPLOAD("파일 업로드를 완료했어요."),
+    DELETE_FILE("파일을 삭제했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.CreateEdgeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateEdgeRequest;
+import kr.flowmeet.api.node.success.EdgeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.EdgeErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
@@ -17,6 +19,7 @@ import kr.flowmeet.domain.node.exception.NodeErrorCode;
 public interface EdgeApi {
 
     @Operation(summary = "연결선 생성", description = "노드 간 연결선을 추가합니다.")
+    @ApiSuccessCode(code = EdgeSuccessCode.class, name = "CREATE_EDGE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     @ApiErrorCode(code = EdgeErrorCode.class, names = {"EDGE_DUPLICATE"})
     CommonResponse<?> createEdge(
@@ -26,6 +29,7 @@ public interface EdgeApi {
     );
 
     @Operation(summary = "연결선 삭제", description = "연결선을 삭제합니다.")
+    @ApiSuccessCode(code = EdgeSuccessCode.class, name = "DELETE_EDGE")
     @ApiErrorCode(code = EdgeErrorCode.class, names = {"EDGE_NOT_FOUND"})
     CommonResponse<?> deleteEdge(
             @UserId Long userId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeController.java
@@ -2,19 +2,16 @@ package kr.flowmeet.api.node.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateEdgeRequest;
-import kr.flowmeet.api.node.dto.request.UpdateEdgeRequest;
 import kr.flowmeet.api.node.facade.EdgeFacade;
+import kr.flowmeet.api.node.success.EdgeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -32,7 +29,7 @@ public class EdgeController implements EdgeApi {
             @Valid @RequestBody CreateEdgeRequest request
     ) {
         edgeFacade.createEdge(userId, projectId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(EdgeSuccessCode.CREATE_EDGE);
     }
 
     @Override
@@ -43,6 +40,6 @@ public class EdgeController implements EdgeApi {
             @PathVariable Long edgeId
     ) {
         edgeFacade.deleteEdge(userId, projectId, edgeId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(EdgeSuccessCode.DELETE_EDGE);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
@@ -16,6 +17,7 @@ import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
+import kr.flowmeet.api.node.success.NodeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.meeting.exception.MeetingErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
@@ -24,9 +26,11 @@ import kr.flowmeet.domain.node.exception.NodeErrorCode;
 public interface NodeApi {
 
     @Operation(summary = "플로우차트 조회", description = "프로젝트의 전체 노드 트리 + 엣지를 조회합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_FLOWCHART")
     CommonResponse<GetFlowchartResponse> getFlowchart(@UserId Long userId, @PathVariable Long projectId);
 
     @Operation(summary = "노드 상세 조회", description = "노드 클릭 시 사이드바 상세 정보를 조회합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_NODE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     CommonResponse<GetNodeResponse> getNode(
             @UserId Long userId,
@@ -35,6 +39,7 @@ public interface NodeApi {
     );
 
     @Operation(summary = "노드 추가", description = "메인 노드 또는 서브 노드를 추가합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "CREATE_NODE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND", "NODE_CREATE_FORBIDDEN"})
     CommonResponse<?> createNode(
             @UserId Long userId,
@@ -43,6 +48,7 @@ public interface NodeApi {
     );
 
     @Operation(summary = "노드 수정", description = "노드 제목, 설명, 노트, 상태, 정렬순서를 수정합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "UPDATE_NODE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND", "NODE_UPDATE_FORBIDDEN"})
     CommonResponse<?> updateNode(
             @UserId Long userId,
@@ -52,6 +58,7 @@ public interface NodeApi {
     );
 
     @Operation(summary = "노드 삭제", description = "노드 삭제. 하위 서브 노드도 연쇄 삭제됩니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "DELETE_NODE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     @ApiErrorCode(code = MeetingErrorCode.class, names = {"ACTIVE_MEETING_EXISTS"})
     CommonResponse<?> deleteNode(
@@ -61,6 +68,7 @@ public interface NodeApi {
     );
 
     @Operation(summary = "리스트 뷰 조회", description = "노드를 리스트 형태로 조회합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_NODE_LIST")
     CommonResponse<GetNodeListResponse> getNodeList(
             @UserId Long userId,
             @PathVariable Long projectId,
@@ -68,9 +76,11 @@ public interface NodeApi {
     );
 
     @Operation(summary = "칸반 보드 조회", description = "상태별 그룹으로 노드를 조회합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_KANBAN")
     CommonResponse<GetKanbanResponse> getKanban(@UserId Long userId, @PathVariable Long projectId);
 
     @Operation(summary = "칸반 상태 변경", description = "드래그 & 드롭으로 상태와 순서를 변경합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "UPDATE_NODE_STATUS")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     CommonResponse<?> updateNodeStatus(
             @UserId Long userId,
@@ -80,6 +90,7 @@ public interface NodeApi {
     );
 
     @Operation(summary = "프로젝트 내 검색", description = "노드 제목, 키워드로 검색합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "SEARCH")
     CommonResponse<SearchNodeResponse> search(
             @UserId Long userId,
             @PathVariable Long projectId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeApi.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.CreateAssigneeRequest;
+import kr.flowmeet.api.node.success.NodeAssigneeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.AssigneeErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
@@ -17,6 +19,7 @@ import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 public interface NodeAssigneeApi {
 
     @Operation(summary = "담당자 추가", description = "노드에 담당자를 추가합니다.")
+    @ApiSuccessCode(code = NodeAssigneeSuccessCode.class, name = "CREATE_ASSIGNEE")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND", "NODE_CREATE_FORBIDDEN"})
     @ApiErrorCode(code = AssigneeErrorCode.class, names = {"ASSIGNEE_ALREADY_EXISTS"})
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND"})
@@ -28,6 +31,7 @@ public interface NodeAssigneeApi {
     );
 
     @Operation(summary = "담당자 제거", description = "노드에서 담당자를 제거합니다.")
+    @ApiSuccessCode(code = NodeAssigneeSuccessCode.class, name = "DELETE_ASSIGNEE")
     @ApiErrorCode(code = AssigneeErrorCode.class, names = {"ASSIGNEE_NOT_FOUND"})
     CommonResponse<?> deleteAssignee(
             @UserId Long userId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeController.java
@@ -2,13 +2,11 @@ package kr.flowmeet.api.node.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateAssigneeRequest;
@@ -25,7 +23,6 @@ public class NodeAssigneeController implements NodeAssigneeApi {
 
     @Override
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse<?> createAssignee(
             @UserId Long userId,
             @PathVariable Long projectId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeAssigneeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateAssigneeRequest;
 import kr.flowmeet.api.node.facade.NodeAssigneeFacade;
+import kr.flowmeet.api.node.success.NodeAssigneeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -32,7 +33,7 @@ public class NodeAssigneeController implements NodeAssigneeApi {
             @Valid @RequestBody CreateAssigneeRequest request
     ) {
         nodeAssigneeFacade.createAssignee(userId, projectId, nodeId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeAssigneeSuccessCode.CREATE_ASSIGNEE);
     }
 
     @Override
@@ -44,6 +45,6 @@ public class NodeAssigneeController implements NodeAssigneeApi {
             @PathVariable Long assigneeId
     ) {
         nodeAssigneeFacade.deleteAssignee(userId, projectId, nodeId, assigneeId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeAssigneeSuccessCode.DELETE_ASSIGNEE);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -1,9 +1,7 @@
 package kr.flowmeet.api.node.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,7 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
@@ -24,8 +21,8 @@ import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.api.node.facade.NodeFacade;
+import kr.flowmeet.api.node.success.NodeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
-import kr.flowmeet.domain.node.entity.NodeStatus;
 
 @RestController
 @RequestMapping("/v1/projects/{projectId}")
@@ -37,22 +34,28 @@ public class NodeController implements NodeApi {
     @Override
     @GetMapping("/nodes")
     public CommonResponse<GetFlowchartResponse> getFlowchart(@UserId Long userId, @PathVariable Long projectId) {
-        return CommonResponse.ok(nodeFacade.getFlowchart(userId, projectId));
+        return CommonResponse.ok(NodeSuccessCode.GET_FLOWCHART, nodeFacade.getFlowchart(userId, projectId));
     }
 
     @Override
     @GetMapping("/nodes/{nodeId}")
-    public CommonResponse<GetNodeResponse> getNode(@UserId Long userId, @PathVariable Long projectId,
-                                                   @PathVariable Long nodeId) {
-        return CommonResponse.ok(nodeFacade.getNode(userId, projectId, nodeId));
+    public CommonResponse<GetNodeResponse> getNode(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
+    ) {
+        return CommonResponse.ok(NodeSuccessCode.GET_NODE, nodeFacade.getNode(userId, projectId, nodeId));
     }
 
     @Override
     @PostMapping("/nodes")
-    public CommonResponse<?> createNode(@UserId Long userId, @PathVariable Long projectId,
-                                        @Valid @RequestBody CreateNodeRequest request) {
+    public CommonResponse<?> createNode(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody CreateNodeRequest request
+    ) {
         nodeFacade.createNode(userId, projectId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeSuccessCode.CREATE_NODE);
     }
 
     @Override
@@ -64,16 +67,18 @@ public class NodeController implements NodeApi {
             @Valid @RequestBody UpdateNodeRequest request
     ) {
         nodeFacade.updateNode(userId, projectId, nodeId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeSuccessCode.UPDATE_NODE);
     }
 
     @Override
     @DeleteMapping("/nodes/{nodeId}")
-    public CommonResponse<?> deleteNode(@UserId Long userId,
-                                        @PathVariable Long projectId,
-                                        @PathVariable Long nodeId) {
+    public CommonResponse<?> deleteNode(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
+    ) {
         nodeFacade.deleteNode(userId, projectId, nodeId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeSuccessCode.DELETE_NODE);
     }
 
     @Override
@@ -83,32 +88,37 @@ public class NodeController implements NodeApi {
             @PathVariable Long projectId,
             @RequestParam(required = false) String sort
     ) {
-        return CommonResponse.ok(
-                nodeFacade.getNodeList(userId, projectId, sort));
+        return CommonResponse.ok(NodeSuccessCode.GET_NODE_LIST, nodeFacade.getNodeList(userId, projectId, sort));
     }
 
     @Override
     @GetMapping("/nodes/kanban")
-    public CommonResponse<GetKanbanResponse> getKanban(@UserId Long userId,
-                                                       @PathVariable Long projectId) {
-        return CommonResponse.ok(nodeFacade.getKanban(userId, projectId));
+    public CommonResponse<GetKanbanResponse> getKanban(
+            @UserId Long userId,
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.ok(NodeSuccessCode.GET_KANBAN, nodeFacade.getKanban(userId, projectId));
     }
 
     @Override
     @PatchMapping("/nodes/{nodeId}/status")
-    public CommonResponse<?> updateNodeStatus(@UserId Long userId,
-                                              @PathVariable Long projectId,
-                                              @PathVariable Long nodeId,
-                                              @Valid @RequestBody UpdateNodeStatusRequest request) {
+    public CommonResponse<?> updateNodeStatus(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @Valid @RequestBody UpdateNodeStatusRequest request
+    ) {
         nodeFacade.updateNodeStatus(userId, projectId, nodeId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NodeSuccessCode.UPDATE_NODE_STATUS);
     }
 
     @Override
     @GetMapping("/search")
-    public CommonResponse<SearchNodeResponse> search(@UserId Long userId,
-                                                     @PathVariable Long projectId,
-                                                     @RequestParam String query) {
-        return CommonResponse.ok(nodeFacade.search(userId, projectId, query));
+    public CommonResponse<SearchNodeResponse> search(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @RequestParam String query
+    ) {
+        return CommonResponse.ok(NodeSuccessCode.SEARCH, nodeFacade.search(userId, projectId, query));
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagApi.java
@@ -7,10 +7,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.AddNodeTagRequest;
 import kr.flowmeet.api.node.dto.request.CreateTagRequest;
 import kr.flowmeet.api.node.dto.request.UpdateTagRequest;
 import kr.flowmeet.api.node.dto.response.GetAllTagsResponse;
+import kr.flowmeet.api.node.success.TagSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.TagErrorCode;
 
@@ -18,12 +20,14 @@ import kr.flowmeet.domain.node.exception.TagErrorCode;
 public interface TagApi {
 
     @Operation(summary = "태그 목록 조회", description = "프로젝트의 전체 태그 목록을 조회합니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "GET_ALL_TAGS")
     CommonResponse<GetAllTagsResponse> getAllTags(
             @UserId Long userId,
             @PathVariable Long projectId
     );
 
     @Operation(summary = "태그 생성", description = "새 태그를 생성합니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "CREATE_TAG")
     @ApiErrorCode(code = TagErrorCode.class, names = {"TAG_NAME_DUPLICATED"})
     CommonResponse<?> createTag(
             @UserId Long userId,
@@ -32,6 +36,7 @@ public interface TagApi {
     );
 
     @Operation(summary = "태그 수정", description = "태그 이름 또는 색상을 수정합니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "UPDATE_TAG")
     @ApiErrorCode(code = TagErrorCode.class, names = {"TAG_NOT_FOUND", "TAG_NAME_DUPLICATED"})
     CommonResponse<?> updateTag(
             @UserId Long userId,
@@ -41,6 +46,7 @@ public interface TagApi {
     );
 
     @Operation(summary = "태그 삭제", description = "태그를 삭제합니다. 연결된 노드 태그도 함께 삭제됩니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "DELETE_TAG")
     @ApiErrorCode(code = TagErrorCode.class, names = {"TAG_NOT_FOUND"})
     CommonResponse<?> deleteTag(
             @UserId Long userId,
@@ -49,6 +55,7 @@ public interface TagApi {
     );
 
     @Operation(summary = "노드에 태그 추가", description = "노드에 기존 태그를 연결합니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "ADD_NODE_TAG")
     @ApiErrorCode(code = TagErrorCode.class, names = {"TAG_NOT_FOUND", "NODE_TAG_ALREADY_EXISTS"})
     CommonResponse<?> addNodeTag(
             @UserId Long userId,
@@ -58,6 +65,7 @@ public interface TagApi {
     );
 
     @Operation(summary = "노드에서 태그 제거", description = "노드에서 태그 연결을 해제합니다.")
+    @ApiSuccessCode(code = TagSuccessCode.class, name = "REMOVE_NODE_TAG")
     CommonResponse<?> removeNodeTag(
             @UserId Long userId,
             @PathVariable Long projectId,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/TagController.java
@@ -16,6 +16,7 @@ import kr.flowmeet.api.node.dto.request.CreateTagRequest;
 import kr.flowmeet.api.node.dto.request.UpdateTagRequest;
 import kr.flowmeet.api.node.dto.response.GetAllTagsResponse;
 import kr.flowmeet.api.node.facade.TagFacade;
+import kr.flowmeet.api.node.success.TagSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -31,7 +32,7 @@ public class TagController implements TagApi {
             @UserId Long userId,
             @PathVariable Long projectId
     ) {
-        return CommonResponse.ok(tagFacade.getAllTags(userId, projectId));
+        return CommonResponse.ok(TagSuccessCode.GET_ALL_TAGS, tagFacade.getAllTags(userId, projectId));
     }
 
     @Override
@@ -42,7 +43,7 @@ public class TagController implements TagApi {
             @Valid @RequestBody CreateTagRequest request
     ) {
         tagFacade.createTag(userId, projectId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(TagSuccessCode.CREATE_TAG);
     }
 
     @Override
@@ -54,7 +55,7 @@ public class TagController implements TagApi {
             @Valid @RequestBody UpdateTagRequest request
     ) {
         tagFacade.updateTag(userId, projectId, tagId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(TagSuccessCode.UPDATE_TAG);
     }
 
     @Override
@@ -65,7 +66,7 @@ public class TagController implements TagApi {
             @PathVariable Long tagId
     ) {
         tagFacade.deleteTag(userId, projectId, tagId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(TagSuccessCode.DELETE_TAG);
     }
 
     @Override
@@ -77,7 +78,7 @@ public class TagController implements TagApi {
             @Valid @RequestBody AddNodeTagRequest request
     ) {
         tagFacade.addNodeTag(userId, projectId, nodeId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(TagSuccessCode.ADD_NODE_TAG);
     }
 
     @Override
@@ -89,6 +90,6 @@ public class TagController implements TagApi {
             @PathVariable Long tagId
     ) {
         tagFacade.removeNodeTag(userId, projectId, nodeId, tagId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(TagSuccessCode.REMOVE_NODE_TAG);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/EdgeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/EdgeSuccessCode.java
@@ -1,0 +1,14 @@
+package kr.flowmeet.api.node.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EdgeSuccessCode implements SuccessCode {
+    CREATE_EDGE("연결선을 생성했어요."),
+    DELETE_EDGE("연결선을 삭제했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeAssigneeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeAssigneeSuccessCode.java
@@ -1,0 +1,14 @@
+package kr.flowmeet.api.node.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NodeAssigneeSuccessCode implements SuccessCode {
+    CREATE_ASSIGNEE("담당자를 추가했어요."),
+    DELETE_ASSIGNEE("담당자를 제거했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
@@ -1,0 +1,21 @@
+package kr.flowmeet.api.node.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NodeSuccessCode implements SuccessCode {
+    GET_FLOWCHART("플로우차트를 조회했어요."),
+    GET_NODE("노드를 조회했어요."),
+    CREATE_NODE("노드를 추가했어요."),
+    UPDATE_NODE("노드를 수정했어요."),
+    DELETE_NODE("노드를 삭제했어요."),
+    GET_NODE_LIST("노드 리스트를 조회했어요."),
+    GET_KANBAN("칸반 보드를 조회했어요."),
+    UPDATE_NODE_STATUS("노드 상태를 변경했어요."),
+    SEARCH("검색을 완료했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/TagSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/TagSuccessCode.java
@@ -1,0 +1,18 @@
+package kr.flowmeet.api.node.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TagSuccessCode implements SuccessCode {
+    GET_ALL_TAGS("태그 목록을 조회했어요."),
+    CREATE_TAG("태그를 생성했어요."),
+    UPDATE_TAG("태그를 수정했어요."),
+    DELETE_TAG("태그를 삭제했어요."),
+    ADD_NODE_TAG("노드에 태그를 추가했어요."),
+    REMOVE_NODE_TAG("노드에서 태그를 제거했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.dto.CursorSliceResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.notification.dto.response.NotificationSummaryResponse;
 import kr.flowmeet.api.notification.dto.response.GetUnreadCountResponse;
+import kr.flowmeet.api.notification.success.NotificationSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.notification.exception.NotificationErrorCode;
 
@@ -17,6 +19,7 @@ public interface NotificationApi {
 
     @Operation(summary = "알림 목록 조회",
             description = "isRead 필터와 커서 기반 슬라이싱을 지원합니다. 첫 요청은 cursorId 생략, 이후 응답의 nextCursorId를 그대로 전달합니다.")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "GET_ALL_NOTIFICATIONS")
     CommonResponse<CursorSliceResponse<NotificationSummaryResponse>> getAllNotifications(
             @UserId Long userId,
             @RequestParam(required = false) Boolean isRead,
@@ -24,12 +27,15 @@ public interface NotificationApi {
             @RequestParam(defaultValue = "20") int size);
 
     @Operation(summary = "알림 읽음 처리")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "MARK_AS_READ")
     @ApiErrorCode(code = NotificationErrorCode.class, names = {"NOTIFICATION_NOT_FOUND", "NOTIFICATION_ACCESS_DENIED"})
     CommonResponse<?> markAsRead(@UserId Long userId, @PathVariable Long notificationId);
 
     @Operation(summary = "전체 알림 읽음 처리")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "MARK_ALL_AS_READ")
     CommonResponse<?> markAllAsRead(@UserId Long userId);
 
     @Operation(summary = "읽지 않은 알림 개수 조회")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "GET_UNREAD_COUNT")
     CommonResponse<GetUnreadCountResponse> getUnreadCount(@UserId Long userId);
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationController.java
@@ -1,6 +1,5 @@
 package kr.flowmeet.api.notification.controller;
 
-import kr.flowmeet.domain.common.vo.CursorSlice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -13,6 +12,7 @@ import kr.flowmeet.api.common.dto.CursorSliceResponse;
 import kr.flowmeet.api.notification.dto.response.NotificationSummaryResponse;
 import kr.flowmeet.api.notification.dto.response.GetUnreadCountResponse;
 import kr.flowmeet.api.notification.facade.NotificationFacade;
+import kr.flowmeet.api.notification.success.NotificationSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -30,26 +30,29 @@ public class NotificationController implements NotificationApi {
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "20") int size
     ) {
-        return CommonResponse.ok(notificationFacade.getAllNotifications(userId, isRead, cursorId, size));
+        return CommonResponse.ok(
+                NotificationSuccessCode.GET_ALL_NOTIFICATIONS,
+                notificationFacade.getAllNotifications(userId, isRead, cursorId, size)
+        );
     }
 
     @Override
     @PatchMapping("/{notificationId}/read")
     public CommonResponse<?> markAsRead(@UserId Long userId, @PathVariable Long notificationId) {
         notificationFacade.markAsRead(userId, notificationId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NotificationSuccessCode.MARK_AS_READ);
     }
 
     @Override
     @PatchMapping("/all")
     public CommonResponse<?> markAllAsRead(@UserId Long userId) {
         notificationFacade.markAllAsRead(userId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(NotificationSuccessCode.MARK_ALL_AS_READ);
     }
 
     @Override
     @GetMapping("/unread-count")
     public CommonResponse<GetUnreadCountResponse> getUnreadCount(@UserId Long userId) {
-        return CommonResponse.ok(notificationFacade.getUnreadCount(userId));
+        return CommonResponse.ok(NotificationSuccessCode.GET_UNREAD_COUNT, notificationFacade.getUnreadCount(userId));
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingApi.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.notification.dto.request.UpdateNotificationSettingRequest;
 import kr.flowmeet.api.notification.dto.response.GetNotificationSettingResponse;
+import kr.flowmeet.api.notification.success.NotificationSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.notification.exception.NotificationErrorCode;
 
@@ -15,13 +17,19 @@ import kr.flowmeet.domain.notification.exception.NotificationErrorCode;
 public interface NotificationSettingApi {
 
     @Operation(summary = "프로젝트별 알림 설정 조회")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "GET_NOTIFICATION_SETTING")
     @ApiErrorCode(code = NotificationErrorCode.class, names = {"NOTIFICATION_SETTING_NOT_FOUND"})
     CommonResponse<GetNotificationSettingResponse> getNotificationSetting(
-            @UserId Long userId, @PathVariable Long projectId);
+            @UserId Long userId,
+            @PathVariable Long projectId
+    );
 
     @Operation(summary = "프로젝트별 알림 설정 수정", description = "변경할 필드만 전달합니다.")
+    @ApiSuccessCode(code = NotificationSuccessCode.class, name = "UPDATE_NOTIFICATION_SETTING")
     @ApiErrorCode(code = NotificationErrorCode.class, names = {"NOTIFICATION_SETTING_NOT_FOUND"})
     CommonResponse<GetNotificationSettingResponse> updateNotificationSetting(
-            @UserId Long userId, @PathVariable Long projectId,
-            @RequestBody UpdateNotificationSettingRequest request);
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @RequestBody UpdateNotificationSettingRequest request
+    );
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationSettingController.java
@@ -11,6 +11,7 @@ import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.notification.dto.request.UpdateNotificationSettingRequest;
 import kr.flowmeet.api.notification.dto.response.GetNotificationSettingResponse;
 import kr.flowmeet.api.notification.facade.NotificationFacade;
+import kr.flowmeet.api.notification.success.NotificationSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -23,15 +24,25 @@ public class NotificationSettingController implements NotificationSettingApi {
     @Override
     @GetMapping
     public CommonResponse<GetNotificationSettingResponse> getNotificationSetting(
-            @UserId Long userId, @PathVariable Long projectId) {
-        return CommonResponse.ok(notificationFacade.getNotificationSetting(userId, projectId));
+            @UserId Long userId,
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.ok(
+                NotificationSuccessCode.GET_NOTIFICATION_SETTING,
+                notificationFacade.getNotificationSetting(userId, projectId)
+        );
     }
 
     @Override
     @PatchMapping
     public CommonResponse<GetNotificationSettingResponse> updateNotificationSetting(
-            @UserId Long userId, @PathVariable Long projectId,
-            @RequestBody UpdateNotificationSettingRequest request) {
-        return CommonResponse.ok(notificationFacade.updateNotificationSetting(userId, projectId, request));
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @RequestBody UpdateNotificationSettingRequest request
+    ) {
+        return CommonResponse.ok(
+                NotificationSuccessCode.UPDATE_NOTIFICATION_SETTING,
+                notificationFacade.updateNotificationSetting(userId, projectId, request)
+        );
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/success/NotificationSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/success/NotificationSuccessCode.java
@@ -1,0 +1,18 @@
+package kr.flowmeet.api.notification.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationSuccessCode implements SuccessCode {
+    GET_ALL_NOTIFICATIONS("알림 목록을 조회했어요."),
+    MARK_AS_READ("알림을 읽음 처리했어요."),
+    MARK_ALL_AS_READ("전체 알림을 읽음 처리했어요."),
+    GET_UNREAD_COUNT("읽지 않은 알림 개수를 조회했어요."),
+    GET_NOTIFICATION_SETTING("알림 설정을 조회했어요."),
+    UPDATE_NOTIFICATION_SETTING("알림 설정을 변경했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectApi.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.dto.CursorSliceResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.project.dto.request.AcceptProjectInvitationRequest;
 import kr.flowmeet.api.project.dto.request.CreateProjectRequest;
 import kr.flowmeet.api.project.dto.request.InviteProjectMemberRequest;
@@ -18,6 +19,7 @@ import kr.flowmeet.api.project.dto.response.AcceptProjectInvitationResponse;
 import kr.flowmeet.api.project.dto.response.CreateProjectResponse;
 import kr.flowmeet.api.project.dto.response.GetProjectResponse;
 import kr.flowmeet.api.project.dto.response.ProjectSummaryResponse;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
@@ -27,11 +29,15 @@ import kr.flowmeet.domain.project.service.ProjectSortType;
 public interface ProjectApi {
 
     @Operation(summary = "프로젝트 생성")
-    CommonResponse<CreateProjectResponse> createProject(@UserId Long userId,
-                                                        @Valid @RequestBody CreateProjectRequest request);
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "CREATE_PROJECT")
+    CommonResponse<CreateProjectResponse> createProject(
+            @UserId Long userId,
+            @Valid @RequestBody CreateProjectRequest request
+    );
 
     @Operation(summary = "프로젝트 목록 조회",
             description = "검색어, 정렬(LATEST/NAME), 커서 기반 슬라이싱을 지원합니다. 첫 요청은 cursorId/cursorValue 생략, 이후 응답의 nextCursorId/nextCursorValue를 그대로 전달합니다.")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "GET_ALL_PROJECTS")
     CommonResponse<CursorSliceResponse<ProjectSummaryResponse>> getAllProjects(
             @UserId Long userId,
             @RequestParam(required = false) String search,
@@ -41,31 +47,49 @@ public interface ProjectApi {
             @RequestParam(defaultValue = "20") int size);
 
     @Operation(summary = "프로젝트 상세 조회")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "GET_PROJECT")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_NOT_FOUND", "PROJECT_ACCESS_DENIED"})
     CommonResponse<GetProjectResponse> getProject(@UserId Long userId, @PathVariable Long projectId);
 
     @Operation(summary = "프로젝트 수정")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "UPDATE_PROJECT")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED"})
-    CommonResponse<?> updateProject(@UserId Long userId, @PathVariable Long projectId,
-                                    @Valid @RequestBody UpdateProjectRequest request);
+    CommonResponse<?> updateProject(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody UpdateProjectRequest request
+    );
 
     @Operation(summary = "프로젝트 이미지 변경", description = "png, jpeg, webp만 허용 (최대 5MB)")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "UPDATE_PROFILE_IMAGE")
     @ApiErrorCode(code = FileErrorCode.class, names = {"FILE_SIZE_EXCEEDED", "FILE_INVALID_TYPE"})
-    CommonResponse<?> updateProfileImage(@UserId Long userId, @PathVariable Long projectId, MultipartFile profileImage);
+    CommonResponse<?> updateProfileImage(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            MultipartFile profileImage
+    );
 
     @Operation(summary = "프로젝트 삭제", description = "OWNER만 삭제할 수 있습니다.")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "DELETE_PROJECT")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_DELETE_FORBIDDEN"})
     CommonResponse<?> deleteProject(@UserId Long userId, @PathVariable Long projectId);
 
     @Operation(summary = "프로젝트 멤버 초대", description = "초대받는 이메일로 초대 링크가 포함된 메일을 전송합니다.")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "INVITE_MEMBER")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_INVITE_FORBIDDEN", "MEMBER_ALREADY_EXISTS"})
-    CommonResponse<?> inviteMember(@UserId Long userId, @PathVariable Long projectId,
-                                   @Valid @RequestBody InviteProjectMemberRequest request);
+    CommonResponse<?> inviteMember(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody InviteProjectMemberRequest request
+    );
 
     @Operation(summary = "프로젝트 초대 수락", description = "메일 링크의 JWT 토큰을 제출하면 해당 프로젝트에 VIEWER로 합류합니다.")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "ACCEPT_INVITATION")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {
             "INVITATION_TOKEN_INVALID", "INVITATION_TOKEN_EXPIRED", "INVITATION_EMAIL_MISMATCH", "MEMBER_ALREADY_EXISTS"
     })
-    CommonResponse<AcceptProjectInvitationResponse> acceptInvitation(@UserId Long userId,
-                                                                     @Valid @RequestBody AcceptProjectInvitationRequest request);
+    CommonResponse<AcceptProjectInvitationResponse> acceptInvitation(
+            @UserId Long userId,
+            @Valid @RequestBody AcceptProjectInvitationRequest request
+    );
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectController.java
@@ -25,6 +25,7 @@ import kr.flowmeet.api.project.dto.response.CreateProjectResponse;
 import kr.flowmeet.api.project.dto.response.GetProjectResponse;
 import kr.flowmeet.api.project.dto.response.ProjectSummaryResponse;
 import kr.flowmeet.api.project.facade.ProjectFacade;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.project.service.ProjectSortType;
 
@@ -37,9 +38,11 @@ public class ProjectController implements ProjectApi {
 
     @Override
     @PostMapping
-    public CommonResponse<CreateProjectResponse> createProject(@UserId Long userId,
-                                                               @Valid @RequestBody CreateProjectRequest request) {
-        return CommonResponse.ok(projectFacade.createProject(userId, request));
+    public CommonResponse<CreateProjectResponse> createProject(
+            @UserId Long userId,
+            @Valid @RequestBody CreateProjectRequest request
+    ) {
+        return CommonResponse.ok(ProjectSuccessCode.CREATE_PROJECT, projectFacade.createProject(userId, request));
     }
 
     @Override
@@ -52,21 +55,27 @@ public class ProjectController implements ProjectApi {
             @RequestParam(required = false) String cursorValue,
             @RequestParam(defaultValue = "20") int size
     ) {
-        return CommonResponse.ok(projectFacade.getAllProjects(userId, search, sort, cursorId, cursorValue, size));
+        return CommonResponse.ok(
+                ProjectSuccessCode.GET_ALL_PROJECTS,
+                projectFacade.getAllProjects(userId, search, sort, cursorId, cursorValue, size)
+        );
     }
 
     @Override
     @GetMapping("/{projectId}")
     public CommonResponse<GetProjectResponse> getProject(@UserId Long userId, @PathVariable Long projectId) {
-        return CommonResponse.ok(projectFacade.getProject(userId, projectId));
+        return CommonResponse.ok(ProjectSuccessCode.GET_PROJECT, projectFacade.getProject(userId, projectId));
     }
 
     @Override
     @PatchMapping("/{projectId}")
-    public CommonResponse<?> updateProject(@UserId Long userId, @PathVariable Long projectId,
-                                           @Valid @RequestBody UpdateProjectRequest request) {
+    public CommonResponse<?> updateProject(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody UpdateProjectRequest request
+    ) {
         projectFacade.updateProject(userId, projectId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.UPDATE_PROJECT);
     }
 
     @Override
@@ -74,30 +83,39 @@ public class ProjectController implements ProjectApi {
     public CommonResponse<?> updateProfileImage(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestPart("profileImage") MultipartFile profileImage) {
+            @RequestPart("profileImage") MultipartFile profileImage
+    ) {
         projectFacade.updateProfileImage(userId, projectId, profileImage);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.UPDATE_PROFILE_IMAGE);
     }
 
     @Override
     @DeleteMapping("/{projectId}")
     public CommonResponse<?> deleteProject(@UserId Long userId, @PathVariable Long projectId) {
         projectFacade.deleteProject(userId, projectId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.DELETE_PROJECT);
     }
 
     @Override
     @PostMapping("/{projectId}/invite")
-    public CommonResponse<?> inviteMember(@UserId Long userId, @PathVariable Long projectId,
-                                          @Valid @RequestBody InviteProjectMemberRequest request) {
+    public CommonResponse<?> inviteMember(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody InviteProjectMemberRequest request
+    ) {
         projectFacade.inviteMember(userId, projectId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.INVITE_MEMBER);
     }
 
     @Override
     @PostMapping("/invitations/accept")
-    public CommonResponse<AcceptProjectInvitationResponse> acceptInvitation(@UserId Long userId,
-                                                                            @Valid @RequestBody AcceptProjectInvitationRequest request) {
-        return CommonResponse.ok(projectFacade.acceptInvitation(userId, request));
+    public CommonResponse<AcceptProjectInvitationResponse> acceptInvitation(
+            @UserId Long userId,
+            @Valid @RequestBody AcceptProjectInvitationRequest request
+    ) {
+        return CommonResponse.ok(
+                ProjectSuccessCode.ACCEPT_INVITATION,
+                projectFacade.acceptInvitation(userId, request)
+        );
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberApi.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.project.dto.response.GetAllProjectMembersResponse;
 import kr.flowmeet.api.project.dto.request.UpdateProjectMemberRoleRequest;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 
@@ -16,20 +18,30 @@ import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 public interface ProjectMemberApi {
 
     @Operation(summary = "멤버 목록 조회")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "GET_ALL_MEMBERS")
     CommonResponse<GetAllProjectMembersResponse> getAllMembers(@UserId Long userId, @PathVariable Long projectId);
 
     @Operation(summary = "멤버 권한 수정", description = "- OWNER 부여: OWNER 권한 필요\n- OWNER 강등: 본인만 가능\n- VIEWER ↔ MEMBER 변경: MEMBER 이상 가능")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "UPDATE_MEMBER_ROLE")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND", "PROJECT_ACCESS_DENIED", "MEMBER_CANNOT_CHANGE_OWNER"})
-    CommonResponse<?> updateMemberRole(@UserId Long userId, @PathVariable Long projectId,
-                                       @PathVariable Long memberId,
-                                       @Valid @RequestBody UpdateProjectMemberRoleRequest request);
+    CommonResponse<?> updateMemberRole(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody UpdateProjectMemberRoleRequest request
+    );
 
     @Operation(summary = "멤버 삭제", description = "OWNER만 삭제할 수 있습니다.")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "DELETE_MEMBER")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"MEMBER_NOT_FOUND", "PROJECT_ACCESS_DENIED", "MEMBER_CANNOT_DELETE_OWNER"})
-    CommonResponse<?> deleteMember(@UserId Long userId, @PathVariable Long projectId,
-                                   @PathVariable Long memberId);
+    CommonResponse<?> deleteMember(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long memberId
+    );
 
     @Operation(summary = "프로젝트 나가기")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "LEAVE_PROJECT")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_OWNER_CANNOT_LEAVE"})
     CommonResponse<?> leaveProject(@UserId Long userId, @PathVariable Long projectId);
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectMemberController.java
@@ -13,6 +13,7 @@ import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.project.dto.response.GetAllProjectMembersResponse;
 import kr.flowmeet.api.project.facade.ProjectMemberFacade;
 import kr.flowmeet.api.project.dto.request.UpdateProjectMemberRoleRequest;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -24,31 +25,43 @@ public class ProjectMemberController implements ProjectMemberApi {
 
     @Override
     @GetMapping
-    public CommonResponse<GetAllProjectMembersResponse> getAllMembers(@UserId Long userId, @PathVariable Long projectId) {
-        return CommonResponse.ok(projectMemberFacade.getAllMembers(userId, projectId));
+    public CommonResponse<GetAllProjectMembersResponse> getAllMembers(
+            @UserId Long userId,
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.ok(
+                ProjectSuccessCode.GET_ALL_MEMBERS,
+                projectMemberFacade.getAllMembers(userId, projectId)
+        );
     }
 
     @Override
     @PatchMapping("/{memberId}/role")
-    public CommonResponse<?> updateMemberRole(@UserId Long userId, @PathVariable Long projectId,
-                                              @PathVariable Long memberId,
-                                              @Valid @RequestBody UpdateProjectMemberRoleRequest request) {
+    public CommonResponse<?> updateMemberRole(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody UpdateProjectMemberRoleRequest request
+    ) {
         projectMemberFacade.updateMemberRole(userId, projectId, memberId, request);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.UPDATE_MEMBER_ROLE);
     }
 
     @Override
     @DeleteMapping("/{memberId}")
-    public CommonResponse<?> deleteMember(@UserId Long userId, @PathVariable Long projectId,
-                                          @PathVariable Long memberId) {
+    public CommonResponse<?> deleteMember(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long memberId
+    ) {
         projectMemberFacade.deleteMember(userId, projectId, memberId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.DELETE_MEMBER);
     }
 
     @Override
     @DeleteMapping("/me")
     public CommonResponse<?> leaveProject(@UserId Long userId, @PathVariable Long projectId) {
         projectMemberFacade.leaveProject(userId, projectId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.LEAVE_PROJECT);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlApi.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.project.dto.request.ProjectUrlRequest;
 import kr.flowmeet.api.project.dto.response.ProjectUrlResponse;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 
@@ -16,18 +18,30 @@ import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 public interface ProjectUrlApi {
 
     @Operation(summary = "URL 추가")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "ADD_URL")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED"})
-    CommonResponse<ProjectUrlResponse> addUrl(@UserId Long userId, @PathVariable Long projectId,
-                                              @Valid @RequestBody ProjectUrlRequest request);
+    CommonResponse<ProjectUrlResponse> addUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody ProjectUrlRequest request
+    );
 
     @Operation(summary = "URL 수정")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "UPDATE_URL")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED", "PROJECT_URL_NOT_FOUND"})
-    CommonResponse<ProjectUrlResponse> updateUrl(@UserId Long userId, @PathVariable Long projectId,
-                                                 @PathVariable Long urlId,
-                                                 @Valid @RequestBody ProjectUrlRequest request);
+    CommonResponse<ProjectUrlResponse> updateUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long urlId,
+            @Valid @RequestBody ProjectUrlRequest request
+    );
 
     @Operation(summary = "URL 삭제")
+    @ApiSuccessCode(code = ProjectSuccessCode.class, name = "DELETE_URL")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED", "PROJECT_URL_NOT_FOUND"})
-    CommonResponse<?> deleteUrl(@UserId Long userId, @PathVariable Long projectId,
-                                @PathVariable Long urlId);
+    CommonResponse<?> deleteUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long urlId
+    );
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/controller/ProjectUrlController.java
@@ -13,6 +13,7 @@ import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.project.dto.request.ProjectUrlRequest;
 import kr.flowmeet.api.project.facade.ProjectUrlFacade;
 import kr.flowmeet.api.project.dto.response.ProjectUrlResponse;
+import kr.flowmeet.api.project.success.ProjectSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -24,24 +25,36 @@ public class ProjectUrlController implements ProjectUrlApi {
 
     @Override
     @PostMapping
-    public CommonResponse<ProjectUrlResponse> addUrl(@UserId Long userId, @PathVariable Long projectId,
-                                                     @Valid @RequestBody ProjectUrlRequest request) {
-        return CommonResponse.ok(projectUrlFacade.addUrl(userId, projectId, request));
+    public CommonResponse<ProjectUrlResponse> addUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody ProjectUrlRequest request
+    ) {
+        return CommonResponse.ok(ProjectSuccessCode.ADD_URL, projectUrlFacade.addUrl(userId, projectId, request));
     }
 
     @Override
     @PatchMapping("/{urlId}")
-    public CommonResponse<ProjectUrlResponse> updateUrl(@UserId Long userId, @PathVariable Long projectId,
-                                                        @PathVariable Long urlId,
-                                                        @Valid @RequestBody ProjectUrlRequest request) {
-        return CommonResponse.ok(projectUrlFacade.updateUrl(userId, projectId, urlId, request));
+    public CommonResponse<ProjectUrlResponse> updateUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long urlId,
+            @Valid @RequestBody ProjectUrlRequest request
+    ) {
+        return CommonResponse.ok(
+                ProjectSuccessCode.UPDATE_URL,
+                projectUrlFacade.updateUrl(userId, projectId, urlId, request)
+        );
     }
 
     @Override
     @DeleteMapping("/{urlId}")
-    public CommonResponse<?> deleteUrl(@UserId Long userId, @PathVariable Long projectId,
-                                       @PathVariable Long urlId) {
+    public CommonResponse<?> deleteUrl(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long urlId
+    ) {
         projectUrlFacade.deleteUrl(userId, projectId, urlId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(ProjectSuccessCode.DELETE_URL);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/success/ProjectSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/success/ProjectSuccessCode.java
@@ -1,0 +1,27 @@
+package kr.flowmeet.api.project.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProjectSuccessCode implements SuccessCode {
+    CREATE_PROJECT("프로젝트를 생성했어요."),
+    GET_ALL_PROJECTS("프로젝트 목록을 조회했어요."),
+    GET_PROJECT("프로젝트를 조회했어요."),
+    UPDATE_PROJECT("프로젝트를 수정했어요."),
+    UPDATE_PROFILE_IMAGE("프로젝트 이미지를 변경했어요."),
+    DELETE_PROJECT("프로젝트를 삭제했어요."),
+    INVITE_MEMBER("멤버 초대 메일을 전송했어요."),
+    ACCEPT_INVITATION("프로젝트에 합류했어요."),
+    GET_ALL_MEMBERS("멤버 목록을 조회했어요."),
+    UPDATE_MEMBER_ROLE("멤버 권한을 변경했어요."),
+    DELETE_MEMBER("멤버를 삭제했어요."),
+    LEAVE_PROJECT("프로젝트에서 나갔어요."),
+    ADD_URL("URL을 추가했어요."),
+    UPDATE_URL("URL을 수정했어요."),
+    DELETE_URL("URL을 삭제했어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/test/TestController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/test/TestController.java
@@ -28,4 +28,14 @@ public class TestController {
         String token = jwtProvider.generateToken(user.getId(), user.getEmail(), user.getNickname());
         return CommonResponse.ok(token);
     }
+
+    @GetMapping("/token/template")
+    public CommonResponse<String> issueToken(
+            @RequestParam Long userId,
+            @RequestParam String email,
+            @RequestParam String nickname
+    ) {
+        String token = jwtProvider.generateToken(userId, email, nickname);
+        return CommonResponse.ok(token);
+    }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
+import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
+import kr.flowmeet.api.user.success.UserSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.user.exception.UserErrorCode;
@@ -18,17 +20,21 @@ import kr.flowmeet.domain.user.exception.UserErrorCode;
 public interface UserApi {
 
     @Operation(summary = "내 정보 조회")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "GET_ME")
     CommonResponse<GetUserResponse> getMe(@UserId Long userId);
 
     @Operation(summary = "내 정보 수정")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "UPDATE_ME")
     @ApiErrorCode(code = UserErrorCode.class, names = {"USER_NICKNAME_DUPLICATED"})
     CommonResponse<UpdateUserResponse> updateMe(@UserId Long userId, @Valid @RequestBody UpdateUserRequest request);
 
     @Operation(summary = "프로필 이미지 변경", description = "png, jpeg, webp만 허용 (최대 5MB)")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "UPDATE_PROFILE_IMAGE")
     @ApiErrorCode(code = FileErrorCode.class, names = {"FILE_SIZE_EXCEEDED", "FILE_INVALID_TYPE"})
     CommonResponse<?> updateProfileImage(@UserId Long userId, MultipartFile profileImage);
 
     @Operation(summary = "회원 탈퇴", description = "소유 중인 프로젝트가 있으면 탈퇴할 수 없습니다.")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "DELETE_ME")
     @ApiErrorCode(code = UserErrorCode.class, names = {"USER_IS_PROJECT_OWNER"})
     CommonResponse<?> deleteMe(@UserId Long userId);
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserController.java
@@ -16,6 +16,7 @@ import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
+import kr.flowmeet.api.user.success.UserSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 
 @RestController
@@ -28,27 +29,29 @@ public class UserController implements UserApi {
     @Override
     @GetMapping("/me")
     public CommonResponse<GetUserResponse> getMe(@UserId Long userId) {
-        return CommonResponse.ok(userFacade.getMe(userId));
+        return CommonResponse.ok(UserSuccessCode.GET_ME, userFacade.getMe(userId));
     }
 
     @Override
     @PatchMapping("/me")
     public CommonResponse<UpdateUserResponse> updateMe(@UserId Long userId, @Valid @RequestBody UpdateUserRequest request) {
-        return CommonResponse.ok(userFacade.updateMe(userId, request));
+        return CommonResponse.ok(UserSuccessCode.UPDATE_ME, userFacade.updateMe(userId, request));
     }
 
     @Override
     @PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public CommonResponse<?> updateProfileImage(@UserId Long userId,
-                                                @RequestPart MultipartFile profileImage) {
+    public CommonResponse<?> updateProfileImage(
+            @UserId Long userId,
+            @RequestPart MultipartFile profileImage
+    ) {
         userFacade.updateProfileImage(userId, profileImage);
-        return CommonResponse.ok();
+        return CommonResponse.ok(UserSuccessCode.UPDATE_PROFILE_IMAGE);
     }
 
     @Override
     @DeleteMapping("/me")
     public CommonResponse<?> deleteMe(@UserId Long userId) {
         userFacade.deleteMe(userId);
-        return CommonResponse.ok();
+        return CommonResponse.ok(UserSuccessCode.DELETE_ME);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/success/UserSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/success/UserSuccessCode.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.api.user.success;
+
+import kr.flowmeet.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+    GET_ME("내 정보를 조회했어요."),
+    UPDATE_ME("내 정보를 수정했어요."),
+    UPDATE_PROFILE_IMAGE("프로필 이미지를 변경했어요."),
+    DELETE_ME("회원 탈퇴가 완료됐어요.");
+
+    private final String message;
+}

--- a/backend/flowmeet-common/src/main/java/kr/flowmeet/common/response/SuccessCode.java
+++ b/backend/flowmeet-common/src/main/java/kr/flowmeet/common/response/SuccessCode.java
@@ -1,0 +1,6 @@
+package kr.flowmeet.common.response;
+
+public interface SuccessCode {
+    String getMessage();
+    String name();
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #76

## 📝작업 내용

성공 응답마다 다른 메시지를 내려줄 수 있도록 `SuccessCode` 체계를 도입했습니다. 기존 `ErrorCode` 인프라(인터페이스 + 도메인별 enum + Swagger 문서화 어노테이션)를 그대로 미러링해서, 학습 비용 없이 동일한 패턴으로 사용할 수 있도록 구성했습니다. 모든 컨트롤러 엔드포인트에 도메인별 `SuccessCode`를 적용했고, 컨벤션에서 어긋나 있던 한 곳의 응답 상태코드(201)도 200으로 정리했습니다.

### 1. SuccessCode 인프라 추가 (`feat`)

#### 1-1. `SuccessCode` 인터페이스 (`flowmeet-common`)

```java
public interface SuccessCode {
    String getMessage();
    String name();
}
```

- 성공 응답은 항상 HTTP 200으로 통일하므로 `httpStatus`는 두지 않음 (`ErrorCode`와의 차이점)
- 비즈니스 의미 구분은 `code` / `message` 필드로만 표현

#### 1-2. `CommonResponse.ok` 오버로드 추가

```java
public static CommonResponse<?> ok(final SuccessCode successCode);
public static <T> CommonResponse<T> ok(final SuccessCode successCode, final T data);
```

- 기존 `ok()` / `ok(data)` 시그니처는 호환을 위해 유지
- `status`는 항상 `HttpStatus.OK.value()`, `code` / `message`만 SuccessCode에서 가져옴

#### 1-3. `@ApiSuccessCode` 어노테이션 + `OperationCustomizer` (Swagger 자동 문서화)

`ApiErrorCode` 패턴과 동일하게, 메서드에 어노테이션을 달면 OpenAPI 200 응답 슬롯의 example을 해당 SuccessCode 메시지로 덮어씁니다.

```java
@ApiSuccessCode(code = UserSuccessCode.class, name = "UPDATE_ME")
CommonResponse<UpdateUserResponse> updateMe(...);
```

- `ApiSuccessCodeOperationCustomizer`를 `SwaggerConfig`에 Bean 등록
- springdoc이 만든 200 응답 슬롯이 다른 키(`default` 등)로 존재해도 200으로 재매핑
- `data` 필드 schema는 컨트롤러 리턴 타입에서 추론되도록 두고, example의 `status` / `code` / `message`만 주입

### 2. 모든 컨트롤러에 SuccessCode 적용 (`refactor`)

#### 2-1. 도메인별 `SuccessCode` enum 추가

`ErrorCode`가 도메인 단위로 묶여있는 구조를 따라 동일하게 묶었습니다. 위치는 `kr.flowmeet.api.{domain}.success`.

| 도메인 | enum | 항목 수 |
| --- | --- | --- |
| File | `FileSuccessCode` | 3 |
| Node | `NodeSuccessCode` | 9 |
| Node | `EdgeSuccessCode` | 2 |
| Node | `NodeAssigneeSuccessCode` | 2 |
| Node | `TagSuccessCode` | 6 |
| Notification | `NotificationSuccessCode` | 6 (Setting 포함) |
| Project | `ProjectSuccessCode` | 15 (Member, Url 포함) |
| User | `UserSuccessCode` | 4 |

#### 2-2. 컨트롤러 / Api 인터페이스 일괄 적용

13개 Api 인터페이스 + 13개 Controller의 모든 엔드포인트에 적용했습니다.

- API 인터페이스: 메서드마다 `@ApiSuccessCode(code = XxxSuccessCode.class, name = "...")` 추가
- Controller: `CommonResponse.ok(data)` / `CommonResponse.ok()` 호출을 `CommonResponse.ok(SuccessCode, data)` / `CommonResponse.ok(SuccessCode)`로 교체
- `@Profile("local")`인 `TestController`는 의도적으로 제외

### 3. 담당자 추가 응답 HTTP status 200으로 통일 (`refactor`)

`NodeAssigneeController.createAssignee`에 남아있던 `@ResponseStatus(HttpStatus.CREATED)`와 미사용 `HttpStatus` / `ResponseStatus` import를 제거했습니다.

- 변경 전: HTTP 201 + body `{ "status": 200, ... }` (HTTP status와 body status 불일치)
- 변경 후: HTTP 200 + body `{ "status": 200, ... }`

성공 응답은 항상 200으로 응답하고, 비즈니스 의미는 `code` / `message`로 표현하는 컨벤션을 전 도메인에 일관되게 적용했습니다.

## 💬리뷰 요구사항(선택)

- API 스펙(엔드포인트, request/response body 구조)은 변경 없습니다. 기존 응답에서 `code`와 `message` 값만 엔드포인트별로 달라집니다.
- `NodeAssigneeController.createAssignee`만 HTTP status가 201 → 200으로 바뀌었습니다. 프론트에서 201을 명시적으로 분기하고 있다면 영향이 있을 수 있습니다.
- 향후 새 엔드포인트 추가 시: 도메인 `SuccessCode` enum에 항목 추가 → API 인터페이스에 `@ApiSuccessCode` → Controller에서 `CommonResponse.ok(SuccessCode, ...)` 호출 순서로 적용하면 됩니다.

