### PR TITLE
[Feat/#136] 프로젝트 URL에 이름 필드 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
@@ -27,6 +27,7 @@ public final class ValidationMessage {
 
     public static final String PROJECT_NAME_REQUIRED = "프로젝트 이름은 필수로 입력해 주세요.";
     public static final String PROJECT_URL_REQUIRED = "URL은 필수로 입력해 주세요.";
+    public static final String PROJECT_URL_NAME_REQUIRED = "URL 이름은 필수로 입력해 주세요.";
     public static final String PROJECT_MEMBER_ROLE_REQUIRED = "역할은 필수로 입력해 주세요.";
     public static final String INVITATION_TOKEN_REQUIRED = "초대 토큰은 필수로 입력해 주세요.";
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/request/ProjectUrlRequest.java
@@ -3,11 +3,19 @@ package kr.flowmeet.api.project.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.flowmeet.api.common.validation.ValidationMessage;
+import kr.flowmeet.domain.project.service.vo.ProjectUrlCommand;
 
 @Schema(description = "프로젝트 URL 등록/수정 요청")
 public record ProjectUrlRequest(
+        @Schema(description = "URL 이름(라벨)", example = "GitHub 레포지토리")
+        @NotBlank(message = ValidationMessage.PROJECT_URL_NAME_REQUIRED)
+        String name,
         @Schema(description = "프로젝트에 연결할 URL", example = "https://github.com/kookmin-sw/2026-capstone-09")
         @NotBlank(message = ValidationMessage.PROJECT_URL_REQUIRED)
         String url
 ) {
+
+    public ProjectUrlCommand toCommand() {
+        return new ProjectUrlCommand(name, url);
+    }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetProjectResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/GetProjectResponse.java
@@ -41,11 +41,13 @@ public record GetProjectResponse(
     public record UrlItem(
             @Schema(description = "URL ID", example = "3")
             Long urlId,
+            @Schema(description = "URL 이름(라벨)", example = "GitHub 레포지토리")
+            String name,
             @Schema(description = "URL 값", example = "https://github.com/kookmin-sw/2026-capstone-09")
             String url
     ) {
         public static UrlItem from(final ProjectUrl projectUrl) {
-            return new UrlItem(projectUrl.getId(), projectUrl.getUrl());
+            return new UrlItem(projectUrl.getId(), projectUrl.getName(), projectUrl.getUrl());
         }
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectUrlResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectUrlResponse.java
@@ -7,10 +7,12 @@ import kr.flowmeet.domain.project.entity.ProjectUrl;
 public record ProjectUrlResponse(
         @Schema(description = "URL ID", example = "3")
         Long urlId,
+        @Schema(description = "URL 이름(라벨)", example = "GitHub 레포지토리")
+        String name,
         @Schema(description = "URL 값", example = "https://github.com/kookmin-sw/2026-capstone-09")
         String url
 ) {
     public static ProjectUrlResponse from(final ProjectUrl projectUrl) {
-        return new ProjectUrlResponse(projectUrl.getId(), projectUrl.getUrl());
+        return new ProjectUrlResponse(projectUrl.getId(), projectUrl.getName(), projectUrl.getUrl());
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectUrlFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectUrlFacade.java
@@ -22,7 +22,7 @@ public class ProjectUrlFacade {
     public ProjectUrlResponse addUrl(final Long userId, final Long projectId, final ProjectUrlRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectUrl projectUrl = projectUrlService.create(projectId, request.url());
+        ProjectUrl projectUrl = projectUrlService.create(projectId, request.toCommand());
 
         return ProjectUrlResponse.from(projectUrl);
     }
@@ -32,7 +32,7 @@ public class ProjectUrlFacade {
                                         final ProjectUrlRequest request) {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
-        ProjectUrl projectUrl = projectUrlService.updateUrl(projectId, urlId, request.url());
+        ProjectUrl projectUrl = projectUrlService.update(projectId, urlId, request.toCommand());
 
         return ProjectUrlResponse.from(projectUrl);
     }

--- a/backend/flowmeet-api/src/main/resources/db/migration/V7__add_name_to_project_urls.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V7__add_name_to_project_urls.sql
@@ -1,0 +1,10 @@
+-- =========================================================
+-- V7__add_name_to_project_urls.sql
+-- 프로젝트 URL 라벨(name) 컬럼 추가
+-- =========================================================
+
+ALTER TABLE project_urls
+    ADD COLUMN name TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE project_urls
+    ALTER COLUMN name DROP DEFAULT;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/ProjectUrl.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/ProjectUrl.java
@@ -44,15 +44,20 @@ public class ProjectUrl extends BaseTimeEntity {
     private Project project;
 
     @Column(nullable = false, columnDefinition = "TEXT")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String url;
 
     @Builder
-    public ProjectUrl(Long projectId, String url) {
+    public ProjectUrl(Long projectId, String name, String url) {
         this.projectId = projectId;
+        this.name = name;
         this.url = url;
     }
 
-    public void updateUrl(final String url) {
+    public void update(final String name, final String url) {
+        this.name = name;
         this.url = url;
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectUrlService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/ProjectUrlService.java
@@ -8,6 +8,7 @@ import kr.flowmeet.domain.common.exception.BusinessException;
 import kr.flowmeet.domain.project.entity.ProjectUrl;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
 import kr.flowmeet.domain.project.repository.ProjectUrlRepository;
+import kr.flowmeet.domain.project.service.vo.ProjectUrlCommand;
 
 @Service
 @RequiredArgsConstructor
@@ -26,19 +27,20 @@ public class ProjectUrlService {
     }
 
     @Transactional
-    public ProjectUrl create(final Long projectId, final String url) {
+    public ProjectUrl create(final Long projectId, final ProjectUrlCommand command) {
         return projectUrlRepository.save(
                 ProjectUrl.builder()
                         .projectId(projectId)
-                        .url(url)
+                        .name(command.name())
+                        .url(command.url())
                         .build()
         );
     }
 
     @Transactional
-    public ProjectUrl updateUrl(final Long projectId, final Long urlId, final String url) {
+    public ProjectUrl update(final Long projectId, final Long urlId, final ProjectUrlCommand command) {
         ProjectUrl projectUrl = findByIdAndProjectId(urlId, projectId);
-        projectUrl.updateUrl(url);
+        projectUrl.update(command.name(), command.url());
         return projectUrl;
     }
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/vo/ProjectUrlCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/service/vo/ProjectUrlCommand.java
@@ -1,0 +1,7 @@
+package kr.flowmeet.domain.project.service.vo;
+
+public record ProjectUrlCommand(
+        String name,
+        String url
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #136 

## 📝작업 내용

프로젝트 URL에 라벨(`name`)을 함께 저장할 수 있도록 추가/수정 API와 응답 스키마를 확장했습니다. 함께 facade↔service 사이는 `ProjectUrlCommand` VO로 전달하도록 정리해 다른 도메인의 Command 패턴과 일치시켰습니다.

### 1. `ProjectUrl`에 `name` 필드 추가 (`feat`)

- `ProjectUrl` 엔티티
  - `name` 필드(`TEXT NOT NULL`) 추가
  - 기존 `updateUrl(url)` → `update(name, url)`로 통합
  - `@Builder` 생성자 시그니처에 `name` 추가
- `V7__add_name_to_project_urls.sql`
  - `name TEXT NOT NULL DEFAULT ''`로 컬럼 추가 후 `DEFAULT` 제거
  - 기존 행은 빈 문자열로 backfill, 신규 INSERT는 애플리케이션이 값을 명시하도록 강제

### 2. 요청/응답 DTO에 `name` 노출 (`feat`)

- `ProjectUrlRequest`
  - `name` 필드 추가 (`@NotBlank`, `ValidationMessage.PROJECT_URL_NAME_REQUIRED`)
  - facade에 전달할 VO를 만드는 `toCommand()` 메서드 추가
- `ProjectUrlResponse`, `GetProjectResponse.UrlItem` 응답에 `name` 필드 노출
- `ValidationMessage.PROJECT_URL_NAME_REQUIRED` 추가

### 3. facade ↔ service 전달을 Command 객체로 정리 (`refactor`)

- `ProjectUrlCommand` (record VO) 신규 추가 — `kr.flowmeet.domain.project.service.vo`
- `ProjectUrlService` 시그니처 변경
  - `create(projectId, url)` → `create(projectId, ProjectUrlCommand)`
  - `updateUrl(projectId, urlId, url)` → `update(projectId, urlId, ProjectUrlCommand)`
- `ProjectUrlFacade`는 `request.toCommand()`로 변환해 호출
- 기존 `TagService`에서 사용하는 Command 패턴과 동일한 형태

## 💬리뷰 요구사항(선택)

- 바뀐 거 별로 없어서 빠르게 확인 부탁드려요~
