### PR TITLE
[Feat/#135] 노드 검색 결과 응답에 필드 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
@@ -1,6 +1,7 @@
 package kr.flowmeet.api.node.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import kr.flowmeet.domain.node.entity.Node;
@@ -9,7 +10,8 @@ import kr.flowmeet.domain.node.entity.NodeTag;
 @Schema(description = "노드 검색 응답")
 public record SearchNodeResponse(
         @Schema(description = "검색된 노드 목록")
-        List<SearchItem> nodes
+        List<SearchItem> nodes,
+        long totalCount
 ) {
 
     public static SearchNodeResponse of(
@@ -23,7 +25,7 @@ public record SearchNodeResponse(
                 ))
                 .toList();
 
-        return new SearchNodeResponse(items);
+        return new SearchNodeResponse(items, items.size());
     }
 
     @Schema(description = "검색된 노드 항목")
@@ -34,10 +36,16 @@ public record SearchNodeResponse(
             String number,
             @Schema(description = "노드 제목", example = "로그인 화면 기획")
             String title,
+            @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
+            String description,
             @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
             String status,
             @Schema(description = "부여된 태그 목록")
-            List<TagItem> tags
+            List<TagItem> tags,
+            @Schema(description = "생성 시각", example = "2026-03-01T09:00:00")
+            LocalDateTime createdAt,
+            @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
+            LocalDateTime updatedAt
     ) {
 
         public static SearchItem from(final Node node, final List<NodeTag> nodeTags) {
@@ -45,8 +53,11 @@ public record SearchNodeResponse(
                     node.getId(),
                     node.getNumber(),
                     node.getTitle(),
+                    node.getDescription(),
                     node.getStatus().name(),
-                    nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList()
+                    nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList(),
+                    node.getCreatedAt(),
+                    node.getUpdatedAt()
             );
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #135 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 추가한 필드
  - 전체 응답에 결과 총 개수 (totalCount)
  - 노드 항목에 생성 시각, 수정 시각, 설명
    - createdAt
    - updatedAt
    - description

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

별 거 없어서 바로 머지하겠습니다.