### PR TITLE
[Feat/#162] 노드 리스트 조회 시 정렬 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -24,6 +24,7 @@ import kr.flowmeet.api.node.success.NodeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.meeting.exception.MeetingErrorCode;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
+import kr.flowmeet.domain.node.service.NodeSortType;
 
 @Tag(name = "Node", description = "노드")
 public interface NodeApi {
@@ -90,12 +91,12 @@ public interface NodeApi {
             @PathVariable Long nodeId
     );
 
-    @Operation(summary = "리스트 뷰 조회", description = "노드를 리스트 형태로 조회합니다.")
+    @Operation(summary = "리스트 뷰 조회", description = "노드를 리스트 형태로 조회합니다. (LATEST: 최신순, NAME: 가나다순)")
     @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_NODE_LIST")
     CommonResponse<GetNodeListResponse> getNodeList(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestParam(required = false) String sort
+            @RequestParam(defaultValue = "LATEST") NodeSortType sort
     );
 
     @Operation(summary = "칸반 보드 조회", description = "상태별 그룹으로 노드를 조회합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -26,6 +26,7 @@ import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.api.node.facade.NodeFacade;
 import kr.flowmeet.api.node.success.NodeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
+import kr.flowmeet.domain.node.service.NodeSortType;
 
 @RestController
 @RequestMapping("/v1/projects/{projectId}")
@@ -113,7 +114,7 @@ public class NodeController implements NodeApi {
     public CommonResponse<GetNodeListResponse> getNodeList(
             @UserId Long userId,
             @PathVariable Long projectId,
-            @RequestParam(required = false) String sort
+            @RequestParam(defaultValue = "LATEST") NodeSortType sort
     ) {
         return CommonResponse.ok(NodeSuccessCode.GET_NODE_LIST, nodeFacade.getNodeList(userId, projectId, sort));
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import kr.flowmeet.domain.common.BaseTimeEntity;
+import kr.flowmeet.domain.node.service.NodeSortType;
 import kr.flowmeet.domain.node.service.NodeValidator;
 import kr.flowmeet.domain.project.entity.ProjectMember;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
@@ -169,18 +170,16 @@ public class NodeFacade {
     public GetNodeListResponse getNodeList(
         final Long userId,
         final Long projectId,
-        final String sort
+        final NodeSortType sort
     ) {
         projectPermissionValidator.validate(projectId, userId);
 
-        List<Node> nodes = nodeService.findAllByProjectId(projectId);
+        List<Node> nodes = nodeService.findAllByProjectId(projectId, sort);
 
         List<Long> nodeIds = getNodeIdFromNodes(nodes);
         Map<Long, List<NodeTag>> nodeTagMap = nodeTagService.findAllByNodeIdsAsMap(nodeIds);
         Map<Long, List<NodeAssignee>> assigneeMap = nodeAssigneeService.findAllByNodeIdsAsMap(nodeIds);
         Set<Long> meetingNodeIds = meetingService.findAllMeetingNodeIds(nodeIds);
-
-        //TODO: 정렬 QueryDSL로 처리하기
 
         return GetNodeListResponse.of(nodes, nodeTagMap, assigneeMap, meetingNodeIds);
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepositoryCustom.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepositoryCustom.java
@@ -2,8 +2,11 @@ package kr.flowmeet.domain.node.repository;
 
 import java.util.List;
 import kr.flowmeet.domain.node.entity.Node;
+import kr.flowmeet.domain.node.service.NodeSortType;
 
 public interface NodeRepositoryCustom {
+
+    List<Node> findAllByProjectId(Long projectId, NodeSortType sort);
 
     List<Node> searchByQuery(Long projectId, String query);
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepositoryCustomImpl.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/NodeRepositoryCustomImpl.java
@@ -8,11 +8,21 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 import kr.flowmeet.domain.node.entity.Node;
+import kr.flowmeet.domain.node.service.NodeSortType;
 
 @RequiredArgsConstructor
 public class NodeRepositoryCustomImpl implements NodeRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Node> findAllByProjectId(final Long projectId, final NodeSortType sort) {
+        return queryFactory
+                .selectFrom(node)
+                .where(node.projectId.eq(projectId))
+                .orderBy(sort.toOrderSpecifier(), node.id.asc())
+                .fetch();
+    }
 
     @Override
     public List<Node> searchByQuery(final Long projectId, final String query) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
@@ -42,6 +42,10 @@ public class NodeService {
         return nodeRepository.findAllByProjectId(projectId);
     }
 
+    public List<Node> findAllByProjectId(final Long projectId, final NodeSortType sort) {
+        return nodeRepository.findAllByProjectId(projectId, sort);
+    }
+
     public List<Node> findAllByIdsAndProjectId(final List<Long> nodeIds, final Long projectId) {
         List<Node> nodes = nodeRepository.findAllByIdInAndProjectId(nodeIds, projectId);
         if (nodes.size() != nodeIds.size()) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeSortType.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeSortType.java
@@ -1,0 +1,19 @@
+package kr.flowmeet.domain.node.service;
+
+import com.querydsl.core.types.OrderSpecifier;
+import kr.flowmeet.domain.node.entity.QNode;
+
+public enum NodeSortType {
+    LATEST(QNode.node.updatedAt.desc()),
+    NAME(QNode.node.title.asc());
+
+    private final OrderSpecifier<?> orderSpecifier;
+
+    NodeSortType(final OrderSpecifier<?> orderSpecifier) {
+        this.orderSpecifier = orderSpecifier;
+    }
+
+    public OrderSpecifier<?> toOrderSpecifier() {
+        return orderSpecifier;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #162 

## 📝작업 내용

리스트 뷰 노드 조회 API의 정렬을 애플리케이션 레벨에서 QueryDSL 기반 DB 정렬로 옮기고, `ProjectSortType`과 동일한 패턴의 `NodeSortType` enum을 도입했습니다. `NodeFacade.getNodeList`에 남아 있던 `//TODO: 정렬 QueryDSL로 처리하기` 부채를 정리하는 작업입니다.

### 1. `NodeSortType` enum 도입

- `kr.flowmeet.domain.node.service.NodeSortType` 추가
  - `LATEST` — `updatedAt DESC`
  - `NAME` — `title ASC`
- `OrderSpecifier<?>`를 직접 보유 → `toOrderSpecifier()`로 노출해 QueryDSL 쿼리에 그대로 연결
- 노드 리스트 API는 커서 페이징이 없어 `ProjectSortType`과 달리 `extractValue`는 두지 않음

### 2. 리포지토리 정렬 조회 메서드 추가

- `NodeRepositoryCustom#findAllByProjectId(Long, NodeSortType)` 추가
- `NodeRepositoryCustomImpl`에서 `sort.toOrderSpecifier()` + `node.id ASC` tiebreak로 안정 정렬 보장
- 기존 Spring Data 파생 메서드 `findAllByProjectId(Long)`는 플로우차트/칸반/하위 노드 탐색 등 정렬이 필요 없는 호출부에서 그대로 사용

### 3. Service / Facade 위임

- `NodeService#findAllByProjectId(Long, NodeSortType)` 오버로드 추가
- `NodeFacade.getNodeList` 시그니처를 `String sort` → `NodeSortType sort`로 교체
- 애플리케이션 레벨 정렬 코드와 `//TODO` 주석 제거

### 4. Controller / Swagger 정리

- `@RequestParam(required = false) String sort` → `@RequestParam(defaultValue = "LATEST") NodeSortType sort`
  - Spring이 enum 바인딩을 처리하므로 잘못된 값은 400으로 응답
- `NodeApi`의 `@Operation.description`에 정렬 옵션(`LATEST`, `NAME`)을 명시

## API 변경

### Request

| 엔드포인트 | 파라미터 | 변경 |
|---|---|---|
| `GET /v1/projects/{projectId}/nodes/list` | `sort` | `String`(미사용) → `NodeSortType` (`LATEST` 기본, `NAME` 선택) |

### 요청 예시

```
GET /v1/projects/1/nodes/list                # LATEST(기본): 최근 수정 순
GET /v1/projects/1/nodes/list?sort=NAME      # NAME: 가나다순
GET /v1/projects/1/nodes/list?sort=INVALID   # 400 Bad Request
```

응답 스키마 자체는 변경 없음.

## 변경 파일

| 모듈 | 파일 | 변경 |
|---|---|---|
| domain | `node/service/NodeSortType.java` | 신규 |
| domain | `node/repository/NodeRepositoryCustom.java` | 메서드 추가 |
| domain | `node/repository/NodeRepositoryCustomImpl.java` | QueryDSL 정렬 조회 구현 |
| domain | `node/service/NodeService.java` | 정렬 오버로드 추가 |
| api | `node/facade/NodeFacade.java` | 정렬 위임 + TODO 제거 |
| api | `node/controller/NodeController.java` | `NodeSortType` 바인딩 |
| api | `node/controller/NodeApi.java` | Swagger 설명 보강 |

## 테스트

- `./gradlew :flowmeet-domain:compileJava :flowmeet-api:compileJava` 성공

## 💬리뷰 요구사항(선택)

프로젝트 목록 조회 시 정렬이랑 비슷하게 구현했습니다. 참고 부탁드려요~