### PR TITLE
[Feat/#167] SQS 초기 세팅 및 AI 작업 도메인 구현

### DIFF
--- a/backend/flowmeet-api/build.gradle
+++ b/backend/flowmeet-api/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     // Mail (미사용, 추후 활용 예정)
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // SQS (LlmResponseListener에서 @SqsListener 사용)
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0')
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
+
     // H2 Console
     implementation 'org.springframework.boot:spring-boot-h2console'
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
@@ -1,0 +1,45 @@
+package kr.flowmeet.api.ai.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import kr.flowmeet.domain.ai.service.AiTaskService;
+import kr.flowmeet.external.sqs.dto.LlmResponseMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LlmResponseListener {
+
+    private final ObjectMapper objectMapper;
+    private final AiTaskService aiTaskService;
+
+    @SqsListener("${cloud.aws.sqs.response-queue-url}")
+    public void handle(final String payload) {
+        try {
+            LlmResponseMessage response = objectMapper.readValue(payload, LlmResponseMessage.class);
+            log.info("LLM 응답 수신 - jobId: {}, status: {}", response.jobId(), response.status());
+
+            if (!response.isSuccess()) {
+                log.error("LLM 처리 실패 - jobId: {}, error: {}", response.jobId(), response.error());
+                aiTaskService.fail(response.jobId(), response.error());
+                return;
+            }
+
+            if (response.isSubSummary()) {
+                String summary = response.result().get("summary").asText();
+                String mermaidCode = response.result().get("mermaidCode").asText();
+                aiTaskService.complete(response.jobId(), summary, mermaidCode);
+            } else {
+                String result = response.result().asText();
+                aiTaskService.complete(response.jobId(), result, null);
+            }
+
+            log.info("LLM 처리 완료 - jobId: {}, taskType: {}", response.jobId(), response.taskType());
+        } catch (Exception e) {
+            log.error("LLM 응답 처리 실패 - payload: {}", payload, e);
+        }
+    }
+}

--- a/backend/flowmeet-api/src/main/resources/config/external.yaml
+++ b/backend/flowmeet-api/src/main/resources/config/external.yaml
@@ -14,6 +14,10 @@ cloud:
       bucket: ${S3_BUCKET:flowmeet-bucket}
       region: ${S3_REGION:ap-northeast-2}
       cdn-url: ${S3_CDN_URL:}
+    sqs:
+      request-queue-url: ${SQS_REQUEST_QUEUE_URL:}
+      response-queue-url: ${SQS_RESPONSE_QUEUE_URL:}
+      region: ${SQS_REGION:ap-northeast-2}
 
 google:
   meet:

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
@@ -42,9 +42,6 @@ public class AiTask extends BaseTimeEntity {
     private AiTaskStatus status;
 
     @Column(columnDefinition = "TEXT")
-    private String requestText;
-
-    @Column(columnDefinition = "TEXT")
     private String result;
 
     @Column(columnDefinition = "TEXT")
@@ -53,12 +50,11 @@ public class AiTask extends BaseTimeEntity {
     private String errorMessage;
 
     @Builder
-    public AiTask(String id, Long userId, AiTaskType taskType, String requestText) {
+    public AiTask(String id, Long userId, AiTaskType taskType) {
         this.id = id;
         this.userId = userId;
         this.taskType = taskType;
         this.status = AiTaskStatus.PENDING;
-        this.requestText = requestText;
     }
 
     public void markProcessing() {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kr.flowmeet.domain.common.BaseTimeEntity;
+import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -33,6 +34,13 @@ public class AiTask extends BaseTimeEntity {
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
     private User user;
 
+    @Column(name = "node_id", nullable = false)
+    private Long nodeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id", insertable = false, updatable = false)
+    private Node node;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AiTaskType taskType;
@@ -50,9 +58,10 @@ public class AiTask extends BaseTimeEntity {
     private String errorMessage;
 
     @Builder
-    public AiTask(String id, Long userId, AiTaskType taskType) {
+    public AiTask(String id, Long userId, Long nodeId, AiTaskType taskType) {
         this.id = id;
         this.userId = userId;
+        this.nodeId = nodeId;
         this.taskType = taskType;
         this.status = AiTaskStatus.PENDING;
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
@@ -1,0 +1,78 @@
+package kr.flowmeet.domain.ai.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kr.flowmeet.domain.common.BaseTimeEntity;
+import kr.flowmeet.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_tasks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiTask extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "ai_task_id")
+    private String id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AiTaskType taskType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AiTaskStatus status;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestText;
+
+    @Column(columnDefinition = "TEXT")
+    private String result;
+
+    @Column(columnDefinition = "TEXT")
+    private String mermaidCode;
+
+    private String errorMessage;
+
+    @Builder
+    public AiTask(String id, Long userId, AiTaskType taskType, String requestText) {
+        this.id = id;
+        this.userId = userId;
+        this.taskType = taskType;
+        this.status = AiTaskStatus.PENDING;
+        this.requestText = requestText;
+    }
+
+    public void markProcessing() {
+        this.status = AiTaskStatus.PROCESSING;
+    }
+
+    public void complete(final String result, final String mermaidCode) {
+        this.status = AiTaskStatus.COMPLETED;
+        this.result = result;
+        this.mermaidCode = mermaidCode;
+    }
+
+    public void fail(final String errorMessage) {
+        this.status = AiTaskStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTaskStatus.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTaskStatus.java
@@ -1,0 +1,8 @@
+package kr.flowmeet.domain.ai.entity;
+
+public enum AiTaskStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTaskType.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTaskType.java
@@ -1,0 +1,6 @@
+package kr.flowmeet.domain.ai.entity;
+
+public enum AiTaskType {
+    SUB_SUMMARY,
+    MAIN_SUMMARY
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/exception/AiTaskErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/exception/AiTaskErrorCode.java
@@ -1,0 +1,15 @@
+package kr.flowmeet.domain.ai.exception;
+
+import kr.flowmeet.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AiTaskErrorCode implements ErrorCode {
+    AI_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "AI 작업을 찾을 수 없어요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/repository/AiTaskRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/repository/AiTaskRepository.java
@@ -1,0 +1,7 @@
+package kr.flowmeet.domain.ai.repository;
+
+import kr.flowmeet.domain.ai.entity.AiTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiTaskRepository extends JpaRepository<AiTask, String> {
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
@@ -23,13 +23,12 @@ public class AiTaskService {
     }
 
     @Transactional
-    public AiTask create(final Long userId, final AiTaskType taskType, final String requestText) {
+    public AiTask create(final Long userId, final AiTaskType taskType) {
         return aiTaskRepository.save(
                 AiTask.builder()
                         .id(UUID.randomUUID().toString())
                         .userId(userId)
                         .taskType(taskType)
-                        .requestText(requestText)
                         .build()
         );
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
@@ -23,11 +23,12 @@ public class AiTaskService {
     }
 
     @Transactional
-    public AiTask create(final Long userId, final AiTaskType taskType) {
+    public AiTask create(final Long userId, final Long nodeId, final AiTaskType taskType) {
         return aiTaskRepository.save(
                 AiTask.builder()
                         .id(UUID.randomUUID().toString())
                         .userId(userId)
+                        .nodeId(nodeId)
                         .taskType(taskType)
                         .build()
         );

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
@@ -1,0 +1,48 @@
+package kr.flowmeet.domain.ai.service;
+
+import java.util.UUID;
+import kr.flowmeet.domain.ai.entity.AiTask;
+import kr.flowmeet.domain.ai.entity.AiTaskType;
+import kr.flowmeet.domain.ai.exception.AiTaskErrorCode;
+import kr.flowmeet.domain.ai.repository.AiTaskRepository;
+import kr.flowmeet.domain.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiTaskService {
+
+    private final AiTaskRepository aiTaskRepository;
+
+    public AiTask findById(final String id) {
+        return aiTaskRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(AiTaskErrorCode.AI_TASK_NOT_FOUND));
+    }
+
+    @Transactional
+    public AiTask create(final Long userId, final AiTaskType taskType, final String requestText) {
+        return aiTaskRepository.save(
+                AiTask.builder()
+                        .id(UUID.randomUUID().toString())
+                        .userId(userId)
+                        .taskType(taskType)
+                        .requestText(requestText)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void complete(final String jobId, final String result, final String mermaidCode) {
+        AiTask task = findById(jobId);
+        task.complete(result, mermaidCode);
+    }
+
+    @Transactional
+    public void fail(final String jobId, final String errorMessage) {
+        AiTask task = findById(jobId);
+        task.fail(errorMessage);
+    }
+}

--- a/backend/flowmeet-external/build.gradle
+++ b/backend/flowmeet-external/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     implementation 'com.google.http-client:google-http-client-gson:1.45.0'
 
     implementation 'net.dv8tion:JDA:5.2.2'
+
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0')
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
 }

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/SqsMessageSender.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/SqsMessageSender.java
@@ -1,0 +1,26 @@
+package kr.flowmeet.external.sqs;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import kr.flowmeet.external.sqs.config.SqsProperties;
+import kr.flowmeet.external.sqs.dto.LlmRequestMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SqsMessageSender {
+
+    private final SqsTemplate sqsTemplate;
+    private final SqsProperties sqsProperties;
+
+    public void send(final LlmRequestMessage message) {
+        log.info("SQS 메시지 전송 - jobId: {}, taskType: {}", message.jobId(), message.taskType());
+        sqsTemplate.send(sendOptions -> sendOptions
+                .queue(sqsProperties.getRequestQueueUrl())
+                .payload(message)
+        );
+        log.info("SQS 메시지 전송 완료 - jobId: {}", message.jobId());
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/config/SqsConfig.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/config/SqsConfig.java
@@ -1,0 +1,31 @@
+package kr.flowmeet.external.sqs.config;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SqsProperties.class)
+public class SqsConfig {
+
+    private final SqsProperties sqsProperties;
+
+    @Bean
+    public SqsAsyncClient sqsAsyncClient() {
+        return SqsAsyncClient.builder()
+                .region(Region.of(sqsProperties.getRegion()))
+                .build();
+    }
+
+    @Bean
+    public SqsTemplate sqsTemplate(final SqsAsyncClient sqsAsyncClient) {
+        return SqsTemplate.builder()
+                .sqsAsyncClient(sqsAsyncClient)
+                .build();
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/config/SqsProperties.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/config/SqsProperties.java
@@ -1,0 +1,15 @@
+package kr.flowmeet.external.sqs.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "cloud.aws.sqs")
+public class SqsProperties {
+
+    private final String requestQueueUrl;
+    private final String responseQueueUrl;
+    private final String region;
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmRequestMessage.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmRequestMessage.java
@@ -1,0 +1,8 @@
+package kr.flowmeet.external.sqs.dto;
+
+public record LlmRequestMessage(
+        String jobId,
+        String taskType,
+        String text
+) {
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmResponseMessage.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmResponseMessage.java
@@ -1,0 +1,20 @@
+package kr.flowmeet.external.sqs.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmResponseMessage(
+        String jobId,
+        String taskType,
+        String status,
+        JsonNode result,
+        String error
+) {
+
+    public boolean isSuccess() {
+        return "success".equals(status);
+    }
+
+    public boolean isSubSummary() {
+        return "sub-summary".equals(taskType);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #167 

## 📝작업 내용

### SQS 비동기 메시지 파이프라인 구축
- `llm-request-queue` 메시지 발행 Producer (`SqsMessageSender`) 구현
- `llm-response-queue` 응답 수신 Listener (`LlmResponseListener`) 구현
- SQS 설정 클래스 구현 (`SqsConfig`, `SqsProperties`)
- 요청/응답 메시지 DTO 구현 (`LlmRequestMessage`, `LlmResponseMessage`)
- `spring-cloud-aws-starter-sqs` 의존성 추가 (external, api 모듈)
- `external.yaml`에 SQS 큐 URL 설정 추가

### AI 요약 작업 상태 관리 도메인 구현
- `AiTask` 엔티티 구현 (PK: UUID를 job_id로 사용, 상태: PENDING/COMPLETED/FAILED)
- `AiTaskService` 구현 (생성, 완료, 실패 처리)
- `AiTaskRepository`, `AiTaskErrorCode` 정의

### 모듈 구조
- **flowmeet-external**: SQS Config, Producer, DTO (외부 연동)
- **flowmeet-domain**: AiTask 엔티티, Service, Repository (도메인 로직)
- **flowmeet-api**: LlmResponseListener (external DTO + domain Service 조합, 기존 Facade 패턴과 동일)

## 💬리뷰 요구사항(선택)

> - `LlmResponseListener`를 기존 패턴(Facade가 external + domain 조합)에 맞춰 `flowmeet-api`에 배치했는데, Listener도 이 위치가 적절한지 의견 부탁드립니다.
> - AI response 메시지 필드명이 camelCase로 넘어오는 게 맞는지 한 번 더 확인 부탁드립니다. (현재 `jobId`, `taskType`, `mermaidCode` 기준으로 구현)
> - LLM 응답의 `result` 타입이 sub-summary일 때는 JSON 객체(summary + mermaidCode), main-summary일 때는 문자열로 다릅니다. `JsonNode`로 받아서 분기 처리했는데 더 나은 방법이 있을지 의견 부탁드립니다.