### PR TITLE
[Feat/#176] 노드 상태에 보류, 종료 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -114,7 +114,7 @@ public interface NodeApi {
             @Valid @RequestBody UpdateNodeKanbanRequest request
     );
 
-    @Operation(summary = "노드 상태 변경", description = "노드의 상태(WAITING/IN_PROGRESS/DONE)만 변경합니다.")
+    @Operation(summary = "노드 상태 변경", description = "노드의 상태(WAITING/IN_PROGRESS/ON_HOLD/DONE/CLOSED)만 변경합니다.")
     @ApiSuccessCode(code = NodeSuccessCode.class, name = "UPDATE_NODE_STATUS")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     CommonResponse<?> updateNodeStatus(

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeKanbanRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeKanbanRequest.java
@@ -8,7 +8,7 @@ import kr.flowmeet.domain.node.service.vo.UpdateNodeKanbanCommand;
 
 @Schema(description = "칸반 카드 이동(드래그 앤 드롭) 요청")
 public record UpdateNodeKanbanRequest(
-        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
         @NotNull(message = ValidationMessage.NODE_STATUS_REQUIRED)
         NodeStatus status,
         @Schema(description = "칸반 내 정렬 순서", example = "1024")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/UpdateNodeStatusRequest.java
@@ -8,7 +8,7 @@ import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
 
 @Schema(description = "노드 상태 변경 요청")
 public record UpdateNodeStatusRequest(
-        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+        @Schema(description = "변경할 노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
         @NotNull(message = ValidationMessage.NODE_STATUS_REQUIRED)
         NodeStatus status
 ) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
@@ -56,7 +56,7 @@ public record GetFlowchartResponse(
             String title,
             @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
             String description,
-            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
             String status,
             @Schema(description = "같은 상태 내 정렬 순서", example = "1024")
             int sortOrder,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
@@ -15,8 +15,12 @@ public record GetKanbanResponse(
         List<KanbanItem> waiting,
         @Schema(description = "진행 중 상태의 노드 목록")
         List<KanbanItem> inProgress,
+        @Schema(description = "보류 상태의 노드 목록")
+        List<KanbanItem> onHold,
         @Schema(description = "완료 상태의 노드 목록")
-        List<KanbanItem> done
+        List<KanbanItem> done,
+        @Schema(description = "종료 상태의 노드 목록")
+        List<KanbanItem> closed
 ) {
 
     public static GetKanbanResponse of(
@@ -27,7 +31,9 @@ public record GetKanbanResponse(
         return new GetKanbanResponse(
                 toKanbanItems(statusMap.getOrDefault(NodeStatus.WAITING, List.of()), nodeTagMap, assigneeMap),
                 toKanbanItems(statusMap.getOrDefault(NodeStatus.IN_PROGRESS, List.of()), nodeTagMap, assigneeMap),
-                toKanbanItems(statusMap.getOrDefault(NodeStatus.DONE, List.of()), nodeTagMap, assigneeMap)
+                toKanbanItems(statusMap.getOrDefault(NodeStatus.ON_HOLD, List.of()), nodeTagMap, assigneeMap),
+                toKanbanItems(statusMap.getOrDefault(NodeStatus.DONE, List.of()), nodeTagMap, assigneeMap),
+                toKanbanItems(statusMap.getOrDefault(NodeStatus.CLOSED, List.of()), nodeTagMap, assigneeMap)
         );
     }
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
@@ -43,7 +43,7 @@ public record GetNodeListResponse(
             String title,
             @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
             String description,
-            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
             String status,
             @Schema(description = "부여된 태그 목록")
             List<TagItem> tags,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
@@ -26,7 +26,7 @@ public record GetNodeResponse(
         String description,
         @Schema(description = "노트 내용(마크다운)", example = "## 로그인 시나리오\n- Google OAuth ...")
         String noteContent,
-        @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+        @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
         String status,
         @Schema(description = "같은 상태 내 정렬 순서", example = "1024")
         int sortOrder,

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/SearchNodeResponse.java
@@ -38,7 +38,7 @@ public record SearchNodeResponse(
             String title,
             @Schema(description = "노드 설명", example = "OAuth2 로그인 플로우 정리")
             String description,
-            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "DONE"})
+            @Schema(description = "노드 상태", example = "IN_PROGRESS", allowableValues = {"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"})
             String status,
             @Schema(description = "부여된 태그 목록")
             List<TagItem> tags,

--- a/backend/flowmeet-api/src/main/resources/db/migration/V14__add_node_status_check.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V14__add_node_status_check.sql
@@ -1,0 +1,14 @@
+-- =========================================================
+-- V14__add_node_status_check.sql
+-- nodes.status를 NodeStatus enum 값으로 제한
+-- =========================================================
+
+ALTER TABLE nodes
+    ADD CONSTRAINT ck_nodes_status
+    CHECK (status IN (
+        'WAITING',
+        'IN_PROGRESS',
+        'ON_HOLD',
+        'DONE',
+        'CLOSED'
+    ));

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/NodeStatus.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/NodeStatus.java
@@ -1,5 +1,5 @@
 package kr.flowmeet.domain.node.entity;
 
 public enum NodeStatus {
-    WAITING, IN_PROGRESS, DONE
+    WAITING, IN_PROGRESS, ON_HOLD, DONE, CLOSED
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#176

## 📝작업 내용

기존 `WAITING / IN_PROGRESS / DONE` 3단계 노드 상태에 **잠깐 멈춘 상태**와 **아예 폐기한 상태**를 표현할 두 값을 추가했어요.

| enum | 한국어 | 의미 |
|---|---|---|
| `ON_HOLD` | 보류 | 진행하다가 외부 의존성·우선순위 때문에 잠깐 멈춘 상태. 다시 재개할 여지가 있음 |
| `CLOSED` | 종료 | 더 이상 진행하지 않기로 결정한 상태. 완료(`DONE`)와 달리 "끝까지 안 함" |

칸반 흐름은 `WAITING → IN_PROGRESS → ON_HOLD → DONE → CLOSED` 순서로 정렬했어요.

### 1. NodeStatus enum 값 추가 (`feat`)

- `kr.flowmeet.domain.node.entity.NodeStatus`에 `ON_HOLD`, `CLOSED` 추가
- 선언 순서를 칸반 흐름과 일치하도록 정렬

### 2. nodes.status CHECK 제약 추가 (`feat`)

- `V14__add_node_status_check.sql` 신설
  - `ck_nodes_status` 제약으로 5개 enum 값(`WAITING`, `IN_PROGRESS`, `ON_HOLD`, `DONE`, `CLOSED`)만 허용
- 기존 데이터는 모두 enum 값이라 별도 백필은 불필요
- V4(`tags.color` CHECK 추가)와 동일한 패턴

### 3. 신규 상태를 API 응답/요청에 노출 (`feat`)

#### Swagger `allowableValues` 일괄 갱신

- `UpdateNodeStatusRequest`, `UpdateNodeKanbanRequest` (요청)
- `GetNodeResponse`, `GetFlowchartResponse`, `GetNodeListResponse`, `SearchNodeResponse` (응답)
- 모두 `{"WAITING", "IN_PROGRESS", "ON_HOLD", "DONE", "CLOSED"}`로 통일

#### `GetKanbanResponse` 그룹 확장

- 기존 `waiting / inProgress / done` → `waiting / inProgress / onHold / done / closed` 5개 그룹
- 칸반 보드에 5개 컬럼으로 노출할지, `closed`만 별도 "보관함" 뷰로 분리할지는 프론트가 결정할 수 있는 구조
- 그룹핑 로직은 기존 `Map<NodeStatus, List<Node>>` 기반이라 추가 쿼리 없음

#### `NodeApi#updateNodeStatus`

- Operation description을 `WAITING/IN_PROGRESS/ON_HOLD/DONE/CLOSED`로 갱신

## 💬리뷰 요구사항(선택)

@sinji2102 님 한국 표시 이름 아래 참고 부탁드립니다.
- ON_HOLD (보류)
- CLOSED (종료)
