### PR TITLE
[Feat/#138] 계정 설정 시 이메일 인증 API 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/validation/ValidationMessage.java
@@ -33,6 +33,7 @@ public final class ValidationMessage {
 
     public static final String EMAIL_REQUIRED = "이메일은 필수로 입력해 주세요.";
     public static final String EMAIL_INVALID = "이메일 형식을 다시 확인해 주세요.";
+    public static final String EMAIL_VERIFICATION_CODE_REQUIRED = "인증 코드는 필수로 입력해 주세요.";
 
     public static final String NICKNAME_REQUIRED = "닉네임은 필수로 입력해 주세요.";
     public static final String NICKNAME_MAX_LENGTH = "닉네임은 최대 20자까지 입력할 수 있어요.";

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserApi.java
@@ -8,11 +8,14 @@ import org.springframework.web.multipart.MultipartFile;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
 import kr.flowmeet.api.common.swagger.ApiSuccessCode;
-import kr.flowmeet.api.user.dto.response.GetUserResponse;
+import kr.flowmeet.api.user.dto.request.SendEmailVerificationRequest;
 import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
+import kr.flowmeet.api.user.dto.request.VerifyEmailRequest;
+import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
 import kr.flowmeet.api.user.success.UserSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
+import kr.flowmeet.domain.emailverification.exception.EmailVerificationErrorCode;
 import kr.flowmeet.domain.file.exception.FileErrorCode;
 import kr.flowmeet.domain.user.exception.UserErrorCode;
 
@@ -23,9 +26,10 @@ public interface UserApi {
     @ApiSuccessCode(code = UserSuccessCode.class, name = "GET_ME")
     CommonResponse<GetUserResponse> getMe(@UserId Long userId);
 
-    @Operation(summary = "내 정보 수정")
+    @Operation(summary = "내 정보 수정", description = "이메일을 변경할 때는 인증 코드 검증이 끝난 이메일만 사용할 수 있습니다.")
     @ApiSuccessCode(code = UserSuccessCode.class, name = "UPDATE_ME")
-    @ApiErrorCode(code = UserErrorCode.class, names = {"USER_NICKNAME_DUPLICATED"})
+    @ApiErrorCode(code = UserErrorCode.class, names = {"USER_NICKNAME_DUPLICATED", "USER_EMAIL_DUPLICATED", "USER_EMAIL_SAME_AS_CURRENT"})
+    @ApiErrorCode(code = EmailVerificationErrorCode.class, names = {"EMAIL_VERIFICATION_REQUIRED", "EMAIL_VERIFICATION_CODE_EXPIRED"})
     CommonResponse<UpdateUserResponse> updateMe(@UserId Long userId, @Valid @RequestBody UpdateUserRequest request);
 
     @Operation(summary = "프로필 이미지 변경", description = "png, jpeg, webp만 허용 (최대 5MB)")
@@ -37,4 +41,14 @@ public interface UserApi {
     @ApiSuccessCode(code = UserSuccessCode.class, name = "DELETE_ME")
     @ApiErrorCode(code = UserErrorCode.class, names = {"USER_IS_PROJECT_OWNER"})
     CommonResponse<?> deleteMe(@UserId Long userId);
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "변경할 이메일 주소로 6자리 인증 코드를 발송합니다. 코드 유효시간은 5분입니다.")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "SEND_EMAIL_VERIFICATION")
+    @ApiErrorCode(code = UserErrorCode.class, names = {"USER_EMAIL_DUPLICATED", "USER_EMAIL_SAME_AS_CURRENT"})
+    CommonResponse<?> sendEmailVerification(@UserId Long userId, @Valid @RequestBody SendEmailVerificationRequest request);
+
+    @Operation(summary = "이메일 인증 코드 검증", description = "발송된 인증 코드로 이메일 소유를 확인합니다.")
+    @ApiSuccessCode(code = UserSuccessCode.class, name = "VERIFY_EMAIL")
+    @ApiErrorCode(code = EmailVerificationErrorCode.class, names = {"EMAIL_VERIFICATION_NOT_FOUND", "EMAIL_VERIFICATION_CODE_INVALID", "EMAIL_VERIFICATION_CODE_EXPIRED"})
+    CommonResponse<?> verifyEmail(@UserId Long userId, @Valid @RequestBody VerifyEmailRequest request);
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/controller/UserController.java
@@ -7,14 +7,17 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import kr.flowmeet.api.common.dto.CommonResponse;
-import kr.flowmeet.api.user.dto.response.GetUserResponse;
+import kr.flowmeet.api.user.dto.request.SendEmailVerificationRequest;
 import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
+import kr.flowmeet.api.user.dto.request.VerifyEmailRequest;
+import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
 import kr.flowmeet.api.user.success.UserSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
@@ -53,5 +56,25 @@ public class UserController implements UserApi {
     public CommonResponse<?> deleteMe(@UserId Long userId) {
         userFacade.deleteMe(userId);
         return CommonResponse.ok(UserSuccessCode.DELETE_ME);
+    }
+
+    @Override
+    @PostMapping("/me/email-verifications")
+    public CommonResponse<?> sendEmailVerification(
+            @UserId Long userId,
+            @Valid @RequestBody SendEmailVerificationRequest request
+    ) {
+        userFacade.sendEmailVerification(userId, request);
+        return CommonResponse.ok(UserSuccessCode.SEND_EMAIL_VERIFICATION);
+    }
+
+    @Override
+    @PostMapping("/me/email-verifications/verify")
+    public CommonResponse<?> verifyEmail(
+            @UserId Long userId,
+            @Valid @RequestBody VerifyEmailRequest request
+    ) {
+        userFacade.verifyEmail(userId, request);
+        return CommonResponse.ok(UserSuccessCode.VERIFY_EMAIL);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/SendEmailVerificationRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/SendEmailVerificationRequest.java
@@ -1,0 +1,15 @@
+package kr.flowmeet.api.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
+
+@Schema(description = "이메일 인증 코드 발송 요청")
+public record SendEmailVerificationRequest(
+        @Schema(description = "인증할 이메일", example = "flowmin@flowmeet.kr")
+        @NotBlank(message = ValidationMessage.EMAIL_REQUIRED)
+        @Email(message = ValidationMessage.EMAIL_INVALID)
+        String email
+) {
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/VerifyEmailRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/dto/request/VerifyEmailRequest.java
@@ -1,0 +1,18 @@
+package kr.flowmeet.api.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
+
+@Schema(description = "이메일 인증 코드 검증 요청")
+public record VerifyEmailRequest(
+        @Schema(description = "인증할 이메일", example = "flowmin@flowmeet.kr")
+        @NotBlank(message = ValidationMessage.EMAIL_REQUIRED)
+        @Email(message = ValidationMessage.EMAIL_INVALID)
+        String email,
+        @Schema(description = "인증 코드", example = "123456")
+        @NotBlank(message = ValidationMessage.EMAIL_VERIFICATION_CODE_REQUIRED)
+        String code
+) {
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/event/EmailVerificationIssuedEventListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/event/EmailVerificationIssuedEventListener.java
@@ -1,0 +1,33 @@
+package kr.flowmeet.api.user.event;
+
+import java.util.Map;
+import kr.flowmeet.domain.emailverification.event.EmailVerificationIssuedEvent;
+import kr.flowmeet.external.email.EmailSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationIssuedEventListener {
+
+    private static final String EMAIL_VERIFICATION_TEMPLATE = "email/email-verification";
+    private static final String EMAIL_VERIFICATION_SUBJECT = "[FlowMeet] 이메일 인증 코드";
+
+    private final EmailSender emailSender;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(final EmailVerificationIssuedEvent event) {
+        try {
+            Map<String, Object> variables = Map.of("code", event.code());
+            emailSender.send(event.email(), EMAIL_VERIFICATION_SUBJECT, EMAIL_VERIFICATION_TEMPLATE, variables);
+        } catch (Exception e) {
+            log.error("[EmailVerificationIssuedEventListener] 인증 메일 발송 실패. to={}", event.email(), e);
+        }
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
@@ -1,26 +1,37 @@
 package kr.flowmeet.api.user.facade;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import kr.flowmeet.api.file.facade.ImageUploader;
-import kr.flowmeet.api.user.dto.response.GetUserResponse;
+import kr.flowmeet.api.user.dto.request.SendEmailVerificationRequest;
 import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
+import kr.flowmeet.api.user.dto.request.VerifyEmailRequest;
+import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
+import kr.flowmeet.domain.emailverification.entity.EmailVerification;
+import kr.flowmeet.domain.emailverification.service.EmailVerificationService;
 import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.user.entity.User;
 import kr.flowmeet.domain.user.service.UserService;
+import kr.flowmeet.external.email.EmailSender;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserFacade {
 
+    private static final String EMAIL_VERIFICATION_TEMPLATE = "email/email-verification";
+    private static final String EMAIL_VERIFICATION_SUBJECT = "[FlowMeet] 이메일 인증 코드";
+
     private final UserService userService;
+    private final EmailVerificationService emailVerificationService;
     private final ProjectMemberService projectMemberService;
     private final ImageUploader imageUploader;
+    private final EmailSender emailSender;
 
     public GetUserResponse getMe(final Long userId) {
         User user = userService.findById(userId);
@@ -36,7 +47,9 @@ public class UserFacade {
             user.updateNickname(request.nickname());
         }
 
-        if (request.email() != null) {
+        if (request.email() != null && !request.email().equals(user.getEmail())) {
+            userService.validateEmailChangeable(request.email(), user.getEmail());
+            emailVerificationService.consumeVerified(userId, request.email());
             user.updateEmail(request.email());
         }
 
@@ -60,5 +73,24 @@ public class UserFacade {
                 .forEach(projectMemberService::delete);
 
         userService.delete(user);
+    }
+
+    @Transactional
+    public void sendEmailVerification(final Long userId, final SendEmailVerificationRequest request) {
+        User user = userService.findById(userId);
+        userService.validateEmailChangeable(request.email(), user.getEmail());
+
+        EmailVerification verification = emailVerificationService.issueCode(userId, request.email());
+        sendVerificationCodeEmail(request.email(), verification.getCode());
+    }
+
+    @Transactional
+    public void verifyEmail(final Long userId, final VerifyEmailRequest request) {
+        emailVerificationService.verify(userId, request.email(), request.code());
+    }
+
+    private void sendVerificationCodeEmail(final String email, final String code) {
+        Map<String, Object> variables = Map.of("code", code);
+        emailSender.send(email, EMAIL_VERIFICATION_SUBJECT, EMAIL_VERIFICATION_TEMPLATE, variables);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
@@ -1,6 +1,5 @@
 package kr.flowmeet.api.user.facade;
 
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,27 +10,21 @@ import kr.flowmeet.api.user.dto.request.UpdateUserRequest;
 import kr.flowmeet.api.user.dto.request.VerifyEmailRequest;
 import kr.flowmeet.api.user.dto.response.GetUserResponse;
 import kr.flowmeet.api.user.dto.response.UpdateUserResponse;
-import kr.flowmeet.domain.emailverification.entity.EmailVerification;
 import kr.flowmeet.domain.emailverification.service.EmailVerificationService;
 import kr.flowmeet.domain.file.entity.FileDomainType;
 import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.user.entity.User;
 import kr.flowmeet.domain.user.service.UserService;
-import kr.flowmeet.external.email.EmailSender;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserFacade {
 
-    private static final String EMAIL_VERIFICATION_TEMPLATE = "email/email-verification";
-    private static final String EMAIL_VERIFICATION_SUBJECT = "[FlowMeet] 이메일 인증 코드";
-
     private final UserService userService;
     private final EmailVerificationService emailVerificationService;
     private final ProjectMemberService projectMemberService;
     private final ImageUploader imageUploader;
-    private final EmailSender emailSender;
 
     public GetUserResponse getMe(final Long userId) {
         User user = userService.findById(userId);
@@ -80,17 +73,11 @@ public class UserFacade {
         User user = userService.findById(userId);
         userService.validateEmailChangeable(request.email(), user.getEmail());
 
-        EmailVerification verification = emailVerificationService.issueCode(userId, request.email());
-        sendVerificationCodeEmail(request.email(), verification.getCode());
+        emailVerificationService.issueCode(userId, request.email());
     }
 
     @Transactional
     public void verifyEmail(final Long userId, final VerifyEmailRequest request) {
         emailVerificationService.verify(userId, request.email(), request.code());
-    }
-
-    private void sendVerificationCodeEmail(final String email, final String code) {
-        Map<String, Object> variables = Map.of("code", code);
-        emailSender.send(email, EMAIL_VERIFICATION_SUBJECT, EMAIL_VERIFICATION_TEMPLATE, variables);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/success/UserSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/success/UserSuccessCode.java
@@ -10,7 +10,9 @@ public enum UserSuccessCode implements SuccessCode {
     GET_ME("내 정보를 조회했어요."),
     UPDATE_ME("내 정보를 수정했어요."),
     UPDATE_PROFILE_IMAGE("프로필 이미지를 변경했어요."),
-    DELETE_ME("회원 탈퇴가 완료됐어요.");
+    DELETE_ME("회원 탈퇴가 완료됐어요."),
+    SEND_EMAIL_VERIFICATION("인증 코드를 보냈어요. 메일함을 확인해 주세요."),
+    VERIFY_EMAIL("이메일 인증에 성공했어요.");
 
     private final String message;
 }

--- a/backend/flowmeet-api/src/main/resources/db/migration/V11__add_email_verifications.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V11__add_email_verifications.sql
@@ -1,0 +1,17 @@
+-- =========================================================
+-- V11__add_email_verifications.sql
+-- 이메일 인증 코드 보관 테이블
+-- =========================================================
+
+CREATE TABLE email_verifications (
+    email_verification_id BIGSERIAL    PRIMARY KEY,
+    user_id               BIGINT       NOT NULL,
+    email                 VARCHAR(255) NOT NULL,
+    code                  VARCHAR(10)  NOT NULL,
+    expires_at            TIMESTAMP    NOT NULL,
+    verified_at           TIMESTAMP,
+    created_at            TIMESTAMP    NOT NULL,
+    CONSTRAINT fk_email_verifications_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE INDEX idx_email_verifications_user_id_email ON email_verifications (user_id, email);

--- a/backend/flowmeet-api/src/main/resources/templates/email/email-verification.html
+++ b/backend/flowmeet-api/src/main/resources/templates/email/email-verification.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>FlowMeet 이메일 인증 코드</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f6f8fa; margin: 0; padding: 24px;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 560px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden;">
+        <tr>
+            <td style="padding: 32px;">
+                <h1 style="margin: 0 0 16px; font-size: 22px; color: #111827;">이메일 인증 코드</h1>
+                <p style="margin: 0 0 16px; font-size: 15px; color: #374151; line-height: 1.6;">
+                    아래 인증 코드를 5분 안에 입력해 주세요.
+                </p>
+                <p style="margin: 0 0 24px; padding: 16px 20px; background-color: #f3f4f6; border-radius: 10px; text-align: center; font-size: 28px; font-weight: 700; letter-spacing: 6px; color: #111827;">
+                    <span th:text="${code}">000000</span>
+                </p>
+                <p style="margin: 0; font-size: 12px; color: #9ca3af; line-height: 1.6;">
+                    본인이 요청하지 않은 인증 메일이라면 이 메일을 무시해도 돼요.
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/entity/EmailVerification.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/entity/EmailVerification.java
@@ -1,0 +1,79 @@
+package kr.flowmeet.domain.emailverification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import kr.flowmeet.domain.common.BaseCreatedTimeEntity;
+import kr.flowmeet.domain.user.entity.User;
+
+@Entity
+@Table(
+        name = "email_verifications",
+        indexes = {
+                @Index(name = "idx_email_verifications_user_id_email", columnList = "user_id, email")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends BaseCreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "email_verification_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Builder
+    public EmailVerification(Long userId, String email, String code, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.email = email;
+        this.code = code;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public boolean isVerified() {
+        return verifiedAt != null;
+    }
+
+    public boolean matchesCode(final String code) {
+        return this.code.equals(code);
+    }
+
+    public void markVerified() {
+        this.verifiedAt = LocalDateTime.now();
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/event/EmailVerificationIssuedEvent.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/event/EmailVerificationIssuedEvent.java
@@ -1,0 +1,10 @@
+package kr.flowmeet.domain.emailverification.event;
+
+public record EmailVerificationIssuedEvent(
+        String email,
+        String code
+) {
+    public static EmailVerificationIssuedEvent of(final String email, final String code) {
+        return new EmailVerificationIssuedEvent(email, code);
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/exception/EmailVerificationErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/exception/EmailVerificationErrorCode.java
@@ -1,0 +1,18 @@
+package kr.flowmeet.domain.emailverification.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import kr.flowmeet.common.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailVerificationErrorCode implements ErrorCode {
+    EMAIL_VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드를 다시 요청해 주세요."),
+    EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증 코드를 다시 확인해 주세요."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증 시간이 지났어요. 인증 코드를 다시 요청해 주세요."),
+    EMAIL_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "이메일을 먼저 인증해 주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/repository/EmailVerificationRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/repository/EmailVerificationRepository.java
@@ -1,0 +1,23 @@
+package kr.flowmeet.domain.emailverification.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import kr.flowmeet.domain.emailverification.entity.EmailVerification;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findTopByUserIdAndEmailAndVerifiedAtIsNullOrderByCreatedAtDesc(
+            Long userId, String email
+    );
+
+    Optional<EmailVerification> findTopByUserIdAndEmailAndVerifiedAtIsNotNullOrderByCreatedAtDesc(
+            Long userId, String email
+    );
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM EmailVerification ev WHERE ev.userId = :userId AND ev.email = :email")
+    int deleteAllByUserIdAndEmail(@Param("userId") Long userId, @Param("email") String email);
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
@@ -1,0 +1,74 @@
+package kr.flowmeet.domain.emailverification.service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import kr.flowmeet.domain.common.exception.BusinessException;
+import kr.flowmeet.domain.emailverification.entity.EmailVerification;
+import kr.flowmeet.domain.emailverification.exception.EmailVerificationErrorCode;
+import kr.flowmeet.domain.emailverification.repository.EmailVerificationRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailVerificationService {
+
+    private static final int CODE_LENGTH = 6;
+    private static final int CODE_BOUND = 1_000_000;
+    private static final long EXPIRATION_MINUTES = 5;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Transactional
+    public EmailVerification issueCode(final Long userId, final String email) {
+        emailVerificationRepository.deleteAllByUserIdAndEmail(userId, email);
+
+        EmailVerification verification = EmailVerification.builder()
+                .userId(userId)
+                .email(email)
+                .code(generateCode())
+                .expiresAt(LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES))
+                .build();
+
+        return emailVerificationRepository.save(verification);
+    }
+
+    @Transactional
+    public void verify(final Long userId, final String email, final String code) {
+        EmailVerification verification = emailVerificationRepository
+                .findTopByUserIdAndEmailAndVerifiedAtIsNullOrderByCreatedAtDesc(userId, email)
+                .orElseThrow(() -> new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_NOT_FOUND));
+
+        if (verification.isExpired()) {
+            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!verification.matchesCode(code)) {
+            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_INVALID);
+        }
+
+        verification.markVerified();
+    }
+
+    @Transactional
+    public void consumeVerified(final Long userId, final String email) {
+        EmailVerification verification = emailVerificationRepository
+                .findTopByUserIdAndEmailAndVerifiedAtIsNotNullOrderByCreatedAtDesc(userId, email)
+                .orElseThrow(() -> new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_REQUIRED));
+
+        if (verification.isExpired()) {
+            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        emailVerificationRepository.deleteAllByUserIdAndEmail(userId, email);
+    }
+
+    private String generateCode() {
+        int value = RANDOM.nextInt(CODE_BOUND);
+        return String.format("%0" + CODE_LENGTH + "d", value);
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
@@ -67,10 +67,6 @@ public class EmailVerificationService {
                 .findTopByUserIdAndEmailAndVerifiedAtIsNotNullOrderByCreatedAtDesc(userId, email)
                 .orElseThrow(() -> new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_REQUIRED));
 
-        if (verification.isExpired()) {
-            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED);
-        }
-
         emailVerificationRepository.deleteAllByUserIdAndEmail(userId, email);
     }
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
@@ -3,10 +3,12 @@ package kr.flowmeet.domain.emailverification.service;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import kr.flowmeet.domain.common.exception.BusinessException;
 import kr.flowmeet.domain.emailverification.entity.EmailVerification;
+import kr.flowmeet.domain.emailverification.event.EmailVerificationIssuedEvent;
 import kr.flowmeet.domain.emailverification.exception.EmailVerificationErrorCode;
 import kr.flowmeet.domain.emailverification.repository.EmailVerificationRepository;
 
@@ -22,6 +24,7 @@ public class EmailVerificationService {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     private final EmailVerificationRepository emailVerificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public EmailVerification issueCode(final Long userId, final String email) {
@@ -34,7 +37,11 @@ public class EmailVerificationService {
                 .expiresAt(LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES))
                 .build();
 
-        return emailVerificationRepository.save(verification);
+        EmailVerification saved = emailVerificationRepository.save(verification);
+
+        eventPublisher.publishEvent(EmailVerificationIssuedEvent.of(saved.getEmail(), saved.getCode()));
+
+        return saved;
     }
 
     @Transactional

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
@@ -10,6 +10,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없어요."),
     USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임이에요."),
+    USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 이메일이에요."),
+    USER_EMAIL_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "지금 사용 중인 이메일이에요. 다른 이메일을 입력해 주세요."),
     USER_IS_PROJECT_OWNER(HttpStatus.BAD_REQUEST, "소유 중인 프로젝트가 있어서 탈퇴할 수 없어요. 프로젝트 소유권을 넘기거나 프로젝트를 삭제한 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/service/UserService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/service/UserService.java
@@ -51,6 +51,17 @@ public class UserService {
         }
     }
 
+    public void validateEmailChangeable(final String newEmail, final String currentEmail) {
+        if (newEmail.equals(currentEmail)) {
+            throw new BusinessException(UserErrorCode.USER_EMAIL_SAME_AS_CURRENT);
+        }
+
+        userRepository.findByEmail(newEmail)
+                .ifPresent(existing -> {
+                    throw new BusinessException(UserErrorCode.USER_EMAIL_DUPLICATED);
+                });
+    }
+
     @Transactional
     public void delete(final User user) {
         userRepository.delete(user);


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #138

## 📝작업 내용

계정 설정 모달에서 이메일 변경 시 사용할 이메일 인증 API를 추가했다. 변경하려는 이메일 주소를 사용자가 실제로 소유하고 있는지 확인하지 않으면 무단으로 다른 사람 이메일로 바꿀 수 있어, 인증 코드 발송/검증을 거친 이메일만 변경에 사용할 수 있도록 강제했다.

### 추가된 API

| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST | `/v1/users/me/email-verifications` | 변경할 이메일로 6자리 인증 코드 발송 (5분 유효) |
| POST | `/v1/users/me/email-verifications/verify` | 인증 코드 검증 |

기존 `PATCH /v1/users/me`는 이메일 변경 시 검증 완료된 코드를 소비(consume)해야만 통과한다. 검증된 기록이 없거나 만료됐다면 `EMAIL_VERIFICATION_REQUIRED` / `EMAIL_VERIFICATION_CODE_EXPIRED` 로 응답한다.

### 도메인 모델

`email_verifications` 테이블과 `EmailVerification` 엔티티를 신설했다. 코드 재요청 시 같은 (userId, email) 조합의 이전 코드는 모두 삭제 후 새 코드를 저장한다. 검증된 코드는 이메일 변경 시점에 삭제되어 재사용을 막는다.

- 코드: 6자리 숫자 (`SecureRandom`)
- 유효시간: 발급 후 5분
- 검증 흐름: `issueCode` → 사용자가 메일 확인 → `verify` (verifiedAt 마킹) → `PATCH /v1/users/me` 호출 시 `consumeVerified` 로 검증 기록 소비

### 인증 메일 발송 비동기화

invitation 메일 패턴과 동일하게 `EmailVerificationIssuedEvent` → `@Async @TransactionalEventListener(AFTER_COMMIT)` 흐름으로 처리했다. API 응답이 SMTP 응답 지연에 묶이지 않고, 트랜잭션 커밋 후에 메일이 나가므로 "DB에 코드가 없는데 메일은 발송된" 상태도 발생하지 않는다. SMTP 실패 시에는 listener에서 로그만 남기고 사용자가 "다시 받기"로 신규 코드를 발급받도록 한다.

### 추가된 에러 / 성공 코드

`UserErrorCode`
- `USER_EMAIL_DUPLICATED` (CONFLICT) — 이미 다른 사용자가 사용 중인 이메일
- `USER_EMAIL_SAME_AS_CURRENT` (BAD_REQUEST) — 현재 이메일과 동일

`EmailVerificationErrorCode` (신규)
- `EMAIL_VERIFICATION_NOT_FOUND` (NOT_FOUND) — 발급된 코드가 없음
- `EMAIL_VERIFICATION_CODE_INVALID` (BAD_REQUEST)
- `EMAIL_VERIFICATION_CODE_EXPIRED` (BAD_REQUEST)
- `EMAIL_VERIFICATION_REQUIRED` (BAD_REQUEST) — 변경 시도 시 검증된 코드 없음

`UserSuccessCode`
- `SEND_EMAIL_VERIFICATION` — "인증 코드를 보냈어요. 메일함을 확인해 주세요."
- `VERIFY_EMAIL` — "이메일 인증에 성공했어요."

### 범위에서 제외

- **재요청 쿨다운/Rate limit**: 동일 이메일에 대한 발송 빈도 제한은 두지 않았다. 운영하면서 남용 사례가 보이면 별도 도입 검토.
- **소셜 이메일(`socialEmail`) 변경**: 본 PR은 일반 `email` 컬럼만 대상이다.

## 💬리뷰 요구사항(선택)

- `consumeVerified` 의 만료 검증: verify 시점에 한 번 검증되더라도 `PATCH /v1/users/me` 호출까지 5분 안에 끝나야 변경이 통과합니다. 모달 UX상 문제 없을 거라 보고 갔는데, 5분이 빠듯하다고 판단되면 만료시간 늘리는 방향으로 조정해보겠습니다!
