### PR TITLE
[Feat/#149] 노드 상태 변경 API 변경

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
@@ -32,6 +32,8 @@ public class GlobalExceptionHandler {
 
         log.error("에러 발생: ({}) {}", exception.getClass().getSimpleName(), exception.getMessage());
 
+        exception.printStackTrace();
+
         CommonResponse<?> response = CommonResponse.error(exception);
 
         return ResponseEntity

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -10,6 +10,7 @@ import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
 import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
+import kr.flowmeet.api.node.dto.request.UpdateNodeKanbanRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
@@ -79,7 +80,17 @@ public interface NodeApi {
     @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_KANBAN")
     CommonResponse<GetKanbanResponse> getKanban(@UserId Long userId, @PathVariable Long projectId);
 
-    @Operation(summary = "칸반 상태 변경", description = "드래그 & 드롭으로 상태와 순서를 변경합니다.")
+    @Operation(summary = "칸반 카드 이동", description = "드래그 & 드롭으로 상태와 순서를 동시에 변경합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "UPDATE_NODE_KANBAN")
+    @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
+    CommonResponse<?> updateNodeKanban(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @Valid @RequestBody UpdateNodeKanbanRequest request
+    );
+
+    @Operation(summary = "노드 상태 변경", description = "노드의 상태(WAITING/IN_PROGRESS/DONE)만 변경합니다.")
     @ApiSuccessCode(code = NodeSuccessCode.class, name = "UPDATE_NODE_STATUS")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     CommonResponse<?> updateNodeStatus(

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
+import kr.flowmeet.api.node.dto.request.UpdateNodeKanbanRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
@@ -98,6 +99,18 @@ public class NodeController implements NodeApi {
             @PathVariable Long projectId
     ) {
         return CommonResponse.ok(NodeSuccessCode.GET_KANBAN, nodeFacade.getKanban(userId, projectId));
+    }
+
+    @Override
+    @PatchMapping("/nodes/{nodeId}/kanban")
+    public CommonResponse<?> updateNodeKanban(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @Valid @RequestBody UpdateNodeKanbanRequest request
+    ) {
+        nodeFacade.updateNodeKanban(userId, projectId, nodeId, request);
+        return CommonResponse.ok(NodeSuccessCode.UPDATE_NODE_KANBAN);
     }
 
     @Override

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeKanbanRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeKanbanRequest.java
@@ -1,0 +1,22 @@
+package kr.flowmeet.api.node.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import kr.flowmeet.api.common.validation.ValidationMessage;
+import kr.flowmeet.domain.node.entity.NodeStatus;
+import kr.flowmeet.domain.node.service.vo.UpdateNodeKanbanCommand;
+
+@Schema(description = "칸반 카드 이동(드래그 앤 드롭) 요청")
+public record UpdateNodeKanbanRequest(
+        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+        @NotNull(message = ValidationMessage.NODE_STATUS_REQUIRED)
+        NodeStatus status,
+        @Schema(description = "칸반 내 정렬 순서", example = "1024")
+        @NotNull(message = ValidationMessage.NODE_SORT_ORDER_REQUIRED)
+        Integer sortOrder
+) {
+
+    public UpdateNodeKanbanCommand toCommand() {
+        return new UpdateNodeKanbanCommand(status, sortOrder);
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
@@ -6,17 +6,14 @@ import kr.flowmeet.api.common.validation.ValidationMessage;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
 
-@Schema(description = "노드 상태 변경(드래그 앤 드롭) 요청")
+@Schema(description = "노드 상태 변경 요청")
 public record UpdateNodeStatusRequest(
         @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
         @NotNull(message = ValidationMessage.NODE_STATUS_REQUIRED)
-        NodeStatus status,
-        @Schema(description = "칸반 내 정렬 순서", example = "1024")
-        @NotNull(message = ValidationMessage.NODE_SORT_ORDER_REQUIRED)
-        Integer sortOrder
+        NodeStatus status
 ) {
 
     public UpdateNodeStatusCommand toCommand() {
-        return new UpdateNodeStatusCommand(status, sortOrder);
+        return new UpdateNodeStatusCommand(status);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import kr.flowmeet.api.common.exception.ApiException;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
+import kr.flowmeet.api.node.dto.request.UpdateNodeKanbanRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
@@ -161,6 +162,18 @@ public class NodeFacade {
                 .collect(Collectors.groupingBy(Node::getStatus));
 
         return GetKanbanResponse.of(statusMap, nodeTagMap, assigneeMap);
+    }
+
+    @Transactional
+    public void updateNodeKanban(
+            final Long userId,
+            final Long projectId,
+            final Long nodeId,
+            final UpdateNodeKanbanRequest request
+    ) {
+        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+
+        nodeService.updateNodeKanban(projectId, nodeId, request.toCommand());
     }
 
     @Transactional

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
@@ -14,6 +14,7 @@ public enum NodeSuccessCode implements SuccessCode {
     DELETE_NODE("노드를 삭제했어요."),
     GET_NODE_LIST("노드 리스트를 조회했어요."),
     GET_KANBAN("칸반 보드를 조회했어요."),
+    UPDATE_NODE_KANBAN("칸반 카드를 옮겼어요."),
     UPDATE_NODE_STATUS("노드 상태를 변경했어요."),
     SEARCH("검색을 완료했어요.");
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
@@ -108,9 +108,13 @@ public class Node extends BaseTimeEntity {
         this.sortOrder = sortOrder;
     }
 
-    public void updateStatus(final NodeStatus status, final int sortOrder) {
+    public void updateKanban(final NodeStatus status, final int sortOrder) {
         this.status = status;
         this.sortOrder = sortOrder;
+    }
+
+    public void updateStatus(final NodeStatus status) {
+        this.status = status;
     }
 
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import kr.flowmeet.domain.node.entity.NodeStatus;
-import kr.flowmeet.domain.node.entity.NodeType;
 import kr.flowmeet.domain.node.service.vo.CreateNodeCommand;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeCommand;
+import kr.flowmeet.domain.node.service.vo.UpdateNodeKanbanCommand;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -160,9 +160,16 @@ public class NodeService {
     }
 
     @Transactional
+    public void updateNodeKanban(final Long projectId, final Long nodeId, final UpdateNodeKanbanCommand command) {
+        Node node = findByIdAndProjectId(nodeId, projectId);
+
+        node.updateKanban(command.status(), command.sortOrder());
+    }
+
+    @Transactional
     public void updateNodeStatus(final Long projectId, final Long nodeId, final UpdateNodeStatusCommand command) {
         Node node = findByIdAndProjectId(nodeId, projectId);
 
-        node.updateStatus(command.status(), command.sortOrder());
+        node.updateStatus(command.status());
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/UpdateNodeKanbanCommand.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/vo/UpdateNodeKanbanCommand.java
@@ -2,7 +2,8 @@ package kr.flowmeet.domain.node.service.vo;
 
 import kr.flowmeet.domain.node.entity.NodeStatus;
 
-public record UpdateNodeStatusCommand(
-        NodeStatus status
+public record UpdateNodeKanbanCommand(
+        NodeStatus status,
+        Integer sortOrder
 ) {
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #149

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

노드 상태만 변경하는 API가 필요하다는 요구사항을 반영하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

사소한 거라 바로 머지할게요~
