### PR TITLE
[Feat/#96] api_gateway_base_path를 추가

### DIFF
--- a/ai/app/main.py
+++ b/ai/app/main.py
@@ -4,4 +4,4 @@ from mangum import Mangum
 
 app = FastAPI()
 app.include_router(router)
-handler = Mangum(app, lifespan="off")
+handler = Mangum(app, lifespan="off", api_gateway_base_path="/default")


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #96 

## 📝작업 내용

> mangum 핸들러에서 /default/docs → /docs로 변환해주고자 api_gateway_base_path를 추가했습니다.

### 스크린샷 (선택)
<img width="901" height="277" alt="image" src="https://github.com/user-attachments/assets/715bace6-1915-4417-a53d-380e1a4875c1" />
<img width="1209" height="388" alt="image" src="https://github.com/user-attachments/assets/df6fad9a-427b-4bf0-b286-0b206638c669" />

## 💬리뷰 요구사항(선택)

> lambda 로그에서 에러가 없고, API배포도 {proxy+}로 하였는데 왜 /docs로 진입하면 Not Found가 뜨는지 정확한 원인을 아시나요? 

알아보니 FastAPI까지는 들어왔는데 /docs 라우트가 없다고 판단한 상태라서 stage인 default를 제거해주어야 FastAPI가 인식 가능하다고 하여 Mangum handler에 api_gateway_base_path="/default"를 추가하였습니다.

혹시 다른 해결방안을 알고 계신가요? 짐작가는 원인이 있으시거나 위 상황을 겪어보신 적이 있다면 조언해주시면 감사하겠습니다.