### PR TITLE
[Feat/#134] 연결된 노드 목록 조회용 API 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/scheduler/TempFileCleanupScheduler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/file/scheduler/TempFileCleanupScheduler.java
@@ -1,4 +1,4 @@
-package kr.flowmeet.api.scheduler;
+package kr.flowmeet.api.file.scheduler;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/scheduler/MeetingReminderScheduler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/scheduler/MeetingReminderScheduler.java
@@ -1,4 +1,4 @@
-package kr.flowmeet.api.scheduler;
+package kr.flowmeet.api.meeting.scheduler;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -17,6 +17,7 @@ import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeTitleRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
 import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
+import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
@@ -121,6 +122,15 @@ public interface NodeApi {
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
             @Valid @RequestBody UpdateNodeStatusRequest request
+    );
+
+    @Operation(summary = "연결된 노드 조회", description = "노드와 연결선으로 이어진 상대 노드 목록을 조회합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_LINKED_NODES")
+    @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
+    CommonResponse<GetLinkedNodesResponse> getLinkedNodes(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
     );
 
     @Operation(summary = "프로젝트 내 검색", description = "노드 제목, 키워드로 검색합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -20,6 +20,7 @@ import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeTitleRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
 import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
+import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
@@ -150,6 +151,19 @@ public class NodeController implements NodeApi {
     ) {
         nodeFacade.updateNodeStatus(userId, projectId, nodeId, request);
         return CommonResponse.ok(NodeSuccessCode.UPDATE_NODE_STATUS);
+    }
+
+    @Override
+    @GetMapping("/nodes/{nodeId}/linked-nodes")
+    public CommonResponse<GetLinkedNodesResponse> getLinkedNodes(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
+    ) {
+        return CommonResponse.ok(
+                NodeSuccessCode.GET_LINKED_NODES,
+                nodeFacade.getLinkedNodes(userId, projectId, nodeId)
+        );
     }
 
     @Override

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetLinkedNodesResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetLinkedNodesResponse.java
@@ -1,0 +1,85 @@
+package kr.flowmeet.api.node.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.flowmeet.domain.node.entity.Edge;
+import kr.flowmeet.domain.node.entity.Node;
+import kr.flowmeet.domain.user.entity.User;
+
+@Schema(description = "노드에 연결된 상대 노드 목록 조회 응답")
+public record GetLinkedNodesResponse(
+        @Schema(description = "연결된 노드 목록")
+        List<LinkedNodeItem> linkedNodes
+) {
+
+    public static GetLinkedNodesResponse of(final Long nodeId, final List<Edge> edges) {
+        List<LinkedNodeItem> items = edges.stream()
+                .map(edge -> LinkedNodeItem.of(nodeId, edge))
+                .toList();
+
+        return new GetLinkedNodesResponse(items);
+    }
+
+    @Schema(description = "연결된 상대 노드 항목")
+    public record LinkedNodeItem(
+            @Schema(description = "연결선 ID", example = "9001")
+            Long edgeId,
+            @Schema(description = "조회한 노드의 연결선 내 역할", example = "START", allowableValues = {"START", "END"})
+            NodeLinkType linkType,
+            @Schema(description = "연결된 상대 노드 ID", example = "102")
+            Long linkedNodeId,
+            @Schema(description = "노드 번호 (노드 1번의 서브 노드라면 1.1)", example = "1")
+            String number,
+            @Schema(description = "노드 제목", example = "메인 노드 제목입니다.")
+            String title,
+            @Schema(description = "노드 설명", example = "노드 노트 요약 내용입니다.")
+            String description,
+            @Schema(description = "연결선 코멘트", example = "로그인 성공 시 대시보드로 이동")
+            String comment,
+            @Schema(description = "연결선을 만든 사용자 정보")
+            LinkCreatorItem createdBy,
+            @Schema(description = "연결선 생성 시각", example = "2026-04-19T10:15:30")
+            LocalDateTime createdAt
+    ) {
+
+        public static LinkedNodeItem of(final Long nodeId, final Edge edge) {
+            boolean isStart = nodeId.equals(edge.getStartNodeId());
+            NodeLinkType linkType = isStart ? NodeLinkType.START : NodeLinkType.END;
+            Node linkedNode = isStart ? edge.getEndNode() : edge.getStartNode();
+
+            return new LinkedNodeItem(
+                    edge.getId(),
+                    linkType,
+                    linkedNode.getId(),
+                    linkedNode.getNumber(),
+                    linkedNode.getTitle(),
+                    linkedNode.getDescription(),
+                    edge.getComment(),
+                    LinkCreatorItem.from(edge.getCreatedBy()),
+                    edge.getCreatedAt()
+            );
+        }
+    }
+
+    @Schema(description = "연결선을 만든 사용자 정보")
+    public record LinkCreatorItem(
+            @Schema(description = "사용자 ID", example = "91")
+            Long userId,
+            @Schema(description = "닉네임", example = "윤신지")
+            String nickname,
+            @Schema(description = "프로필 이미지 URL", example = "https://cdn.flowmeet.kr/profile/91.png")
+            String profileImageUrl
+    ) {
+
+        public static LinkCreatorItem from(final User user) {
+            return new LinkCreatorItem(user.getId(), user.getNickname(), user.getProfileImageUrl());
+        }
+    }
+
+    @Schema(description = "조회한 노드의 연결선 내 역할 (START: 시작 노드, END: 끝 노드)")
+    public enum NodeLinkType {
+        START,
+        END
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -18,6 +18,7 @@ import kr.flowmeet.api.node.dto.request.UpdateNodeKanbanRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
 import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
+import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
@@ -217,6 +218,19 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeStatus(projectId, nodeId, request.toCommand());
+    }
+
+    public GetLinkedNodesResponse getLinkedNodes(
+            final Long userId,
+            final Long projectId,
+            final Long nodeId
+    ) {
+        projectPermissionValidator.validate(projectId, userId);
+        nodeValidator.validateIsIn(nodeId, projectId);
+
+        List<Edge> edges = edgeService.findAllLinkedByNodeId(projectId, nodeId);
+
+        return GetLinkedNodesResponse.of(nodeId, edges);
     }
 
     public SearchNodeResponse search(final Long userId, final Long projectId, final String query) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
@@ -18,6 +18,7 @@ public enum NodeSuccessCode implements SuccessCode {
     GET_KANBAN("칸반 보드를 조회했어요."),
     UPDATE_NODE_KANBAN("칸반 카드를 옮겼어요."),
     UPDATE_NODE_STATUS("노드 상태를 변경했어요."),
+    GET_LINKED_NODES("연결된 노드를 조회했어요."),
     SEARCH("검색을 완료했어요.");
 
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import kr.flowmeet.domain.node.entity.Edge;
 
-public interface EdgeRepository extends JpaRepository<Edge, Long> {
+public interface EdgeRepository extends JpaRepository<Edge, Long>, EdgeRepositoryCustom {
 
     List<Edge> findAllByProjectId(Long projectId);
 
@@ -24,8 +24,4 @@ public interface EdgeRepository extends JpaRepository<Edge, Long> {
 
     @Query("SELECT e FROM Edge e JOIN FETCH e.createdBy WHERE e.projectId = :projectId")
     List<Edge> findAllWithCreatedBy(@Param("projectId") Long projectId);
-
-    @Query("SELECT e FROM Edge e JOIN FETCH e.startNode JOIN FETCH e.endNode JOIN FETCH e.createdBy "
-            + "WHERE e.projectId = :projectId AND (e.startNodeId = :nodeId OR e.endNodeId = :nodeId)")
-    List<Edge> findAllLinkedByNodeId(@Param("projectId") Long projectId, @Param("nodeId") Long nodeId);
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepository.java
@@ -24,4 +24,8 @@ public interface EdgeRepository extends JpaRepository<Edge, Long> {
 
     @Query("SELECT e FROM Edge e JOIN FETCH e.createdBy WHERE e.projectId = :projectId")
     List<Edge> findAllWithCreatedBy(@Param("projectId") Long projectId);
+
+    @Query("SELECT e FROM Edge e JOIN FETCH e.startNode JOIN FETCH e.endNode JOIN FETCH e.createdBy "
+            + "WHERE e.projectId = :projectId AND (e.startNodeId = :nodeId OR e.endNodeId = :nodeId)")
+    List<Edge> findAllLinkedByNodeId(@Param("projectId") Long projectId, @Param("nodeId") Long nodeId);
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepositoryCustom.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kr.flowmeet.domain.node.repository;
+
+import java.util.List;
+import kr.flowmeet.domain.node.entity.Edge;
+
+public interface EdgeRepositoryCustom {
+
+    List<Edge> findAllLinkedByNodeId(Long projectId, Long nodeId);
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepositoryCustomImpl.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/repository/EdgeRepositoryCustomImpl.java
@@ -1,0 +1,37 @@
+package kr.flowmeet.domain.node.repository;
+
+import static kr.flowmeet.domain.node.entity.QEdge.edge;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import kr.flowmeet.domain.node.entity.Edge;
+
+@RequiredArgsConstructor
+public class EdgeRepositoryCustomImpl implements EdgeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Edge> findAllLinkedByNodeId(final Long projectId, final Long nodeId) {
+        return queryFactory
+                .selectFrom(edge)
+                .innerJoin(edge.startNode).fetchJoin()
+                .innerJoin(edge.endNode).fetchJoin()
+                .innerJoin(edge.createdBy).fetchJoin()
+                .where(
+                        projectIdEq(projectId),
+                        nodeIdContains(nodeId)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression projectIdEq(final Long projectId) {
+        return projectId == null ? null : edge.projectId.eq(projectId);
+    }
+
+    private BooleanExpression nodeIdContains(final Long nodeId) {
+        return nodeId == null ? null : edge.startNodeId.eq(nodeId).or(edge.endNodeId.eq(nodeId));
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/EdgeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/EdgeService.java
@@ -26,6 +26,10 @@ public class EdgeService {
                 .orElseThrow(() -> new BusinessException(EdgeErrorCode.EDGE_NOT_FOUND));
     }
 
+    public List<Edge> findAllLinkedByNodeId(final Long projectId, final Long nodeId) {
+        return edgeRepository.findAllLinkedByNodeId(projectId, nodeId);
+    }
+
     @Transactional
     public Edge create(final Long projectId, final Long createdById, final CreateEdgeCommand command) {
         Long startNodeId = command.startNodeId();


### PR DESCRIPTION
## #️⃣연관된 이슈

#134

## 📝작업 내용

노드 상세 페이지의 "참조 노드" 모달에 들어갈 **연결된 노드 조회 API**를 추가했어요. 이미 만들어 둔 `Edge` 도메인을 그대로 활용해 특정 노드와 연결된 상대 노드 목록을 내려줍니다.

<img width="800" height="718" alt="참조 노드 모달" src="https://github.com/user-attachments/assets/3c27c1d5-65ec-43d0-b2b7-16de2976d45f" />

<br>

| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/v1/projects/{projectId}/nodes/{nodeId}/linked-nodes` | 노드와 연결선으로 이어진 상대 노드 목록 조회 |

### 1. 연결된 노드 조회 API (`feat`)

- `NodeApi`, `NodeController`에 `getLinkedNodes` 추가 — 기존 `/v1/projects/{projectId}` prefix를 따라 `/nodes/{nodeId}/linked-nodes`로 매핑
- `NodeFacade#getLinkedNodes` — 프로젝트 권한 검증 → 노드가 프로젝트에 속하는지 확인 → 연결된 엣지 조회 → 응답 변환
- `EdgeService#findAllLinkedByNodeId(projectId, nodeId)` 추가
- 성공 코드 `NodeSuccessCode.GET_LINKED_NODES("연결된 노드를 조회했어요.")` 추가
- 노드 미존재 시 기존 `NodeErrorCode.NODE_NOT_FOUND` 재사용

### 2. 응답 DTO `GetLinkedNodesResponse` (`feat`)

- `LinkedNodeItem` — 상대 노드 정보(`linkedNodeId`, `number`, `title`, `description`)와 엣지 정보(`edgeId`, `comment`, `createdAt`), 연결한 사용자(`LinkCreatorItem`)를 함께 내려줌
- DTO 내부에 `NodeLinkType { START, END }` enum 정의
  - 조회한 노드가 엣지의 `startNodeId`이면 `START`, `endNodeId`이면 `END`
  - "이 노드가 연결선 위에서 어떤 역할인지"를 한 필드로 표현
- 모달의 `연결한 사람: 윤신지` 표기를 위해 `LinkCreatorItem`(userId, nickname, profileImageUrl) 포함

### 3. QueryDSL 적용 (`refactor`)

처음에는 `EdgeRepository`에 `@Query`로 JPQL을 직접 작성했지만, 다른 도메인(`Node`, `Project`, `ChatSession` 등)이 모두 `*RepositoryCustom` + `*RepositoryCustomImpl` 패턴으로 QueryDSL을 쓰고 있어 일관성을 위해 전환했어요.

- `EdgeRepositoryCustom` 인터페이스 + `EdgeRepositoryCustomImpl` 신설
- `EdgeRepository`가 `EdgeRepositoryCustom`을 추가 구현하도록 확장
- 조건은 `BooleanExpression` private 메서드(`projectIdEq`, `nodeIdContains`)로 분리해 null-safe 동적 조건 패턴을 따름
- `startNode`, `endNode`, `createdBy` 모두 `innerJoin().fetchJoin()`으로 한 번에 가져와 N+1 방지

## 💬리뷰 요구사항(선택)
