### PR TITLE
[Feat/#90] ai_deploy.yml에서 python version 고정

### DIFF
--- a/.github/workflows/ai_deploy.yml
+++ b/.github/workflows/ai_deploy.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
+        with:
+          python-version: "3.11"
 
       - name: AWS CLI 설정
         uses: aws-actions/configure-aws-credentials@v2
@@ -30,6 +32,7 @@ jobs:
       - name: 패키지 설치
         run: |
           cd ai
+          pip install --upgrade pip
           pip install -r requirements.txt -t ./package
           cp -r app ./package/
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #90 

## 📝작업 내용

> 아래 에러 해결을 위해 python version을 3.11로 고정 시켰습니다.

Runtime.ImportModuleError:
No module named 'pydantic_core._pydantic_core'

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
