### PR TITLE
[Feat/#73] API 세팅

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // output: 'export', // 이 설정이 핵심입니다.
+  // trailingSlash: true, // 경로 끝에 /를 붙여 정적 파일 구조 최적화
 };
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.20",
     "framer-motion": "^12.38.0",
+    "js-cookie": "^3.0.5",
     "next": "16.1.6",
     "pretendard": "^1.3.9",
     "react": "19.2.3",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-unused-imports": "^4.4.1",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
+    "swagger-typescript-api": "^13.6.10",
     "tailwindcss": "^4",
     "typescript": "^5",
     "wait-on": "^9.0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "dev:desktop": "wait-on http://localhost:3000 && cross-env NODE_ENV=development electron .",
     "dev:electron": "concurrently -k \"pnpm dev\" \"pnpm dev:desktop\"",
-    "lint": "eslint"
+    "lint": "eslint",
+    "api:gen": "dotenv -- sh -c 'npx swagger-typescript-api generate -p $SWAGGER_URL -o ./src/api --httpClientType fetch --module-name-first-tag'"
   },
   "dependencies": {
     "@tiptap/extension-collaboration": "^3.20.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      js-cookie:
+        specifier: ^3.0.5
+        version: 3.0.5
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -66,6 +69,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
+      '@types/js-cookie':
+        specifier: ^3.0.6
+        version: 3.0.6
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -1238,6 +1244,9 @@ packages:
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/js-cookie@3.0.6':
+    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2507,6 +2516,10 @@ packages:
   joi@18.0.2:
     resolution: {integrity: sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==}
     engines: {node: '>= 20'}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4800,6 +4813,8 @@ snapshots:
 
   '@types/http-cache-semantics@4.2.0': {}
 
+  '@types/js-cookie@3.0.6': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -6275,6 +6290,8 @@ snapshots:
       '@hapi/tlds': 1.1.6
       '@hapi/topo': 6.0.2
       '@standard-schema/spec': 1.1.0
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(prettier@3.8.1)
+      swagger-typescript-api:
+        specifier: ^13.6.10
+        version: 13.6.10(react@19.2.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -126,6 +129,22 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -197,6 +216,23 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/js-api@4.0.0':
+    resolution: {integrity: sha512-EOArR/6drRzM1/hwOIz1pZw90FL31Ud4Y7hEHGWVtMNmAwS9SrwZ8hMENGlLVXCeGW/kL46p8kX7eO6x9Nmezg==}
+    peerDependencies:
+      '@biomejs/wasm-bundler': ^2.3.0
+      '@biomejs/wasm-nodejs': ^2.3.0
+      '@biomejs/wasm-web': ^2.3.0
+    peerDependenciesMeta:
+      '@biomejs/wasm-bundler':
+        optional: true
+      '@biomejs/wasm-nodejs':
+        optional: true
+      '@biomejs/wasm-web':
+        optional: true
+
+  '@biomejs/wasm-nodejs@2.4.12':
+    resolution: {integrity: sha512-3SGczq2LKHJw9TYhJEmNwgBY767wSu+nRZVkp+oDiczYn2u7Xekb4smn/r3KJpaxGKkxxtTV4h6RTwBUKzf8Fw==}
 
   '@electron/get@2.0.3':
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
@@ -300,6 +336,9 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/schemasafe@1.3.0':
+    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1238,6 +1277,12 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/swagger-schema-official@2.0.25':
+    resolution: {integrity: sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -1473,8 +1518,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1594,6 +1650,14 @@ packages:
   buffer-from@0.1.2:
     resolution: {integrity: sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==}
 
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
@@ -1614,6 +1678,9 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1624,6 +1691,16 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -1657,6 +1734,13 @@ packages:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
     engines: {node: '>=18'}
     hasBin: true
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -1740,9 +1824,15 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1757,6 +1847,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
@@ -1845,8 +1938,14 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.0:
+    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2005,6 +2104,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eta@3.5.0:
+    resolution: {integrity: sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==}
+    engines: {node: '>=6.0.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -2029,6 +2135,12 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2147,6 +2259,10 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  giget@3.2.0:
+    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2224,6 +2340,9 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http2-client@1.3.5:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -2409,6 +2528,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2620,6 +2742,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2659,12 +2786,44 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  node-fetch-h2@2.3.0:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
+    engines: {node: 4.x || >=6.0.0}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-readfiles@0.2.0:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
+
+  oas-kit-common@1.0.8:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
+
+  oas-linter@3.2.2:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==}
+
+  oas-resolver@2.5.6:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
+    hasBin: true
+
+  oas-schema-walker@1.1.5:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==}
+
+  oas-validator@5.0.8:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2705,8 +2864,14 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2754,8 +2919,14 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2767,6 +2938,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2940,6 +3114,9 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -2988,9 +3165,16 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  reftools@1.1.9:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2998,6 +3182,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-alpn@1.2.1:
@@ -3101,6 +3289,24 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  should-equal@2.0.0:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
+
+  should-format@3.0.3:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==}
+
+  should-type-adaptors@1.1.0:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==}
+
+  should-type@1.4.0:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==}
+
+  should-util@1.0.1:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==}
+
+  should@13.2.3:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -3213,12 +3419,28 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-schema-official@2.0.0-bab6bed:
+    resolution: {integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==}
+
+  swagger-typescript-api@13.6.10:
+    resolution: {integrity: sha512-X+DenKK2txtI0LdNcpmWddcZWiWaf6erIZ+m9Wz7vk/yMFmPJ9EljSuX+dnJQ9YuzjV1imaRCDKsHA4CG2wUZA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  swagger2openapi@7.0.8:
+    resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
+    hasBin: true
+
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -3244,6 +3466,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3267,6 +3492,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3293,6 +3522,11 @@ packages:
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3360,6 +3594,12 @@ packages:
     resolution: {integrity: sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3430,6 +3670,11 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3448,6 +3693,17 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yummies@7.18.0:
+    resolution: {integrity: sha512-fgldINrxPi20XJjIa1LOniyqHROm5HwDmmq0VZtQml4u3cMerm8H7H2BM8kMhHilgd8l7rg3mN4xt2apc2l/xA==}
+    peerDependencies:
+      mobx: ^6.12.4
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      mobx:
+        optional: true
+      react:
+        optional: true
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -3479,6 +3735,25 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3582,6 +3857,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/js-api@4.0.0(@biomejs/wasm-nodejs@2.4.12)':
+    optionalDependencies:
+      '@biomejs/wasm-nodejs': 2.4.12
+
+  '@biomejs/wasm-nodejs@2.4.12': {}
 
   '@electron/get@2.0.3':
     dependencies:
@@ -3743,6 +4024,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/schemasafe@1.3.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4557,6 +4840,11 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
+  '@types/swagger-schema-official@2.0.25': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/yauzl@2.10.3':
@@ -4802,12 +5090,23 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -4954,6 +5253,21 @@ snapshots:
   buffer-from@0.1.2:
     optional: true
 
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.2.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 3.0.1
+
   cacheable-lookup@5.0.4: {}
 
   cacheable-request@7.0.4:
@@ -4983,6 +5297,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  call-me-maybe@1.0.2: {}
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001780: {}
@@ -4991,6 +5307,16 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  citty@0.2.2: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   client-only@0.0.1: {}
 
@@ -5026,6 +5352,10 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@1.9.0:
     optional: true
@@ -5109,7 +5439,11 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.7: {}
+
   delayed-stream@1.0.0: {}
+
+  destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
 
@@ -5121,6 +5455,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-cli@11.0.0:
     dependencies:
@@ -5282,8 +5620,12 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.46.0: {}
+
   es6-error@4.1.1:
     optional: true
+
+  es6-promise@3.3.1: {}
 
   escalade@3.2.0: {}
 
@@ -5513,6 +5855,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eta@3.5.0: {}
+
+  exsolve@1.0.8: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -5540,6 +5886,10 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5658,6 +6008,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  giget@3.2.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -5746,6 +6098,8 @@ snapshots:
     optional: true
 
   http-cache-semantics@4.2.0: {}
+
+  http2-client@1.3.5: {}
 
   http2-wrapper@1.0.3:
     dependencies:
@@ -5937,6 +6291,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1:
@@ -6119,6 +6475,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.9: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -6159,9 +6517,52 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch-h2@2.3.0:
+    dependencies:
+      http2-client: 1.3.5
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-readfiles@0.2.0:
+    dependencies:
+      es6-promise: 3.3.1
+
   node-releases@2.0.36: {}
 
   normalize-url@6.1.0: {}
+
+  oas-kit-common@1.0.8:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+
+  oas-linter@3.2.2:
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.3
+
+  oas-resolver@2.5.6:
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.7.2
+
+  oas-schema-walker@1.1.5: {}
+
+  oas-validator@5.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.3
 
   object-assign@4.1.1: {}
 
@@ -6210,9 +6611,13 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  ohash@2.0.11: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -6262,13 +6667,23 @@ snapshots:
   path-type@4.0.0:
     optional: true
 
+  pathe@2.0.3: {}
+
   pend@1.2.0: {}
+
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
 
@@ -6427,6 +6842,11 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -6482,6 +6902,8 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
+  readdirp@5.0.0: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -6493,6 +6915,8 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  reftools@1.1.9: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -6503,6 +6927,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -6649,6 +7075,32 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  should-equal@2.0.0:
+    dependencies:
+      should-type: 1.4.0
+
+  should-format@3.0.3:
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+
+  should-type-adaptors@1.1.0:
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+
+  should-type@1.4.0: {}
+
+  should-util@1.0.1: {}
+
+  should@13.2.3:
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -6790,11 +7242,58 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-schema-official@2.0.0-bab6bed: {}
+
+  swagger-typescript-api@13.6.10(react@19.2.3):
+    dependencies:
+      '@apidevtools/swagger-parser': 12.1.0(openapi-types@12.1.3)
+      '@biomejs/js-api': 4.0.0(@biomejs/wasm-nodejs@2.4.12)
+      '@biomejs/wasm-nodejs': 2.4.12
+      '@types/swagger-schema-official': 2.0.25
+      c12: 3.3.4
+      citty: 0.2.2
+      consola: 3.4.2
+      es-toolkit: 1.46.0
+      eta: 3.5.0
+      nanoid: 5.1.9
+      openapi-types: 12.1.3
+      swagger-schema-official: 2.0.0-bab6bed
+      swagger2openapi: 7.0.8
+      type-fest: 5.6.0
+      typescript: 6.0.3
+      yaml: 2.8.3
+      yummies: 7.18.0(react@19.2.3)
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - encoding
+      - magicast
+      - mobx
+      - react
+
+  swagger2openapi@7.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
 
   tabbable@6.4.0: {}
+
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -6820,6 +7319,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
@@ -6841,6 +7342,10 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -6887,6 +7392,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -6970,6 +7477,13 @@ snapshots:
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7055,8 +7569,9 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@1.10.3:
-    optional: true
+  yaml@1.10.3: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 
@@ -7080,6 +7595,17 @@ snapshots:
       lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
+
+  yummies@7.18.0(react@19.2.3):
+    dependencies:
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      dayjs: 1.11.20
+      dompurify: 3.4.1
+      nanoid: 5.1.9
+      tailwind-merge: 3.5.0
+    optionalDependencies:
+      react: 19.2.3
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1,0 +1,3201 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+/** 프로젝트 생성 요청 */
+export interface CreateProjectRequest {
+  /**
+   * 프로젝트 이름
+   * @minLength 1
+   * @example "FlowMeet 리뉴얼"
+   */
+  name: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCreateProjectResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CreateProjectResponse;
+}
+
+/** 프로젝트 생성 응답 */
+export interface CreateProjectResponse {
+  /**
+   * 생성된 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  createdAt?: string;
+}
+
+/** 프로젝트 URL 등록/수정 요청 */
+export interface ProjectUrlRequest {
+  /**
+   * 프로젝트에 연결할 URL
+   * @minLength 1
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseProjectUrlResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: ProjectUrlResponse;
+}
+
+/** 프로젝트 URL 응답 */
+export interface ProjectUrlResponse {
+  /**
+   * URL ID
+   * @format int64
+   * @example 3
+   */
+  urlId?: number;
+  /**
+   * URL 값
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url?: string;
+}
+
+/** 태그 생성 요청 */
+export interface CreateTagRequest {
+  /**
+   * 태그 이름
+   * @minLength 1
+   * @example "긴급"
+   */
+  name: string;
+  /**
+   * 태그 색상
+   * @example "RED"
+   */
+  color:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseObject {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: any;
+}
+
+/** 노드 생성 요청 */
+export interface CreateNodeRequest {
+  /**
+   * 노드 제목
+   * @minLength 1
+   * @example "로그인 화면 기획"
+   */
+  title: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 유형
+   * @example "MAIN"
+   */
+  type?: "MAIN" | "SUB";
+  /**
+   * 상위 노드 ID (루트인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+}
+
+/** 노드 태그 추가 요청 */
+export interface AddNodeTagRequest {
+  /**
+   * 추가할 태그 ID
+   * @format int64
+   * @example 5
+   */
+  tagId: number;
+}
+
+/** 노드 담당자 지정 요청 */
+export interface CreateAssigneeRequest {
+  /**
+   * 담당자로 지정할 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId: number;
+}
+
+/** 프로젝트 멤버 초대 요청 */
+export interface InviteProjectMemberRequest {
+  /**
+   * 초대할 사용자 이메일
+   * @format email
+   * @minLength 1
+   * @example "teammate@flowmeet.kr"
+   */
+  email: string;
+}
+
+/** 노드 간 엣지 생성 요청 */
+export interface CreateEdgeRequest {
+  /**
+   * 엣지의 시작 노드 ID
+   * @format int64
+   * @example 101
+   */
+  startNodeId: number;
+  /**
+   * 엣지의 종료 노드 ID
+   * @format int64
+   * @example 102
+   */
+  endNodeId: number;
+  /**
+   * 엣지에 대한 설명
+   * @example "로그인 성공 시 대시보드로 이동"
+   */
+  comment?: string;
+}
+
+/** 프로젝트 초대 수락 요청 */
+export interface AcceptProjectInvitationRequest {
+  /**
+   * 초대 메일 링크에 포함된 JWT 토큰
+   * @minLength 1
+   */
+  token: string;
+}
+
+/** 프로젝트 초대 수락 응답 */
+export interface AcceptProjectInvitationResponse {
+  /**
+   * 수락한 프로젝트 ID
+   * @format int64
+   * @example 12
+   */
+  projectId?: number;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseAcceptProjectInvitationResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: AcceptProjectInvitationResponse;
+}
+
+/** 파일 업로드 완료 확인 요청 */
+export interface ConfirmFileUploadRequest {
+  /**
+   * Presigned URL 발급 시 받은 파일 키
+   * @minLength 1
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey: string;
+  /**
+   * 원본 파일 이름
+   * @minLength 1
+   * @example "meeting-notes.pdf"
+   */
+  fileName: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  fileSize?: number;
+  /**
+   * 파일 확장자
+   * @minLength 1
+   * @example "pdf"
+   */
+  extension: string;
+  /**
+   * 콘텐츠 타입(MIME)
+   * @minLength 1
+   * @example "application/pdf"
+   */
+  contentType: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseFileInformationResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: FileInformationResponse;
+}
+
+/** 파일 정보 응답 */
+export interface FileInformationResponse {
+  /**
+   * 파일 식별용 키
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey?: string;
+  /**
+   * 원본 파일 이름
+   * @example "meeting-notes.pdf"
+   */
+  name?: string;
+  /**
+   * 파일 확장자
+   * @example "pdf"
+   */
+  extension?: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  size?: number;
+  /**
+   * 파일이 속한 도메인 타입
+   * @example "NODE_ATTACHMENT"
+   */
+  domainType?:
+    | "USER_PROFILE"
+    | "PROJECT_IMAGE"
+    | "NODE_ATTACHMENT"
+    | "NODE_NOTE_IMAGE"
+    | "MEETING_SUMMARY"
+    | "CHAT_ATTACHMENT"
+    | "TEMP";
+  /**
+   * 파일이 속한 엔티티 ID
+   * @format int64
+   * @example 128
+   */
+  entityId?: number;
+  /**
+   * 접근 가능한 최종 URL
+   * @example "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf"
+   */
+  uploadUrl?: string;
+}
+
+/** S3 업로드용 Presigned URL 발급 요청 */
+export interface CreatePresignedUrlRequest {
+  /**
+   * 원본 파일 이름
+   * @minLength 1
+   * @example "meeting-notes.pdf"
+   */
+  fileName: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  fileSize?: number;
+  /**
+   * 콘텐츠 타입(MIME)
+   * @minLength 1
+   * @example "application/pdf"
+   */
+  contentType: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCreatePresignedUrlResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CreatePresignedUrlResponse;
+}
+
+/** Presigned URL 발급 응답 */
+export interface CreatePresignedUrlResponse {
+  /**
+   * 파일 식별용 키
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey?: string;
+  /**
+   * 업로드에 사용할 Presigned URL
+   * @example "https://flowmeet-bucket.s3.amazonaws.com/node/20260419/abc123-meeting-notes.pdf?X-Amz-Signature=..."
+   */
+  presignedUrl?: string;
+  /**
+   * 업로드 완료 후 접근 가능한 최종 URL
+   * @example "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf"
+   */
+  uploadUrl?: string;
+}
+
+/** 내 정보 수정 요청 */
+export interface UpdateUserRequest {
+  /**
+   * 닉네임(최대 20자)
+   * @minLength 0
+   * @maxLength 20
+   * @example "플로우민"
+   */
+  nickname: string;
+  /**
+   * 이메일
+   * @format email
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseUpdateUserResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: UpdateUserResponse;
+}
+
+/** 내 정보 수정 응답 */
+export interface UpdateUserResponse {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 프로젝트 수정 요청 */
+export interface UpdateProjectRequest {
+  /**
+   * 변경할 프로젝트 이름
+   * @minLength 1
+   * @example "FlowMeet v2"
+   */
+  name: string;
+}
+
+/** 태그 수정 요청 */
+export interface UpdateTagRequest {
+  /**
+   * 변경할 태그 이름
+   * @minLength 1
+   * @example "매우 긴급"
+   */
+  name: string;
+  /**
+   * 변경할 태그 색상
+   * @example "RED"
+   */
+  color:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 프로젝트 알림 설정 수정 요청 */
+export interface UpdateNotificationSettingRequest {
+  /**
+   * 회의 관련 알림 수신 여부
+   * @example true
+   */
+  meetingEnabled?: boolean;
+  /**
+   * 노드 관련 알림 수신 여부
+   * @example true
+   */
+  nodeEnabled?: boolean;
+  /**
+   * 데스크톱 푸시 알림 수신 여부
+   * @example false
+   */
+  desktopEnabled?: boolean;
+  /**
+   * 이메일 알림 수신 여부
+   * @example true
+   */
+  emailEnabled?: boolean;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNotificationSettingResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNotificationSettingResponse;
+}
+
+/** 프로젝트 알림 설정 조회 응답 */
+export interface GetNotificationSettingResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 회의 관련 알림 수신 여부
+   * @example true
+   */
+  meetingEnabled?: boolean;
+  /**
+   * 노드 관련 알림 수신 여부
+   * @example true
+   */
+  nodeEnabled?: boolean;
+  /**
+   * 데스크톱 푸시 알림 수신 여부
+   * @example false
+   */
+  desktopEnabled?: boolean;
+  /**
+   * 이메일 알림 수신 여부
+   * @example true
+   */
+  emailEnabled?: boolean;
+}
+
+/** 노드 수정 요청 (변경할 필드만 전달) */
+export interface UpdateNodeRequest {
+  /**
+   * 변경할 제목
+   * @example "로그인 화면 기획 (v2)"
+   */
+  title?: string;
+  /**
+   * 변경할 설명
+   * @example "OAuth2 로그인 플로우 정리 및 와이어프레임 첨부"
+   */
+  description?: string;
+  /**
+   * 변경할 노트 내용(마크다운)
+   * @example "## 로그인 시나리오
+   * - Google OAuth ..."
+   */
+  noteContent?: string;
+  /**
+   * 변경할 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 칸반 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+}
+
+/** 노드 상태 변경(드래그 앤 드롭) 요청 */
+export interface UpdateNodeStatusRequest {
+  /**
+   * 변경할 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 칸반 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder: number;
+}
+
+/** 프로젝트 멤버 권한 변경 요청 */
+export interface UpdateProjectMemberRoleRequest {
+  /**
+   * 변경할 권한
+   * @example "MEMBER"
+   */
+  role: "VIEWER" | "MEMBER" | "OWNER";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetUserResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetUserResponse;
+}
+
+/** 내 정보 조회 응답 */
+export interface GetUserResponse {
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+  /**
+   * 가입 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCursorSliceResponseProjectSummaryResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CursorSliceResponseProjectSummaryResponse;
+}
+
+/** 커서 기반 페이지 응답 */
+export interface CursorSliceResponseProjectSummaryResponse {
+  /** 조회된 데이터 목록 */
+  content?: ProjectSummaryResponse[];
+  /**
+   * 요청한 페이지 크기
+   * @format int32
+   * @example 20
+   */
+  size?: number;
+  /**
+   * 다음 페이지 존재 여부
+   * @example true
+   */
+  hasNext?: boolean;
+  /**
+   * 다음 페이지 조회용 커서 ID
+   * @format int64
+   * @example 42
+   */
+  nextCursorId?: number;
+  /**
+   * 다음 페이지 조회용 커서 값(정렬 기준 값)
+   * @example "2026-04-19T10:00:00"
+   */
+  nextCursorValue?: string;
+}
+
+/** 프로젝트 목록 요약 응답 */
+export interface ProjectSummaryResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 프로젝트 멤버 수
+   * @format int32
+   * @example 8
+   */
+  memberCount?: number;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetProjectResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetProjectResponse;
+}
+
+/** 프로젝트 상세 조회 응답 */
+export interface GetProjectResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 내 권한
+   * @example "OWNER"
+   */
+  myRole?: "VIEWER" | "MEMBER" | "OWNER";
+  /**
+   * 프로젝트 멤버 수
+   * @format int32
+   * @example 8
+   */
+  memberCount?: number;
+  /** 프로젝트에 등록된 URL 목록 */
+  urls?: UrlItem[];
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 프로젝트에 등록된 URL 항목 */
+export interface UrlItem {
+  /**
+   * URL ID
+   * @format int64
+   * @example 3
+   */
+  urlId?: number;
+  /**
+   * URL 값
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetAllTagsResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetAllTagsResponse;
+}
+
+/** 프로젝트 태그 전체 조회 응답 */
+export interface GetAllTagsResponse {
+  /** 태그 목록 */
+  tags?: TagItem[];
+}
+
+/** 태그 정보 */
+export interface TagItem {
+  /**
+   * 태그 ID
+   * @format int64
+   * @example 5
+   */
+  tagId?: number;
+  /**
+   * 태그 이름
+   * @example "긴급"
+   */
+  name?: string;
+  /**
+   * 태그 색상
+   * @example "RED"
+   */
+  color?:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseSearchNodeResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: SearchNodeResponse;
+}
+
+/** 검색된 노드 항목 */
+export interface SearchItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+}
+
+/** 노드 검색 응답 */
+export interface SearchNodeResponse {
+  /** 검색된 노드 목록 */
+  nodes?: SearchItem[];
+}
+
+/** 노드 담당자 정보 */
+export interface AssigneeItem {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetFlowchartResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetFlowchartResponse;
+}
+
+/** 엣지 생성자 정보 */
+export interface EdgeCreatorItem {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 노드 간 엣지 항목 */
+export interface EdgeItem {
+  /**
+   * 엣지 ID
+   * @format int64
+   * @example 9001
+   */
+  edgeId?: number;
+  /**
+   * 시작 노드 ID
+   * @format int64
+   * @example 101
+   */
+  startNodeId?: number;
+  /**
+   * 종료 노드 ID
+   * @format int64
+   * @example 102
+   */
+  endNodeId?: number;
+  /** 엣지를 생성한 사용자 정보 */
+  createdBy?: EdgeCreatorItem;
+  /**
+   * 엣지 설명
+   * @example "로그인 성공 시 대시보드로 이동"
+   */
+  comment?: string;
+}
+
+/** 플로우차트 조회 응답 (노드와 엣지) */
+export interface GetFlowchartResponse {
+  /** 노드 목록 */
+  nodes?: NodeItem[];
+  /** 노드 간 엣지 목록 */
+  edges?: EdgeItem[];
+}
+
+/** 플로우차트의 노드 항목 */
+export interface NodeItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 상위 노드 ID (메인인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /**
+   * 연결된 회의 존재 여부
+   * @example true
+   */
+  hasMeeting?: boolean;
+  /**
+   * 하위 노드 ID 목록
+   * @example [110,111]
+   */
+  childNodeIds?: number[];
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNodeResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNodeResponse;
+}
+
+/** 노드 상세 조회 응답 */
+export interface GetNodeResponse {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 상위 노드 ID (루트인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노트 내용(마크다운)
+   * @example "## 로그인 시나리오
+   * - Google OAuth ..."
+   */
+  noteContent?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /** 연결된 회의 정보 (없으면 null) */
+  meeting?: MeetingItem;
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 노드에 연결된 회의 정보 */
+export interface MeetingItem {
+  /**
+   * 회의 ID
+   * @format int64
+   * @example 57
+   */
+  meetingId?: number;
+  /**
+   * 회의 상태
+   * @example "SCHEDULED"
+   */
+  status?: string;
+  /**
+   * 회의 시작 시각
+   * @format date-time
+   * @example "2026-04-20T14:00:00"
+   */
+  startedAt?: string;
+  /**
+   * 회의 시작 푸시 알림 사용 여부
+   * @example true
+   */
+  isPushEnabled?: boolean;
+  /**
+   * 푸시 알림 예약 시각
+   * @format date-time
+   * @example "2026-04-20T13:50:00"
+   */
+  pushNotifyAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNodeListResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNodeListResponse;
+}
+
+/** 노드 목록 조회 응답 */
+export interface GetNodeListResponse {
+  /** 노드 목록 */
+  nodes?: NodeListItem[];
+}
+
+/** 노드 목록의 개별 항목 */
+export interface NodeListItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /**
+   * 연결된 회의 존재 여부
+   * @example true
+   */
+  hasMeeting?: boolean;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetKanbanResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetKanbanResponse;
+}
+
+/** 칸반 보드 조회 응답 (상태별 그룹핑) */
+export interface GetKanbanResponse {
+  /** 대기 상태의 노드 목록 */
+  waiting?: KanbanItem[];
+  /** 진행 중 상태의 노드 목록 */
+  inProgress?: KanbanItem[];
+  /** 완료 상태의 노드 목록 */
+  done?: KanbanItem[];
+}
+
+/** 칸반 보드의 개별 노드 카드 */
+export interface KanbanItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetAllProjectMembersResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetAllProjectMembersResponse;
+}
+
+/** 프로젝트 멤버 전체 조회 응답 */
+export interface GetAllProjectMembersResponse {
+  /** 프로젝트 멤버 목록 */
+  members?: ProjectMemberInfo[];
+}
+
+/** 프로젝트 멤버 정보 */
+export interface ProjectMemberInfo {
+  /**
+   * 프로젝트 멤버 ID
+   * @format int64
+   * @example 42
+   */
+  memberId?: number;
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+  /**
+   * 프로젝트 내 권한
+   * @example "MEMBER"
+   */
+  role?: "VIEWER" | "MEMBER" | "OWNER";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCursorSliceResponseNotificationSummaryResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CursorSliceResponseNotificationSummaryResponse;
+}
+
+/** 커서 기반 페이지 응답 */
+export interface CursorSliceResponseNotificationSummaryResponse {
+  /** 조회된 데이터 목록 */
+  content?: NotificationSummaryResponse[];
+  /**
+   * 요청한 페이지 크기
+   * @format int32
+   * @example 20
+   */
+  size?: number;
+  /**
+   * 다음 페이지 존재 여부
+   * @example true
+   */
+  hasNext?: boolean;
+  /**
+   * 다음 페이지 조회용 커서 ID
+   * @format int64
+   * @example 42
+   */
+  nextCursorId?: number;
+  /**
+   * 다음 페이지 조회용 커서 값(정렬 기준 값)
+   * @example "2026-04-19T10:00:00"
+   */
+  nextCursorValue?: string;
+}
+
+/** 알림 요약 응답 */
+export interface NotificationSummaryResponse {
+  /**
+   * 알림 ID
+   * @format int64
+   * @example 4821
+   */
+  notificationId?: number;
+  /**
+   * 알림 유형
+   * @example "MEETING_CREATED"
+   */
+  type?:
+    | "MEETING_CREATED"
+    | "MEETING_INVITE"
+    | "MEETING_REMINDER"
+    | "MEETING_ENDED"
+    | "MEMBER_INVITE"
+    | "NODE_ASSIGNED"
+    | "NODE_UPDATED";
+  /**
+   * 알림 제목
+   * @example "새 회의"
+   */
+  title?: string;
+  /**
+   * 알림 본문
+   * @example "FlowMeet 프로젝트에 새 회의가 만들어졌어요"
+   */
+  content?: string;
+  /**
+   * 관련 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 관련 프로젝트 이름
+   * @example "FlowMeet"
+   */
+  projectName?: string;
+  /**
+   * 관련 노드 ID
+   * @format int64
+   * @example 128
+   */
+  nodeId?: number;
+  /**
+   * 읽음 여부
+   * @example false
+   */
+  isRead?: boolean;
+  /**
+   * 알림 생성 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  createdAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetUnreadCountResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetUnreadCountResponse;
+}
+
+/** 읽지 않은 알림 개수 응답 */
+export interface GetUnreadCountResponse {
+  /**
+   * 읽지 않은 알림 개수
+   * @format int64
+   * @example 5
+   */
+  unreadCount?: number;
+}
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "https://api.flowmeet.kr";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+              ? JSON.stringify(property)
+              : `${property}`,
+        );
+        return formData;
+      }, new FormData());
+    },
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const responseToParse = responseFormat ? response.clone() : response;
+      const data = !responseFormat
+        ? r
+        : await responseToParse[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title FlowMeet API
+ * @version v1
+ * @baseUrl https://api.flowmeet.kr
+ *
+ * FlowMeet 프로젝트 관리 및 회의 지원 서비스 API
+ */
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  project = {
+    /**
+     * @description 검색어, 정렬(LATEST/NAME), 커서 기반 슬라이싱을 지원합니다. 첫 요청은 cursorId/cursorValue 생략, 이후 응답의 nextCursorId/nextCursorValue를 그대로 전달합니다.
+     *
+     * @tags Project
+     * @name GetAllProjects
+     * @summary 프로젝트 목록 조회
+     * @request GET:/v1/projects
+     * @secure
+     */
+    getAllProjects: (
+      query?: {
+        search?: string;
+        /** @default "LATEST" */
+        sort?: "LATEST" | "NAME";
+        /** @format int64 */
+        cursorId?: number;
+        cursorValue?: string;
+        /**
+         * @format int32
+         * @default 20
+         */
+        size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseCursorSliceResponseProjectSummaryResponse,
+        any
+      >({
+        path: `/v1/projects`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Project
+     * @name CreateProject
+     * @summary 프로젝트 생성
+     * @request POST:/v1/projects
+     * @secure
+     */
+    createProject: (data: CreateProjectRequest, params: RequestParams = {}) =>
+      this.request<CommonResponseCreateProjectResponse, any>({
+        path: `/v1/projects`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 초대받는 이메일로 초대 링크가 포함된 메일을 전송합니다.
+     *
+     * @tags Project
+     * @name InviteMember
+     * @summary 프로젝트 멤버 초대
+     * @request POST:/v1/projects/{projectId}/invite
+     * @secure
+     */
+    inviteMember: (
+      projectId: number,
+      data: InviteProjectMemberRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/invite`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 메일 링크의 JWT 토큰을 제출하면 해당 프로젝트에 VIEWER로 합류합니다.
+     *
+     * @tags Project
+     * @name AcceptInvitation
+     * @summary 프로젝트 초대 수락
+     * @request POST:/v1/projects/invitations/accept
+     * @secure
+     */
+    acceptInvitation: (
+      data: AcceptProjectInvitationRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseAcceptProjectInvitationResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/invitations/accept`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Project
+     * @name GetProject
+     * @summary 프로젝트 상세 조회
+     * @request GET:/v1/projects/{projectId}
+     * @secure
+     */
+    getProject: (projectId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseGetProjectResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description OWNER만 삭제할 수 있습니다.
+     *
+     * @tags Project
+     * @name DeleteProject
+     * @summary 프로젝트 삭제
+     * @request DELETE:/v1/projects/{projectId}
+     * @secure
+     */
+    deleteProject: (projectId: number, params: RequestParams = {}) =>
+      this.request<CommonResponseObject, any>({
+        path: `/v1/projects/${projectId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Project
+     * @name UpdateProject
+     * @summary 프로젝트 수정
+     * @request PATCH:/v1/projects/{projectId}
+     * @secure
+     */
+    updateProject: (
+      projectId: number,
+      data: UpdateProjectRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description png, jpeg, webp만 허용 (최대 5MB)
+     *
+     * @tags Project
+     * @name UpdateProfileImage1
+     * @summary 프로젝트 이미지 변경
+     * @request PATCH:/v1/projects/{projectId}/profile-image
+     * @secure
+     */
+    updateProfileImage1: (
+      projectId: number,
+      data: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/profile-image`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        ...params,
+      }),
+  };
+  projectUrl = {
+    /**
+     * No description
+     *
+     * @tags ProjectUrl
+     * @name AddUrl
+     * @summary URL 추가
+     * @request POST:/v1/projects/{projectId}/urls
+     * @secure
+     */
+    addUrl: (
+      projectId: number,
+      data: ProjectUrlRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseProjectUrlResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/urls`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags ProjectUrl
+     * @name DeleteUrl
+     * @summary URL 삭제
+     * @request DELETE:/v1/projects/{projectId}/urls/{urlId}
+     * @secure
+     */
+    deleteUrl: (projectId: number, urlId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/urls/${urlId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags ProjectUrl
+     * @name UpdateUrl
+     * @summary URL 수정
+     * @request PATCH:/v1/projects/{projectId}/urls/{urlId}
+     * @secure
+     */
+    updateUrl: (
+      projectId: number,
+      urlId: number,
+      data: ProjectUrlRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseProjectUrlResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/urls/${urlId}`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+  tag = {
+    /**
+     * @description 프로젝트의 전체 태그 목록을 조회합니다.
+     *
+     * @tags Tag
+     * @name GetAllTags
+     * @summary 태그 목록 조회
+     * @request GET:/v1/projects/{projectId}/tags
+     * @secure
+     */
+    getAllTags: (projectId: number, params: RequestParams = {}) =>
+      this.request<CommonResponseGetAllTagsResponse, any>({
+        path: `/v1/projects/${projectId}/tags`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 새 태그를 생성합니다.
+     *
+     * @tags Tag
+     * @name CreateTag
+     * @summary 태그 생성
+     * @request POST:/v1/projects/{projectId}/tags
+     * @secure
+     */
+    createTag: (
+      projectId: number,
+      data: CreateTagRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/tags`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 노드에 기존 태그를 연결합니다.
+     *
+     * @tags Tag
+     * @name AddNodeTag
+     * @summary 노드에 태그 추가
+     * @request POST:/v1/projects/{projectId}/nodes/{nodeId}/tags
+     * @secure
+     */
+    addNodeTag: (
+      projectId: number,
+      nodeId: number,
+      data: AddNodeTagRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}/tags`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 태그를 삭제합니다. 연결된 노드 태그도 함께 삭제됩니다.
+     *
+     * @tags Tag
+     * @name DeleteTag
+     * @summary 태그 삭제
+     * @request DELETE:/v1/projects/{projectId}/tags/{tagId}
+     * @secure
+     */
+    deleteTag: (projectId: number, tagId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/tags/${tagId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 태그 이름 또는 색상을 수정합니다.
+     *
+     * @tags Tag
+     * @name UpdateTag
+     * @summary 태그 수정
+     * @request PATCH:/v1/projects/{projectId}/tags/{tagId}
+     * @secure
+     */
+    updateTag: (
+      projectId: number,
+      tagId: number,
+      data: UpdateTagRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/tags/${tagId}`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 노드에서 태그 연결을 해제합니다.
+     *
+     * @tags Tag
+     * @name RemoveNodeTag
+     * @summary 노드에서 태그 제거
+     * @request DELETE:/v1/projects/{projectId}/nodes/{nodeId}/tags/{tagId}
+     * @secure
+     */
+    removeNodeTag: (
+      projectId: number,
+      nodeId: number,
+      tagId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<CommonResponseObject, any>({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}/tags/${tagId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+  };
+  node = {
+    /**
+     * @description 프로젝트의 전체 노드 트리 + 엣지를 조회합니다.
+     *
+     * @tags Node
+     * @name GetFlowchart
+     * @summary 플로우차트 조회
+     * @request GET:/v1/projects/{projectId}/nodes
+     * @secure
+     */
+    getFlowchart: (projectId: number, params: RequestParams = {}) =>
+      this.request<CommonResponseGetFlowchartResponse, any>({
+        path: `/v1/projects/${projectId}/nodes`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 메인 노드 또는 서브 노드를 추가합니다.
+     *
+     * @tags Node
+     * @name CreateNode
+     * @summary 노드 추가
+     * @request POST:/v1/projects/{projectId}/nodes
+     * @secure
+     */
+    createNode: (
+      projectId: number,
+      data: CreateNodeRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 노드 클릭 시 사이드바 상세 정보를 조회합니다.
+     *
+     * @tags Node
+     * @name GetNode
+     * @summary 노드 상세 조회
+     * @request GET:/v1/projects/{projectId}/nodes/{nodeId}
+     * @secure
+     */
+    getNode: (projectId: number, nodeId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseGetNodeResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 노드 삭제. 하위 서브 노드도 연쇄 삭제됩니다.
+     *
+     * @tags Node
+     * @name DeleteNode
+     * @summary 노드 삭제
+     * @request DELETE:/v1/projects/{projectId}/nodes/{nodeId}
+     * @secure
+     */
+    deleteNode: (
+      projectId: number,
+      nodeId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 노드 제목, 설명, 노트, 상태, 정렬순서를 수정합니다.
+     *
+     * @tags Node
+     * @name UpdateNode
+     * @summary 노드 수정
+     * @request PATCH:/v1/projects/{projectId}/nodes/{nodeId}
+     * @secure
+     */
+    updateNode: (
+      projectId: number,
+      nodeId: number,
+      data: UpdateNodeRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 드래그 & 드롭으로 상태와 순서를 변경합니다.
+     *
+     * @tags Node
+     * @name UpdateNodeStatus
+     * @summary 칸반 상태 변경
+     * @request PATCH:/v1/projects/{projectId}/nodes/{nodeId}/status
+     * @secure
+     */
+    updateNodeStatus: (
+      projectId: number,
+      nodeId: number,
+      data: UpdateNodeStatusRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}/status`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 노드 제목, 키워드로 검색합니다.
+     *
+     * @tags Node
+     * @name Search
+     * @summary 프로젝트 내 검색
+     * @request GET:/v1/projects/{projectId}/search
+     * @secure
+     */
+    search: (
+      projectId: number,
+      query: {
+        query: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<CommonResponseSearchNodeResponse, any>({
+        path: `/v1/projects/${projectId}/search`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 노드를 리스트 형태로 조회합니다.
+     *
+     * @tags Node
+     * @name GetNodeList
+     * @summary 리스트 뷰 조회
+     * @request GET:/v1/projects/{projectId}/nodes/list
+     * @secure
+     */
+    getNodeList: (
+      projectId: number,
+      query?: {
+        sort?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<CommonResponseGetNodeListResponse, any>({
+        path: `/v1/projects/${projectId}/nodes/list`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 상태별 그룹으로 노드를 조회합니다.
+     *
+     * @tags Node
+     * @name GetKanban
+     * @summary 칸반 보드 조회
+     * @request GET:/v1/projects/{projectId}/nodes/kanban
+     * @secure
+     */
+    getKanban: (projectId: number, params: RequestParams = {}) =>
+      this.request<CommonResponseGetKanbanResponse, any>({
+        path: `/v1/projects/${projectId}/nodes/kanban`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+  };
+  nodeAssignee = {
+    /**
+     * @description 노드에 담당자를 추가합니다.
+     *
+     * @tags NodeAssignee
+     * @name CreateAssignee
+     * @summary 담당자 추가
+     * @request POST:/v1/projects/{projectId}/nodes/{nodeId}/assignees
+     * @secure
+     */
+    createAssignee: (
+      projectId: number,
+      nodeId: number,
+      data: CreateAssigneeRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}/assignees`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 노드에서 담당자를 제거합니다.
+     *
+     * @tags NodeAssignee
+     * @name DeleteAssignee
+     * @summary 담당자 제거
+     * @request DELETE:/v1/projects/{projectId}/nodes/{nodeId}/assignees/{assigneeId}
+     * @secure
+     */
+    deleteAssignee: (
+      projectId: number,
+      nodeId: number,
+      assigneeId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/nodes/${nodeId}/assignees/${assigneeId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+  };
+  edge = {
+    /**
+     * @description 노드 간 연결선을 추가합니다.
+     *
+     * @tags Edge
+     * @name CreateEdge
+     * @summary 연결선 생성
+     * @request POST:/v1/projects/{projectId}/edges
+     * @secure
+     */
+    createEdge: (
+      projectId: number,
+      data: CreateEdgeRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/edges`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 연결선을 삭제합니다.
+     *
+     * @tags Edge
+     * @name DeleteEdge
+     * @summary 연결선 삭제
+     * @request DELETE:/v1/projects/{projectId}/edges/{edgeId}
+     * @secure
+     */
+    deleteEdge: (
+      projectId: number,
+      edgeId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/edges/${edgeId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+  };
+  file = {
+    /**
+     * @description 클라이언트의 S3 업로드 완료 후 파일 정보를 등록합니다.
+     *
+     * @tags File
+     * @name ConfirmUpload
+     * @summary 업로드 완료 등록
+     * @request POST:/v1/files
+     * @secure
+     */
+    confirmUpload: (
+      data: ConfirmFileUploadRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseFileInformationResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/files`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags File
+     * @name DeleteFile
+     * @summary 파일 삭제
+     * @request DELETE:/v1/files
+     * @secure
+     */
+    deleteFile: (
+      query: {
+        fileKey: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/files`,
+        method: "DELETE",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description S3 직접 업로드를 위한 Presigned URL을 발급합니다.
+     *
+     * @tags File
+     * @name CreatePresignedUrl
+     * @summary Presigned URL 발급
+     * @request POST:/v1/files/presigned-url
+     * @secure
+     */
+    createPresignedUrl: (
+      data: CreatePresignedUrlRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseCreatePresignedUrlResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/files/presigned-url`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+  user = {
+    /**
+     * No description
+     *
+     * @tags User
+     * @name GetMe
+     * @summary 내 정보 조회
+     * @request GET:/v1/users/me
+     * @secure
+     */
+    getMe: (params: RequestParams = {}) =>
+      this.request<CommonResponseGetUserResponse, any>({
+        path: `/v1/users/me`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 소유 중인 프로젝트가 있으면 탈퇴할 수 없습니다.
+     *
+     * @tags User
+     * @name DeleteMe
+     * @summary 회원 탈퇴
+     * @request DELETE:/v1/users/me
+     * @secure
+     */
+    deleteMe: (params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/users/me`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags User
+     * @name UpdateMe
+     * @summary 내 정보 수정
+     * @request PATCH:/v1/users/me
+     * @secure
+     */
+    updateMe: (data: UpdateUserRequest, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseUpdateUserResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/users/me`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description png, jpeg, webp만 허용 (최대 5MB)
+     *
+     * @tags User
+     * @name UpdateProfileImage
+     * @summary 프로필 이미지 변경
+     * @request PATCH:/v1/users/me/profile-image
+     * @secure
+     */
+    updateProfileImage: (data: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/users/me/profile-image`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        ...params,
+      }),
+  };
+  notificationSetting = {
+    /**
+     * No description
+     *
+     * @tags NotificationSetting
+     * @name GetNotificationSetting
+     * @summary 프로젝트별 알림 설정 조회
+     * @request GET:/v1/projects/{projectId}/notification-settings
+     * @secure
+     */
+    getNotificationSetting: (projectId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseGetNotificationSettingResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/notification-settings`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 변경할 필드만 전달합니다.
+     *
+     * @tags NotificationSetting
+     * @name UpdateNotificationSetting
+     * @summary 프로젝트별 알림 설정 수정
+     * @request PATCH:/v1/projects/{projectId}/notification-settings
+     * @secure
+     */
+    updateNotificationSetting: (
+      projectId: number,
+      data: UpdateNotificationSettingRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseGetNotificationSettingResponse,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/notification-settings`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+  projectMember = {
+    /**
+     * @description - OWNER 부여: OWNER 권한 필요 - OWNER 강등: 본인만 가능 - VIEWER ↔ MEMBER 변경: MEMBER 이상 가능
+     *
+     * @tags ProjectMember
+     * @name UpdateMemberRole
+     * @summary 멤버 권한 수정
+     * @request PATCH:/v1/projects/{projectId}/members/{memberId}/role
+     * @secure
+     */
+    updateMemberRole: (
+      projectId: number,
+      memberId: number,
+      data: UpdateProjectMemberRoleRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/members/${memberId}/role`,
+        method: "PATCH",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags ProjectMember
+     * @name GetAllMembers
+     * @summary 멤버 목록 조회
+     * @request GET:/v1/projects/{projectId}/members
+     * @secure
+     */
+    getAllMembers: (projectId: number, params: RequestParams = {}) =>
+      this.request<CommonResponseGetAllProjectMembersResponse, any>({
+        path: `/v1/projects/${projectId}/members`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description OWNER만 삭제할 수 있습니다.
+     *
+     * @tags ProjectMember
+     * @name DeleteMember
+     * @summary 멤버 삭제
+     * @request DELETE:/v1/projects/{projectId}/members/{memberId}
+     * @secure
+     */
+    deleteMember: (
+      projectId: number,
+      memberId: number,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/members/${memberId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags ProjectMember
+     * @name LeaveProject
+     * @summary 프로젝트 나가기
+     * @request DELETE:/v1/projects/{projectId}/members/me
+     * @secure
+     */
+    leaveProject: (projectId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/members/me`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+  };
+  notification = {
+    /**
+     * No description
+     *
+     * @tags Notification
+     * @name MarkAsRead
+     * @summary 알림 읽음 처리
+     * @request PATCH:/v1/notifications/{notificationId}/read
+     * @secure
+     */
+    markAsRead: (notificationId: number, params: RequestParams = {}) =>
+      this.request<
+        CommonResponseObject,
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/notifications/${notificationId}/read`,
+        method: "PATCH",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Notification
+     * @name MarkAllAsRead
+     * @summary 전체 알림 읽음 처리
+     * @request PATCH:/v1/notifications/all
+     * @secure
+     */
+    markAllAsRead: (params: RequestParams = {}) =>
+      this.request<CommonResponseObject, any>({
+        path: `/v1/notifications/all`,
+        method: "PATCH",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description isRead 필터와 커서 기반 슬라이싱을 지원합니다. 첫 요청은 cursorId 생략, 이후 응답의 nextCursorId를 그대로 전달합니다.
+     *
+     * @tags Notification
+     * @name GetAllNotifications
+     * @summary 알림 목록 조회
+     * @request GET:/v1/notifications
+     * @secure
+     */
+    getAllNotifications: (
+      query?: {
+        isRead?: boolean;
+        /** @format int64 */
+        cursorId?: number;
+        /**
+         * @format int32
+         * @default 20
+         */
+        size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        CommonResponseCursorSliceResponseNotificationSummaryResponse,
+        any
+      >({
+        path: `/v1/notifications`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Notification
+     * @name GetUnreadCount
+     * @summary 읽지 않은 알림 개수 조회
+     * @request GET:/v1/notifications/unread-count
+     * @secure
+     */
+    getUnreadCount: (params: RequestParams = {}) =>
+      this.request<CommonResponseGetUnreadCountResponse, any>({
+        path: `/v1/notifications/unread-count`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+  };
+}

--- a/frontend/src/api/authStorage.ts
+++ b/frontend/src/api/authStorage.ts
@@ -1,17 +1,73 @@
-// 토큰 확인 로직(로컬스토리지)
+// // 토큰 확인 로직(로컬스토리지)
+
+// const ACCESS_KEY = 'access_token';
+// const REFRESH_KEY = 'refresh_token';
+
+// // 브라우저 환경인지 확인하는 유틸리티 -> 서버 사이드 환경 대응
+const isBrowser = typeof window !== 'undefined';
+
+// export const authStorage = {
+//   getAccess: () => {
+//     if (!isBrowser) return null;
+//     return localStorage.getItem(ACCESS_KEY);
+//   },
+
+//   getRefresh: () => {
+//     if (!isBrowser) return null;
+//     return localStorage.getItem(REFRESH_KEY);
+//   },
+
+//   setTokens: (access: string, refresh: string) => {
+//     if (!isBrowser) return;
+//     localStorage.setItem(ACCESS_KEY, access);
+//     localStorage.setItem(REFRESH_KEY, refresh);
+//   },
+
+//   clear: () => {
+//     if (!isBrowser) return;
+//     localStorage.removeItem(ACCESS_KEY);
+//     localStorage.removeItem(REFRESH_KEY);
+//   },
+// };
+
+// 현재 서버 사이드 환경이 많아서 임시로 사용합니다. CSR로 전환할 시 위 코드를 사용하면 됩니다.
+import Cookies from 'js-cookie';
 
 const ACCESS_KEY = 'access_token';
 const REFRESH_KEY = 'refresh_token';
 
+// 쿠키 설정 (보안 및 경로 설정)
+const COOKIE_OPTIONS: Cookies.CookieAttributes = {
+  expires: 7, // 7일 동안 유지
+  path: '/',
+  secure: process.env.NODE_ENV === 'production', // 배포 환경에서만 HTTPS 적용
+  sameSite: 'lax',
+};
+
 export const authStorage = {
-  getAccess: () => localStorage.getItem(ACCESS_KEY),
-  getRefresh: () => localStorage.getItem(REFRESH_KEY),
+  getAccess: () =>
+    Cookies.get(ACCESS_KEY) ||
+    (typeof window !== 'undefined' ? localStorage.getItem(ACCESS_KEY) : null),
+
   setTokens: (access: string, refresh: string) => {
+    // 1. 로컬스토리지 저장
     localStorage.setItem(ACCESS_KEY, access);
     localStorage.setItem(REFRESH_KEY, refresh);
+
+    // 2. 쿠키 저장 (핵심!)
+    Cookies.set(ACCESS_KEY, access, COOKIE_OPTIONS);
+    Cookies.set(REFRESH_KEY, refresh, COOKIE_OPTIONS);
   },
+
+  getRefresh: () => {
+    if (!isBrowser) return null;
+    return localStorage.getItem(REFRESH_KEY);
+  },
+
   clear: () => {
     localStorage.removeItem(ACCESS_KEY);
     localStorage.removeItem(REFRESH_KEY);
+    Cookies.remove(ACCESS_KEY, { path: '/' });
+    Cookies.remove(REFRESH_KEY, { path: '/' });
   },
 };

--- a/frontend/src/api/authStorage.ts
+++ b/frontend/src/api/authStorage.ts
@@ -1,0 +1,17 @@
+// 토큰 확인 로직(로컬스토리지)
+
+const ACCESS_KEY = 'access_token';
+const REFRESH_KEY = 'refresh_token';
+
+export const authStorage = {
+  getAccess: () => localStorage.getItem(ACCESS_KEY),
+  getRefresh: () => localStorage.getItem(REFRESH_KEY),
+  setTokens: (access: string, refresh: string) => {
+    localStorage.setItem(ACCESS_KEY, access);
+    localStorage.setItem(REFRESH_KEY, refresh);
+  },
+  clear: () => {
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+  },
+};

--- a/frontend/src/api/data-contracts.ts
+++ b/frontend/src/api/data-contracts.ts
@@ -1,0 +1,1632 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+/** 프로젝트 생성 요청 */
+export interface CreateProjectRequest {
+  /**
+   * 프로젝트 이름
+   * @minLength 1
+   * @example "FlowMeet 리뉴얼"
+   */
+  name: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCreateProjectResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CreateProjectResponse;
+}
+
+/** 프로젝트 생성 응답 */
+export interface CreateProjectResponse {
+  /**
+   * 생성된 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  createdAt?: string;
+}
+
+/** 프로젝트 URL 등록/수정 요청 */
+export interface ProjectUrlRequest {
+  /**
+   * 프로젝트에 연결할 URL
+   * @minLength 1
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseProjectUrlResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: ProjectUrlResponse;
+}
+
+/** 프로젝트 URL 응답 */
+export interface ProjectUrlResponse {
+  /**
+   * URL ID
+   * @format int64
+   * @example 3
+   */
+  urlId?: number;
+  /**
+   * URL 값
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url?: string;
+}
+
+/** 태그 생성 요청 */
+export interface CreateTagRequest {
+  /**
+   * 태그 이름
+   * @minLength 1
+   * @example "긴급"
+   */
+  name: string;
+  /**
+   * 태그 색상
+   * @example "RED"
+   */
+  color:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseObject {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: any;
+}
+
+/** 노드 생성 요청 */
+export interface CreateNodeRequest {
+  /**
+   * 노드 제목
+   * @minLength 1
+   * @example "로그인 화면 기획"
+   */
+  title: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 유형
+   * @example "MAIN"
+   */
+  type?: "MAIN" | "SUB";
+  /**
+   * 상위 노드 ID (루트인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+}
+
+/** 노드 태그 추가 요청 */
+export interface AddNodeTagRequest {
+  /**
+   * 추가할 태그 ID
+   * @format int64
+   * @example 5
+   */
+  tagId: number;
+}
+
+/** 노드 담당자 지정 요청 */
+export interface CreateAssigneeRequest {
+  /**
+   * 담당자로 지정할 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId: number;
+}
+
+/** 프로젝트 멤버 초대 요청 */
+export interface InviteProjectMemberRequest {
+  /**
+   * 초대할 사용자 이메일
+   * @format email
+   * @minLength 1
+   * @example "teammate@flowmeet.kr"
+   */
+  email: string;
+}
+
+/** 노드 간 엣지 생성 요청 */
+export interface CreateEdgeRequest {
+  /**
+   * 엣지의 시작 노드 ID
+   * @format int64
+   * @example 101
+   */
+  startNodeId: number;
+  /**
+   * 엣지의 종료 노드 ID
+   * @format int64
+   * @example 102
+   */
+  endNodeId: number;
+  /**
+   * 엣지에 대한 설명
+   * @example "로그인 성공 시 대시보드로 이동"
+   */
+  comment?: string;
+}
+
+/** 프로젝트 초대 수락 요청 */
+export interface AcceptProjectInvitationRequest {
+  /**
+   * 초대 메일 링크에 포함된 JWT 토큰
+   * @minLength 1
+   */
+  token: string;
+}
+
+/** 프로젝트 초대 수락 응답 */
+export interface AcceptProjectInvitationResponse {
+  /**
+   * 수락한 프로젝트 ID
+   * @format int64
+   * @example 12
+   */
+  projectId?: number;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseAcceptProjectInvitationResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: AcceptProjectInvitationResponse;
+}
+
+/** 파일 업로드 완료 확인 요청 */
+export interface ConfirmFileUploadRequest {
+  /**
+   * Presigned URL 발급 시 받은 파일 키
+   * @minLength 1
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey: string;
+  /**
+   * 원본 파일 이름
+   * @minLength 1
+   * @example "meeting-notes.pdf"
+   */
+  fileName: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  fileSize?: number;
+  /**
+   * 파일 확장자
+   * @minLength 1
+   * @example "pdf"
+   */
+  extension: string;
+  /**
+   * 콘텐츠 타입(MIME)
+   * @minLength 1
+   * @example "application/pdf"
+   */
+  contentType: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseFileInformationResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: FileInformationResponse;
+}
+
+/** 파일 정보 응답 */
+export interface FileInformationResponse {
+  /**
+   * 파일 식별용 키
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey?: string;
+  /**
+   * 원본 파일 이름
+   * @example "meeting-notes.pdf"
+   */
+  name?: string;
+  /**
+   * 파일 확장자
+   * @example "pdf"
+   */
+  extension?: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  size?: number;
+  /**
+   * 파일이 속한 도메인 타입
+   * @example "NODE_ATTACHMENT"
+   */
+  domainType?:
+    | "USER_PROFILE"
+    | "PROJECT_IMAGE"
+    | "NODE_ATTACHMENT"
+    | "NODE_NOTE_IMAGE"
+    | "MEETING_SUMMARY"
+    | "CHAT_ATTACHMENT"
+    | "TEMP";
+  /**
+   * 파일이 속한 엔티티 ID
+   * @format int64
+   * @example 128
+   */
+  entityId?: number;
+  /**
+   * 접근 가능한 최종 URL
+   * @example "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf"
+   */
+  uploadUrl?: string;
+}
+
+/** S3 업로드용 Presigned URL 발급 요청 */
+export interface CreatePresignedUrlRequest {
+  /**
+   * 원본 파일 이름
+   * @minLength 1
+   * @example "meeting-notes.pdf"
+   */
+  fileName: string;
+  /**
+   * 파일 크기(바이트)
+   * @format int64
+   * @example 204800
+   */
+  fileSize?: number;
+  /**
+   * 콘텐츠 타입(MIME)
+   * @minLength 1
+   * @example "application/pdf"
+   */
+  contentType: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCreatePresignedUrlResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CreatePresignedUrlResponse;
+}
+
+/** Presigned URL 발급 응답 */
+export interface CreatePresignedUrlResponse {
+  /**
+   * 파일 식별용 키
+   * @example "node/20260419/abc123-meeting-notes.pdf"
+   */
+  fileKey?: string;
+  /**
+   * 업로드에 사용할 Presigned URL
+   * @example "https://flowmeet-bucket.s3.amazonaws.com/node/20260419/abc123-meeting-notes.pdf?X-Amz-Signature=..."
+   */
+  presignedUrl?: string;
+  /**
+   * 업로드 완료 후 접근 가능한 최종 URL
+   * @example "https://cdn.flowmeet.kr/node/20260419/abc123-meeting-notes.pdf"
+   */
+  uploadUrl?: string;
+}
+
+/** 내 정보 수정 요청 */
+export interface UpdateUserRequest {
+  /**
+   * 닉네임(최대 20자)
+   * @minLength 0
+   * @maxLength 20
+   * @example "플로우민"
+   */
+  nickname: string;
+  /**
+   * 이메일
+   * @format email
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseUpdateUserResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: UpdateUserResponse;
+}
+
+/** 내 정보 수정 응답 */
+export interface UpdateUserResponse {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 프로젝트 수정 요청 */
+export interface UpdateProjectRequest {
+  /**
+   * 변경할 프로젝트 이름
+   * @minLength 1
+   * @example "FlowMeet v2"
+   */
+  name: string;
+}
+
+/** 태그 수정 요청 */
+export interface UpdateTagRequest {
+  /**
+   * 변경할 태그 이름
+   * @minLength 1
+   * @example "매우 긴급"
+   */
+  name: string;
+  /**
+   * 변경할 태그 색상
+   * @example "RED"
+   */
+  color:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 프로젝트 알림 설정 수정 요청 */
+export interface UpdateNotificationSettingRequest {
+  /**
+   * 회의 관련 알림 수신 여부
+   * @example true
+   */
+  meetingEnabled?: boolean;
+  /**
+   * 노드 관련 알림 수신 여부
+   * @example true
+   */
+  nodeEnabled?: boolean;
+  /**
+   * 데스크톱 푸시 알림 수신 여부
+   * @example false
+   */
+  desktopEnabled?: boolean;
+  /**
+   * 이메일 알림 수신 여부
+   * @example true
+   */
+  emailEnabled?: boolean;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNotificationSettingResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNotificationSettingResponse;
+}
+
+/** 프로젝트 알림 설정 조회 응답 */
+export interface GetNotificationSettingResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 회의 관련 알림 수신 여부
+   * @example true
+   */
+  meetingEnabled?: boolean;
+  /**
+   * 노드 관련 알림 수신 여부
+   * @example true
+   */
+  nodeEnabled?: boolean;
+  /**
+   * 데스크톱 푸시 알림 수신 여부
+   * @example false
+   */
+  desktopEnabled?: boolean;
+  /**
+   * 이메일 알림 수신 여부
+   * @example true
+   */
+  emailEnabled?: boolean;
+}
+
+/** 노드 수정 요청 (변경할 필드만 전달) */
+export interface UpdateNodeRequest {
+  /**
+   * 변경할 제목
+   * @example "로그인 화면 기획 (v2)"
+   */
+  title?: string;
+  /**
+   * 변경할 설명
+   * @example "OAuth2 로그인 플로우 정리 및 와이어프레임 첨부"
+   */
+  description?: string;
+  /**
+   * 변경할 노트 내용(마크다운)
+   * @example "## 로그인 시나리오
+   * - Google OAuth ..."
+   */
+  noteContent?: string;
+  /**
+   * 변경할 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 칸반 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+}
+
+/** 노드 상태 변경(드래그 앤 드롭) 요청 */
+export interface UpdateNodeStatusRequest {
+  /**
+   * 변경할 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 칸반 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder: number;
+}
+
+/** 프로젝트 멤버 권한 변경 요청 */
+export interface UpdateProjectMemberRoleRequest {
+  /**
+   * 변경할 권한
+   * @example "MEMBER"
+   */
+  role: "VIEWER" | "MEMBER" | "OWNER";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetUserResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetUserResponse;
+}
+
+/** 내 정보 조회 응답 */
+export interface GetUserResponse {
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+  /**
+   * 가입 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCursorSliceResponseProjectSummaryResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CursorSliceResponseProjectSummaryResponse;
+}
+
+/** 커서 기반 페이지 응답 */
+export interface CursorSliceResponseProjectSummaryResponse {
+  /** 조회된 데이터 목록 */
+  content?: ProjectSummaryResponse[];
+  /**
+   * 요청한 페이지 크기
+   * @format int32
+   * @example 20
+   */
+  size?: number;
+  /**
+   * 다음 페이지 존재 여부
+   * @example true
+   */
+  hasNext?: boolean;
+  /**
+   * 다음 페이지 조회용 커서 ID
+   * @format int64
+   * @example 42
+   */
+  nextCursorId?: number;
+  /**
+   * 다음 페이지 조회용 커서 값(정렬 기준 값)
+   * @example "2026-04-19T10:00:00"
+   */
+  nextCursorValue?: string;
+}
+
+/** 프로젝트 목록 요약 응답 */
+export interface ProjectSummaryResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 프로젝트 멤버 수
+   * @format int32
+   * @example 8
+   */
+  memberCount?: number;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetProjectResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetProjectResponse;
+}
+
+/** 프로젝트 상세 조회 응답 */
+export interface GetProjectResponse {
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 프로젝트 이름
+   * @example "FlowMeet 리뉴얼"
+   */
+  name?: string;
+  /**
+   * 내 권한
+   * @example "OWNER"
+   */
+  myRole?: "VIEWER" | "MEMBER" | "OWNER";
+  /**
+   * 프로젝트 멤버 수
+   * @format int32
+   * @example 8
+   */
+  memberCount?: number;
+  /** 프로젝트에 등록된 URL 목록 */
+  urls?: UrlItem[];
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 프로젝트에 등록된 URL 항목 */
+export interface UrlItem {
+  /**
+   * URL ID
+   * @format int64
+   * @example 3
+   */
+  urlId?: number;
+  /**
+   * URL 값
+   * @example "https://github.com/kookmin-sw/2026-capstone-09"
+   */
+  url?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetAllTagsResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetAllTagsResponse;
+}
+
+/** 프로젝트 태그 전체 조회 응답 */
+export interface GetAllTagsResponse {
+  /** 태그 목록 */
+  tags?: TagItem[];
+}
+
+/** 태그 정보 */
+export interface TagItem {
+  /**
+   * 태그 ID
+   * @format int64
+   * @example 5
+   */
+  tagId?: number;
+  /**
+   * 태그 이름
+   * @example "긴급"
+   */
+  name?: string;
+  /**
+   * 태그 색상
+   * @example "RED"
+   */
+  color?:
+    | "NEUTRAL"
+    | "RED"
+    | "RED_ORANGE"
+    | "ORANGE"
+    | "LIME"
+    | "GREEN"
+    | "CYAN"
+    | "LIGHT_BLUE"
+    | "BLUE"
+    | "VIOLET"
+    | "PURPLE"
+    | "PINK";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseSearchNodeResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: SearchNodeResponse;
+}
+
+/** 검색된 노드 항목 */
+export interface SearchItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+}
+
+/** 노드 검색 응답 */
+export interface SearchNodeResponse {
+  /** 검색된 노드 목록 */
+  nodes?: SearchItem[];
+}
+
+/** 노드 담당자 정보 */
+export interface AssigneeItem {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetFlowchartResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetFlowchartResponse;
+}
+
+/** 엣지 생성자 정보 */
+export interface EdgeCreatorItem {
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+}
+
+/** 노드 간 엣지 항목 */
+export interface EdgeItem {
+  /**
+   * 엣지 ID
+   * @format int64
+   * @example 9001
+   */
+  edgeId?: number;
+  /**
+   * 시작 노드 ID
+   * @format int64
+   * @example 101
+   */
+  startNodeId?: number;
+  /**
+   * 종료 노드 ID
+   * @format int64
+   * @example 102
+   */
+  endNodeId?: number;
+  /** 엣지를 생성한 사용자 정보 */
+  createdBy?: EdgeCreatorItem;
+  /**
+   * 엣지 설명
+   * @example "로그인 성공 시 대시보드로 이동"
+   */
+  comment?: string;
+}
+
+/** 플로우차트 조회 응답 (노드와 엣지) */
+export interface GetFlowchartResponse {
+  /** 노드 목록 */
+  nodes?: NodeItem[];
+  /** 노드 간 엣지 목록 */
+  edges?: EdgeItem[];
+}
+
+/** 플로우차트의 노드 항목 */
+export interface NodeItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 상위 노드 ID (메인인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /**
+   * 연결된 회의 존재 여부
+   * @example true
+   */
+  hasMeeting?: boolean;
+  /**
+   * 하위 노드 ID 목록
+   * @example [110,111]
+   */
+  childNodeIds?: number[];
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNodeResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNodeResponse;
+}
+
+/** 노드 상세 조회 응답 */
+export interface GetNodeResponse {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 상위 노드 ID (루트인 경우 null)
+   * @format int64
+   * @example 100
+   */
+  parentId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노트 내용(마크다운)
+   * @example "## 로그인 시나리오
+   * - Google OAuth ..."
+   */
+  noteContent?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /** 연결된 회의 정보 (없으면 null) */
+  meeting?: MeetingItem;
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-03-01T09:00:00"
+   */
+  createdAt?: string;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 노드에 연결된 회의 정보 */
+export interface MeetingItem {
+  /**
+   * 회의 ID
+   * @format int64
+   * @example 57
+   */
+  meetingId?: number;
+  /**
+   * 회의 상태
+   * @example "SCHEDULED"
+   */
+  status?: string;
+  /**
+   * 회의 시작 시각
+   * @format date-time
+   * @example "2026-04-20T14:00:00"
+   */
+  startedAt?: string;
+  /**
+   * 회의 시작 푸시 알림 사용 여부
+   * @example true
+   */
+  isPushEnabled?: boolean;
+  /**
+   * 푸시 알림 예약 시각
+   * @format date-time
+   * @example "2026-04-20T13:50:00"
+   */
+  pushNotifyAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetNodeListResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetNodeListResponse;
+}
+
+/** 노드 목록 조회 응답 */
+export interface GetNodeListResponse {
+  /** 노드 목록 */
+  nodes?: NodeListItem[];
+}
+
+/** 노드 목록의 개별 항목 */
+export interface NodeListItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 노드 설명
+   * @example "OAuth2 로그인 플로우 정리"
+   */
+  description?: string;
+  /**
+   * 노드 상태
+   * @example "IN_PROGRESS"
+   */
+  status?: "WAITING" | "IN_PROGRESS" | "DONE";
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+  /**
+   * 연결된 회의 존재 여부
+   * @example true
+   */
+  hasMeeting?: boolean;
+  /**
+   * 마지막 수정 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  updatedAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetKanbanResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetKanbanResponse;
+}
+
+/** 칸반 보드 조회 응답 (상태별 그룹핑) */
+export interface GetKanbanResponse {
+  /** 대기 상태의 노드 목록 */
+  waiting?: KanbanItem[];
+  /** 진행 중 상태의 노드 목록 */
+  inProgress?: KanbanItem[];
+  /** 완료 상태의 노드 목록 */
+  done?: KanbanItem[];
+}
+
+/** 칸반 보드의 개별 노드 카드 */
+export interface KanbanItem {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호 (노드 1번의 서브 노드라면 1.1)
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "로그인 화면 기획"
+   */
+  title?: string;
+  /**
+   * 같은 상태 내 정렬 순서
+   * @format int32
+   * @example 1024
+   */
+  sortOrder?: number;
+  /** 부여된 태그 목록 */
+  tags?: TagItem[];
+  /** 담당자 목록 */
+  assignees?: AssigneeItem[];
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetAllProjectMembersResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetAllProjectMembersResponse;
+}
+
+/** 프로젝트 멤버 전체 조회 응답 */
+export interface GetAllProjectMembersResponse {
+  /** 프로젝트 멤버 목록 */
+  members?: ProjectMemberInfo[];
+}
+
+/** 프로젝트 멤버 정보 */
+export interface ProjectMemberInfo {
+  /**
+   * 프로젝트 멤버 ID
+   * @format int64
+   * @example 42
+   */
+  memberId?: number;
+  /**
+   * 사용자 ID
+   * @format int64
+   * @example 91
+   */
+  userId?: number;
+  /**
+   * 닉네임
+   * @example "플로우민"
+   */
+  nickname?: string;
+  /**
+   * 이메일
+   * @example "flowmin@flowmeet.kr"
+   */
+  email?: string;
+  /**
+   * 프로필 이미지 URL
+   * @example "https://cdn.flowmeet.kr/profile/91.png"
+   */
+  profileImageUrl?: string;
+  /**
+   * 프로젝트 내 권한
+   * @example "MEMBER"
+   */
+  role?: "VIEWER" | "MEMBER" | "OWNER";
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseCursorSliceResponseNotificationSummaryResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: CursorSliceResponseNotificationSummaryResponse;
+}
+
+/** 커서 기반 페이지 응답 */
+export interface CursorSliceResponseNotificationSummaryResponse {
+  /** 조회된 데이터 목록 */
+  content?: NotificationSummaryResponse[];
+  /**
+   * 요청한 페이지 크기
+   * @format int32
+   * @example 20
+   */
+  size?: number;
+  /**
+   * 다음 페이지 존재 여부
+   * @example true
+   */
+  hasNext?: boolean;
+  /**
+   * 다음 페이지 조회용 커서 ID
+   * @format int64
+   * @example 42
+   */
+  nextCursorId?: number;
+  /**
+   * 다음 페이지 조회용 커서 값(정렬 기준 값)
+   * @example "2026-04-19T10:00:00"
+   */
+  nextCursorValue?: string;
+}
+
+/** 알림 요약 응답 */
+export interface NotificationSummaryResponse {
+  /**
+   * 알림 ID
+   * @format int64
+   * @example 4821
+   */
+  notificationId?: number;
+  /**
+   * 알림 유형
+   * @example "MEETING_CREATED"
+   */
+  type?:
+    | "MEETING_CREATED"
+    | "MEETING_INVITE"
+    | "MEETING_REMINDER"
+    | "MEETING_ENDED"
+    | "MEMBER_INVITE"
+    | "NODE_ASSIGNED"
+    | "NODE_UPDATED";
+  /**
+   * 알림 제목
+   * @example "새 회의"
+   */
+  title?: string;
+  /**
+   * 알림 본문
+   * @example "FlowMeet 프로젝트에 새 회의가 만들어졌어요"
+   */
+  content?: string;
+  /**
+   * 관련 프로젝트 ID
+   * @format int64
+   * @example 17
+   */
+  projectId?: number;
+  /**
+   * 관련 프로젝트 이름
+   * @example "FlowMeet"
+   */
+  projectName?: string;
+  /**
+   * 관련 노드 ID
+   * @format int64
+   * @example 128
+   */
+  nodeId?: number;
+  /**
+   * 읽음 여부
+   * @example false
+   */
+  isRead?: boolean;
+  /**
+   * 알림 생성 시각
+   * @format date-time
+   * @example "2026-04-19T10:15:30"
+   */
+  createdAt?: string;
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseGetUnreadCountResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: GetUnreadCountResponse;
+}
+
+/** 읽지 않은 알림 개수 응답 */
+export interface GetUnreadCountResponse {
+  /**
+   * 읽지 않은 알림 개수
+   * @format int64
+   * @example 5
+   */
+  unreadCount?: number;
+}

--- a/frontend/src/api/http-client.ts
+++ b/frontend/src/api/http-client.ts
@@ -1,0 +1,266 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "https://api.flowmeet.kr";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+              ? JSON.stringify(property)
+              : `${property}`,
+        );
+        return formData;
+      }, new FormData());
+    },
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const responseToParse = responseFormat ? response.clone() : response;
+      const data = !responseFormat
+        ? r
+        : await responseToParse[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,16 @@
+import { Api } from './Api';
+import { authStorage } from './authStorage';
+import { customFetch, createAuthFetch } from './interceptors';
+
+export const publicApi = new Api({
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  customFetch: customFetch(),
+});
+
+export const privateApi = new Api<string>({
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  securityWorker: (token) => (token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+  customFetch: createAuthFetch(),
+});
+
+privateApi.setSecurityData(authStorage.getAccess());

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -6,11 +6,17 @@ const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 export const publicApi = new Api({
   baseUrl: baseURL,
+  baseApiParams: {
+    format: 'json',
+  },
   customFetch: customFetch(),
 });
 
 export const privateApi = new Api<string>({
   baseUrl: baseURL,
+  baseApiParams: {
+    format: 'json',
+  },
   securityWorker: (token) => (token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
   customFetch: createAuthFetch(),
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,13 +2,15 @@ import { Api } from './Api';
 import { authStorage } from './authStorage';
 import { customFetch, createAuthFetch } from './interceptors';
 
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
 export const publicApi = new Api({
-  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseUrl: baseURL,
   customFetch: customFetch(),
 });
 
 export const privateApi = new Api<string>({
-  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseUrl: baseURL,
   securityWorker: (token) => (token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
   customFetch: createAuthFetch(),
 });

--- a/frontend/src/api/interceptors.ts
+++ b/frontend/src/api/interceptors.ts
@@ -1,4 +1,3 @@
-// src/api/interceptors.ts
 import { authStorage } from './authStorage';
 
 export function customFetch(baseFetch: typeof fetch = fetch) {

--- a/frontend/src/api/interceptors.ts
+++ b/frontend/src/api/interceptors.ts
@@ -1,0 +1,66 @@
+// src/api/interceptors.ts
+import { authStorage } from './authStorage';
+
+export function customFetch(baseFetch: typeof fetch = fetch) {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await baseFetch(input, init);
+    const json = await response.json();
+    const unwrapped = json.data ?? json;
+
+    return new Response(JSON.stringify(unwrapped), {
+      status: response.status,
+      headers: response.headers,
+    });
+  };
+}
+
+export function createAuthFetch() {
+  const authFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await fetch(input, init);
+
+    if (response.status === 401) {
+      const refreshToken = authStorage.getRefresh();
+      if (!refreshToken) {
+        handleLogout();
+        return response;
+      }
+
+      try {
+        // 추후 리프레시 토큰 요청 코드로 변경
+        const res = await fetch('/auth/refresh', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refreshToken }),
+        });
+        if (!res.ok) {
+          handleLogout();
+          return response;
+        }
+
+        const { accessToken, refreshToken: newRefresh } = await res.json();
+        authStorage.setTokens(accessToken, newRefresh);
+
+        // 새 토큰을 헤더에 직접 넣어서 재시도
+        return fetch(input, {
+          ...init,
+          headers: {
+            ...init?.headers,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+      } catch {
+        handleLogout();
+        return response;
+      }
+    }
+
+    return response;
+  };
+
+  return customFetch(authFetch);
+}
+
+function handleLogout() {
+  authStorage.clear();
+  window.location.href = '/login';
+}

--- a/frontend/src/api/interceptors.ts
+++ b/frontend/src/api/interceptors.ts
@@ -8,7 +8,10 @@ export function customFetch(baseFetch: typeof fetch = fetch) {
 
     return new Response(JSON.stringify(unwrapped), {
       status: response.status,
-      headers: response.headers,
+      statusText: response.statusText,
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   };
 }

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -38,7 +38,7 @@ export function NodeFlowView({ projectId }: NodeFlowViewProps) {
 
         // test
         const test = await privateApi.project.getAllProjects();
-        console.log(test);
+        console.log(test.data);
 
         setFlowChart(JSON.parse(JSON.stringify(EXAMPLE_FLOWCHART_DATA.data)));
       } catch (error) {

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -6,6 +6,7 @@ import { EXAMPLE_FLOWCHART_DATA } from '@/constants/exampleConstant';
 import { FlowChart } from '@/types/FlowChartTypes';
 import { BaseNode } from './BaseNode';
 import { DashedComment } from './DashedComment';
+import { privateApi } from '@/api';
 
 export function NodeFlowView() {
   const [flowChart, setFlowChart] = useState<FlowChart | null>(null);
@@ -20,6 +21,11 @@ export function NodeFlowView() {
       try {
         // TODO: API 호출로 변경
         await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // test
+        const test = await privateApi.project.getAllProjects();
+        console.log(test);
+
         setFlowChart(EXAMPLE_FLOWCHART_DATA);
       } catch (error) {
         console.error('Failed to load flowchart:', error);
@@ -79,7 +85,7 @@ export function NodeFlowView() {
   return (
     <div
       ref={containerRef}
-      className="w-full h-full overflow-auto bg-surface-canvas p-6 [&::-webkit-scrollbar]:hidden"
+      className="bg-surface-canvas h-full w-full overflow-auto p-6 [&::-webkit-scrollbar]:hidden"
       style={{
         scrollbarWidth: 'none',
         msOverflowStyle: 'none',
@@ -90,10 +96,10 @@ export function NodeFlowView() {
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="flex flex-col gap-8 min-w-max">
+      <div className="flex min-w-max flex-col gap-8">
         {/* 메인 노드 */}
         <div className="flex flex-col gap-4">
-          <h2 className="text-body-1 font-semibold text-neutral-90">메인 노드</h2>
+          <h2 className="text-body-1 text-neutral-90 font-semibold">메인 노드</h2>
           <div className="flex gap-4">
             {mainNodes.map((node) => (
               <BaseNode
@@ -109,7 +115,7 @@ export function NodeFlowView() {
 
         {/* 서브 노드 */}
         <div className="flex flex-col gap-4">
-          <h2 className="text-body-1 font-semibold text-neutral-90">서브 노드</h2>
+          <h2 className="text-body-1 text-neutral-90 font-semibold">서브 노드</h2>
           <div className="flex flex-col flex-wrap gap-4">
             {subNodes.map((node) => (
               <BaseNode
@@ -125,7 +131,7 @@ export function NodeFlowView() {
 
         {/* 점선 코멘트 - Default */}
         <div className="flex flex-col gap-4">
-          <h2 className="text-body-1 font-semibold text-neutral-90">점선 코멘트 (Default)</h2>
+          <h2 className="text-body-1 text-neutral-90 font-semibold">점선 코멘트 (Default)</h2>
           <div className="flex gap-4">
             {commentEdges.map((edge) => (
               <DashedComment key={edge.edgeId} edge={edge} isCreateMode={false} />
@@ -135,7 +141,7 @@ export function NodeFlowView() {
 
         {/* 점선 코멘트 - Create */}
         <div className="flex flex-col gap-4">
-          <h2 className="text-body-1 font-semibold text-neutral-90">점선 코멘트 (Create)</h2>
+          <h2 className="text-body-1 text-neutral-90 font-semibold">점선 코멘트 (Create)</h2>
           <div className="flex gap-4">
             <DashedComment isCreateMode={true} />
           </div>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -6,7 +6,7 @@ export function proxy(request: NextRequest) {
   const ua = request.headers.get('user-agent') ?? '';
 
   if (MOBILE_UA.test(ua) && !ua.includes('Electron')) {
-    return NextResponse.redirect(new URL('/desktop-only', request.url));
+    // return NextResponse.redirect(new URL('/desktop-only', request.url));
   }
   return NextResponse.next();
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #73 

## 📝작업 내용

- API 기본 세팅했습니다

### 스크린샷 (선택)
<img width="616" height="513" alt="image" src="https://github.com/user-attachments/assets/92a5f911-4a25-4cbe-80ea-c8af6a9b317f" />

## 💬리뷰 요구사항(선택)

- env 파일 + 로그인이 없어서 임시용 토큰 노션에 추가해두겠습니다!
-  swagger-typescript-api 사용해서 없는 api 있을 때마다 서버가 스웨거에 배포했다는 전제 하에 `npx swagger-typescript-api generate -p https://api.flowmeet.kr/v3/api-docs -o ./src/api --httpClientType fetch --module-name-first-tag` 명령어 입력하거나 `pnpm api:gen` 스크립트 입력하면 됩니다!
- `Api.ts`, `data-contract.ts`, `http-clients.ts` 파일은 제너레이터가 생성해 주는 파일입니다! 
  - `Api.ts` : api 함수들 모여있는 파일
  - `data-contract.ts` : 타입들 모여있는 파일 
  - `http-clients.ts`: HTTP 클라이언트 설정 파일

- 근데 저희...... 일렉트론이 SSR 안 된다고 해서 정적 라우팅 다 갈아엎어야 합니다 큰일났어요..........!!!!!!!!! 일단 내일 중간발표 이후에 리팩토링 한 번 시원하게 다 해야 할 듯 ㅠㅠ -> 토큰도 그래서 쿠키는 임시로만 설정해뒀습니다 