### PR TITLE
[Feat/#160] 디스코드 봇을 통한 에러 알림 기능 구현

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,13 @@ GOOGLE_APP_NAME=FlowMeet
 GOOGLE_CALENDAR_ID=primary
 GOOGLE_MEET_TIMEZONE=Asia/Seoul
 
+# ---------- Discord (에러 알림) ----------
+# Discord 봇으로 GlobalExceptionHandler 의 예기치 못한 예외를 알린다.
+# false 또는 미설정 시 NoOpErrorNotifier 폴백.
+DISCORD_ERROR_NOTIFIER_ENABLED=false
+DISCORD_BOT_TOKEN=
+DISCORD_ERROR_CHANNEL_ID=
+
 # ---------- JVM ----------
 # t3.micro 에서 컨테이너 mem_limit(800m) 의 60% 를 힙으로 사용 → Xmx ≈ 480MB
 JAVA_OPTS=-XX:MaxRAMPercentage=60.0 -XX:+ExitOnOutOfMemoryError

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/dto/CommonResponse.java
@@ -18,6 +18,7 @@ public record CommonResponse<T>(
 ) {
     private static final String SUCCESS_CODE = "OK";
     private static final String SUCCESS_MESSAGE = "요청에 성공했습니다.";
+    private static final String DEFAULT_ERROR_MESSAGE = "오류가 발생했어요. 잠시 후 다시 시도해 주세요.";
 
     public static CommonResponse<?> ok() {
         return ok(null);
@@ -44,7 +45,7 @@ public record CommonResponse<T>(
     }
 
     public static CommonResponse<?> error(final Exception exception, final HttpStatus httpStatus) {
-        return error(exception, httpStatus, exception.getMessage());
+        return error(exception, httpStatus, DEFAULT_ERROR_MESSAGE);
     }
 
     public static CommonResponse<?> error(final Exception exception) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package kr.flowmeet.api.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.common.exception.CustomException;
 import kr.flowmeet.common.exception.ErrorCode;
+import kr.flowmeet.external.notification.ErrorNotifier;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +17,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final ErrorNotifier errorNotifier;
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<CommonResponse<?>> handleCustomException(final CustomException exception) {
@@ -28,11 +34,20 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<CommonResponse<?>> handleException(final Exception exception) {
+    public ResponseEntity<CommonResponse<?>> handleException(
+            final HttpServletRequest request,
+            final Exception exception
+    ) {
 
         log.error("에러 발생: ({}) {}", exception.getClass().getSimpleName(), exception.getMessage());
 
         exception.printStackTrace();
+
+        errorNotifier.notifyError(
+                "[" + exception.getClass().getSimpleName() + "] (" + request.getMethod() + ") " + request.getRequestURI(),
+                exception.getMessage(),
+                exception
+        );
 
         CommonResponse<?> response = CommonResponse.error(exception);
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package kr.flowmeet.api.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
 import kr.flowmeet.api.common.dto.CommonResponse;
+import kr.flowmeet.api.common.util.SensitiveDataMasker;
 import kr.flowmeet.common.exception.CustomException;
 import kr.flowmeet.common.exception.ErrorCode;
 import kr.flowmeet.external.notification.ErrorNotifier;
@@ -14,11 +16,14 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private static final int REQUEST_BODY_LOG_LIMIT = 1500;
 
     private final ErrorNotifier errorNotifier;
 
@@ -46,6 +51,7 @@ public class GlobalExceptionHandler {
         errorNotifier.notifyError(
                 "[" + exception.getClass().getSimpleName() + "] (" + request.getMethod() + ") " + request.getRequestURI(),
                 exception.getMessage(),
+                extractRequestBody(request),
                 exception
         );
 
@@ -82,5 +88,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(status)
                 .body(CommonResponse.error(exception, status, message));
+    }
+
+    private String extractRequestBody(final HttpServletRequest request) {
+        ContentCachingRequestWrapper wrapper = unwrapCachingRequest(request);
+        if (wrapper == null) {
+            return null;
+        }
+        byte[] buf = wrapper.getContentAsByteArray();
+        if (buf.length == 0) {
+            return null;
+        }
+        String body = new String(buf, StandardCharsets.UTF_8);
+        String masked = SensitiveDataMasker.mask(body);
+        if (masked.length() > REQUEST_BODY_LOG_LIMIT) {
+            return masked.substring(0, REQUEST_BODY_LOG_LIMIT) + "...";
+        }
+        return masked;
+    }
+
+    private ContentCachingRequestWrapper unwrapCachingRequest(final HttpServletRequest request) {
+        if (request instanceof ContentCachingRequestWrapper wrapper) {
+            return wrapper;
+        }
+        return null;
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.util.SensitiveDataMasker;
+import kr.flowmeet.auth.security.CurrentUserProvider;
 import kr.flowmeet.common.exception.CustomException;
 import kr.flowmeet.common.exception.ErrorCode;
 import kr.flowmeet.external.notification.ErrorNotifier;
@@ -26,6 +27,7 @@ public class GlobalExceptionHandler {
     private static final int REQUEST_BODY_LOG_LIMIT = 1500;
 
     private final ErrorNotifier errorNotifier;
+    private final CurrentUserProvider currentUserProvider;
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<CommonResponse<?>> handleCustomException(final CustomException exception) {
@@ -51,6 +53,7 @@ public class GlobalExceptionHandler {
         errorNotifier.notifyError(
                 "[" + exception.getClass().getSimpleName() + "] (" + request.getMethod() + ") " + request.getRequestURI(),
                 exception.getMessage(),
+                currentUserProvider.getCurrentUserId().orElse(null),
                 extractRequestBody(request),
                 exception
         );

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/filter/RequestBodyCachingFilter.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/filter/RequestBodyCachingFilter.java
@@ -1,0 +1,39 @@
+package kr.flowmeet.api.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestBodyCachingFilter extends OncePerRequestFilter {
+
+    private static final int CACHE_LIMIT_BYTES = 65_536;
+    private static final String MULTIPART_PREFIX = "multipart/";
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (isMultipart(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        ContentCachingRequestWrapper wrapped = new ContentCachingRequestWrapper(request, CACHE_LIMIT_BYTES);
+        filterChain.doFilter(wrapped, response);
+    }
+
+    private boolean isMultipart(final HttpServletRequest request) {
+        String contentType = request.getContentType();
+        return contentType != null && contentType.toLowerCase().startsWith(MULTIPART_PREFIX);
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/util/SensitiveDataMasker.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/common/util/SensitiveDataMasker.java
@@ -1,0 +1,23 @@
+package kr.flowmeet.api.common.util;
+
+import java.util.regex.Pattern;
+
+public final class SensitiveDataMasker {
+
+    private static final Pattern JSON_SENSITIVE_PATTERN = Pattern.compile(
+            "(\"(?:password|code|refreshToken)\"\\s*:\\s*)\"[^\"]*\"",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private static final String MASKED_REPLACEMENT = "$1\"***\"";
+
+    private SensitiveDataMasker() {
+    }
+
+    public static String mask(final String body) {
+        if (body == null || body.isBlank()) {
+            return body;
+        }
+        return JSON_SENSITIVE_PATTERN.matcher(body).replaceAll(MASKED_REPLACEMENT);
+    }
+}

--- a/backend/flowmeet-api/src/main/resources/config/external.yaml
+++ b/backend/flowmeet-api/src/main/resources/config/external.yaml
@@ -23,3 +23,9 @@ google:
     client-secret: ${OAUTH2_GOOGLE_CLIENT_SECRET:}
     calendar-id: ${GOOGLE_CALENDAR_ID:primary}
     timezone: ${GOOGLE_MEET_TIMEZONE:Asia/Seoul}
+
+discord:
+  error-notifier:
+    enabled: ${DISCORD_ERROR_NOTIFIER_ENABLED:false}
+    bot-token: ${DISCORD_BOT_TOKEN:}
+    channel-id: ${DISCORD_ERROR_CHANNEL_ID:}

--- a/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/security/CurrentUserProvider.java
+++ b/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/security/CurrentUserProvider.java
@@ -1,0 +1,21 @@
+package kr.flowmeet.auth.security;
+
+import java.util.Optional;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CurrentUserProvider {
+
+    public Optional<Long> getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return Optional.empty();
+        }
+        if (authentication.getPrincipal() instanceof Long userId) {
+            return Optional.of(userId);
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/flowmeet-external/build.gradle
+++ b/backend/flowmeet-external/build.gradle
@@ -14,4 +14,6 @@ dependencies {
     implementation 'com.google.apis:google-api-services-calendar:v3-rev20240705-2.0.0'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.27.0'
     implementation 'com.google.http-client:google-http-client-gson:1.45.0'
+
+    implementation 'net.dv8tion:JDA:5.2.2'
 }

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
@@ -1,0 +1,90 @@
+package kr.flowmeet.external.notification;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.OffsetDateTime;
+import kr.flowmeet.external.notification.config.DiscordProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+
+@Slf4j
+@RequiredArgsConstructor
+public class DiscordErrorNotifier implements ErrorNotifier {
+
+    private static final int ERROR_COLOR = 0xE74C3C;
+    private static final int CODE_BLOCK_OVERHEAD = "```\n\n```".length();
+    private static final int CODE_BLOCK_CONTENT_LIMIT = MessageEmbed.VALUE_MAX_LENGTH - CODE_BLOCK_OVERHEAD;
+    private static final String TRUNCATION_SUFFIX = "...";
+
+    private final JDA jda;
+    private final DiscordProperties properties;
+
+    @Override
+    public void notifyError(
+            final String title,
+            final String description,
+            final Throwable throwable
+    ) {
+        try {
+            TextChannel channel = jda.getTextChannelById(properties.channelId());
+            if (channel == null) {
+                log.warn("[DiscordErrorNotifier] channel not found. channelId={}", properties.channelId());
+                return;
+            }
+
+            MessageEmbed embed = buildEmbed(title, description, throwable);
+            channel.sendMessageEmbeds(embed).queue(
+                    success -> {},
+                    failure -> log.error("[DiscordErrorNotifier] send failed", failure)
+            );
+        } catch (Exception e) {
+            log.error("[DiscordErrorNotifier] notifyError failed", e);
+        }
+    }
+
+    private MessageEmbed buildEmbed(
+            final String title,
+            final String description,
+            final Throwable throwable
+    ) {
+        EmbedBuilder embed = new EmbedBuilder()
+                .setTitle(truncate(title, MessageEmbed.TITLE_MAX_LENGTH))
+                .setColor(ERROR_COLOR)
+                .setTimestamp(OffsetDateTime.now());
+
+        if (description != null && !description.isBlank()) {
+            embed.setDescription(truncate(description, MessageEmbed.DESCRIPTION_MAX_LENGTH));
+        }
+
+        if (throwable != null) {
+            embed.addField("Exception", truncate(throwable.getClass().getName(), MessageEmbed.VALUE_MAX_LENGTH), false);
+            embed.addField("Stack Trace", asCodeBlock(formatStackTrace(throwable)), false);
+        }
+
+        return embed.build();
+    }
+
+    private String asCodeBlock(final String content) {
+        return "```\n" + truncate(content, CODE_BLOCK_CONTENT_LIMIT) + "\n```";
+    }
+
+    private String formatStackTrace(final Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    private String truncate(final String value, final int maxLength) {
+        if (value == null) {
+            return "";
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength - TRUNCATION_SUFFIX.length()) + TRUNCATION_SUFFIX;
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
@@ -27,6 +27,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
     public void notifyError(
             final String title,
             final String description,
+            final String requestBody,
             final Throwable throwable
     ) {
         try {
@@ -36,7 +37,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
                 return;
             }
 
-            MessageEmbed embed = buildEmbed(title, description, throwable);
+            MessageEmbed embed = buildEmbed(title, description, requestBody, throwable);
             channel.sendMessageEmbeds(embed).queue(
                     success -> {},
                     failure -> log.error("[DiscordErrorNotifier] send failed", failure)
@@ -49,6 +50,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
     private MessageEmbed buildEmbed(
             final String title,
             final String description,
+            final String requestBody,
             final Throwable throwable
     ) {
         EmbedBuilder embed = new EmbedBuilder()
@@ -62,6 +64,13 @@ public class DiscordErrorNotifier implements ErrorNotifier {
 
         if (throwable != null) {
             embed.addField("Exception", truncate(throwable.getClass().getName(), MessageEmbed.VALUE_MAX_LENGTH), false);
+        }
+
+        if (requestBody != null && !requestBody.isBlank()) {
+            embed.addField("Request Body", asCodeBlock(requestBody), false);
+        }
+
+        if (throwable != null) {
             embed.addField("Stack Trace", asCodeBlock(formatStackTrace(throwable)), false);
         }
 

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/DiscordErrorNotifier.java
@@ -19,6 +19,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
     private static final int CODE_BLOCK_OVERHEAD = "```\n\n```".length();
     private static final int CODE_BLOCK_CONTENT_LIMIT = MessageEmbed.VALUE_MAX_LENGTH - CODE_BLOCK_OVERHEAD;
     private static final String TRUNCATION_SUFFIX = "...";
+    private static final String ANONYMOUS_USER = "anonymous";
 
     private final JDA jda;
     private final DiscordProperties properties;
@@ -27,6 +28,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
     public void notifyError(
             final String title,
             final String description,
+            final Long userId,
             final String requestBody,
             final Throwable throwable
     ) {
@@ -37,7 +39,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
                 return;
             }
 
-            MessageEmbed embed = buildEmbed(title, description, requestBody, throwable);
+            MessageEmbed embed = buildEmbed(title, description, userId, requestBody, throwable);
             channel.sendMessageEmbeds(embed).queue(
                     success -> {},
                     failure -> log.error("[DiscordErrorNotifier] send failed", failure)
@@ -50,6 +52,7 @@ public class DiscordErrorNotifier implements ErrorNotifier {
     private MessageEmbed buildEmbed(
             final String title,
             final String description,
+            final Long userId,
             final String requestBody,
             final Throwable throwable
     ) {
@@ -62,8 +65,10 @@ public class DiscordErrorNotifier implements ErrorNotifier {
             embed.setDescription(truncate(description, MessageEmbed.DESCRIPTION_MAX_LENGTH));
         }
 
+        embed.addField("User ID", userId != null ? String.valueOf(userId) : ANONYMOUS_USER, true);
+
         if (throwable != null) {
-            embed.addField("Exception", truncate(throwable.getClass().getName(), MessageEmbed.VALUE_MAX_LENGTH), false);
+            embed.addField("Exception", truncate(throwable.getClass().getName(), MessageEmbed.VALUE_MAX_LENGTH), true);
         }
 
         if (requestBody != null && !requestBody.isBlank()) {

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
@@ -1,0 +1,6 @@
+package kr.flowmeet.external.notification;
+
+public interface ErrorNotifier {
+
+    void notifyError(String title, String description, Throwable throwable);
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
@@ -5,6 +5,7 @@ public interface ErrorNotifier {
     void notifyError(
             String title,
             String description,
+            Long userId,
             String requestBody,
             Throwable throwable
     );

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/ErrorNotifier.java
@@ -2,5 +2,10 @@ package kr.flowmeet.external.notification;
 
 public interface ErrorNotifier {
 
-    void notifyError(String title, String description, Throwable throwable);
+    void notifyError(
+            String title,
+            String description,
+            String requestBody,
+            Throwable throwable
+    );
 }

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.external.notification;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NoOpErrorNotifier implements ErrorNotifier {
+
+    @Override
+    public void notifyError(
+            final String title,
+            final String description,
+            final Throwable throwable
+    ) {
+        log.debug("[NoOpErrorNotifier] notifyError skipped. title={}", title);
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
@@ -9,6 +9,7 @@ public class NoOpErrorNotifier implements ErrorNotifier {
     public void notifyError(
             final String title,
             final String description,
+            final Long userId,
             final String requestBody,
             final Throwable throwable
     ) {

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/NoOpErrorNotifier.java
@@ -9,6 +9,7 @@ public class NoOpErrorNotifier implements ErrorNotifier {
     public void notifyError(
             final String title,
             final String description,
+            final String requestBody,
             final Throwable throwable
     ) {
         log.debug("[NoOpErrorNotifier] notifyError skipped. title={}", title);

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/DiscordConfig.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/DiscordConfig.java
@@ -1,0 +1,38 @@
+package kr.flowmeet.external.notification.config;
+
+import java.util.EnumSet;
+import kr.flowmeet.external.notification.DiscordErrorNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(DiscordProperties.class)
+@ConditionalOnProperty(prefix = "discord.error-notifier", name = "enabled", havingValue = "true")
+public class DiscordConfig {
+
+    private final DiscordProperties properties;
+
+    @Bean(destroyMethod = "shutdownNow")
+    public JDA discordJda() throws InterruptedException {
+        log.info("[DiscordConfig] starting JDA");
+        JDA jda = JDABuilder.createLight(properties.botToken(), EnumSet.noneOf(GatewayIntent.class))
+                .build();
+        jda.awaitReady();
+        log.info("[DiscordConfig] JDA ready");
+        return jda;
+    }
+
+    @Bean
+    public DiscordErrorNotifier discordErrorNotifier(final JDA discordJda) {
+        return new DiscordErrorNotifier(discordJda, properties);
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/DiscordProperties.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/DiscordProperties.java
@@ -1,0 +1,11 @@
+package kr.flowmeet.external.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "discord.error-notifier")
+public record DiscordProperties(
+        boolean enabled,
+        String botToken,
+        String channelId
+) {
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/ErrorNotifierConfig.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/notification/config/ErrorNotifierConfig.java
@@ -1,0 +1,17 @@
+package kr.flowmeet.external.notification.config;
+
+import kr.flowmeet.external.notification.ErrorNotifier;
+import kr.flowmeet.external.notification.NoOpErrorNotifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ErrorNotifierConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(ErrorNotifier.class)
+    public NoOpErrorNotifier noOpErrorNotifier() {
+        return new NoOpErrorNotifier();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #160

## 📝작업 내용

JDA 기반 Discord 봇으로 백엔드 예기치 못한 예외(500)를 알리는 기능을 추가했어요. 알림 송신부는 인터페이스로 추상화해서 환경별로 NoOp 폴백이 동작해요.

### 1. Discord 봇 기반 에러 알림 추상화 구현 (`258e2c8`)

- `flowmeet-external/notification` 패키지 신설
  - `ErrorNotifier` — 에러 알림 추상 인터페이스
  - `DiscordErrorNotifier` — JDA `JDABuilder.createLight` + 임베드 메시지 송신 (제목/예외/스택트레이스)
  - `NoOpErrorNotifier` — 봇 미설정 환경 폴백 (`@ConditionalOnMissingBean(ErrorNotifier.class)`)
- `DiscordConfig` — `discord.error-notifier.enabled=true` 일 때만 JDA 빈 등록, 종료 시 `shutdownNow`로 정리
- `GlobalExceptionHandler` — `@ExceptionHandler(Exception.class)` 경로에서 알림 송신 (CustomException은 예상된 에러라 송신 대상 아님)
- 환경 변수: `DISCORD_ERROR_NOTIFIER_ENABLED`, `DISCORD_BOT_TOKEN`, `DISCORD_ERROR_CHANNEL_ID` (.env.example, config/external.yaml 갱신)
- 의존성: `net.dv8tion:JDA:5.2.2`

### 2. 에러 알림에 요청 body 포함 (`930649f`)

`@RequestBody`가 컨트롤러에서 한 번 소비되면 다시 못 읽는 문제를 해결하기 위해 요청 본문을 미리 캐싱하는 필터 추가.

- `RequestBodyCachingFilter` (`OncePerRequestFilter`, 최우선 순위)
  - 멀티파트 요청은 통과
  - 그 외는 `ContentCachingRequestWrapper` (64KB 한도) 로 감싸 본문 캐싱
- `SensitiveDataMasker` — JSON 텍스트의 `password`, `code`, `refreshToken` 키 값 `"***"` 로 치환
- `GlobalExceptionHandler` — 캐싱된 본문 → 마스킹 → 1500자 truncate 후 알림에 포함
- Discord 임베드 1024자 필드 제한 정확히 적용 (코드 블록 오버헤드 8자 차감)

### 3. 에러 알림에 요청자 userId 포함 (`68493b3`)

- `flowmeet-auth/security/CurrentUserProvider` — `getCurrentUserId(): Optional<Long>` 헬퍼 빈
- `GlobalExceptionHandler` — provider 주입 후 `Authentication.principal` 에서 userId 추출 (인증 안 된 요청은 `anonymous` 표기)
- spring-security 클래스를 `flowmeet-api` 에서 직접 import 하지 않고 `flowmeet-auth` 헬퍼만 의존하도록 격리

### 4. 500 에러 메시지 UX 가이드 적용 (`3951ce6`)

`CommonResponse.error(Exception)` 폴백 메시지를 UX 라이팅 가이드(해요체, 다음 행동 안내) 에 맞게 수정.

## 💬리뷰 요구사항

1. 마스킹 키는 일단 `password`, `code`, `refreshToken` 만 추가했어요. 추가로 마스킹할 필드 있으면 알려주세요.
2. 운영 적용 시 `DISCORD_BOT_TOKEN`, `DISCORD_ERROR_CHANNEL_ID` 환경 변수를 EC2 `.env` 에 추가하고 `DISCORD_ERROR_NOTIFIER_ENABLED=true` 로 켜야 해요.
