### PR TITLE
[Feat/#180] 노드 담당자 응답에 assigneeId 노출

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AssigneeItem.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AssigneeItem.java
@@ -1,10 +1,13 @@
 package kr.flowmeet.api.node.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.user.entity.User;
 
 @Schema(description = "노드 담당자 정보")
 public record AssigneeItem(
+        @Schema(description = "노드 담당자 ID", example = "10")
+        Long assigneeId,
         @Schema(description = "사용자 ID", example = "91")
         Long userId,
         @Schema(description = "닉네임", example = "플로우민")
@@ -15,7 +18,8 @@ public record AssigneeItem(
         String profileImageUrl
 ) {
 
-    public static AssigneeItem from(final User user) {
-        return new AssigneeItem(user.getId(), user.getNickname(), user.getEmail(), user.getProfileImageUrl());
+    public static AssigneeItem from(final NodeAssignee assignee) {
+        final User user = assignee.getUser();
+        return new AssigneeItem(assignee.getId(), user.getId(), user.getNickname(), user.getEmail(), user.getProfileImageUrl());
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
@@ -88,7 +88,7 @@ public record GetFlowchartResponse(
                     node.getStatus().name(),
                     node.getSortOrder(),
                     nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList(),
-                    nodeAssignees.stream().map(na -> AssigneeItem.from(na.getUser())).toList(),
+                    nodeAssignees.stream().map(AssigneeItem::from).toList(),
                     hasMeeting,
                     childNodeIds,
                     node.getUpdatedAt()

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetKanbanResponse.java
@@ -82,7 +82,7 @@ public record GetKanbanResponse(
                     node.getTitle(),
                     node.getSortOrder(),
                     nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList(),
-                    nodeAssignees.stream().map(na -> AssigneeItem.from(na.getUser())).toList(),
+                    nodeAssignees.stream().map(AssigneeItem::from).toList(),
                     node.getCreatedAt(),
                     node.getUpdatedAt()
             );

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeListResponse.java
@@ -68,7 +68,7 @@ public record GetNodeListResponse(
                     node.getDescription(),
                     node.getStatus().name(),
                     nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList(),
-                    nodeAssignees.stream().map(na -> AssigneeItem.from(na.getUser())).toList(),
+                    nodeAssignees.stream().map(AssigneeItem::from).toList(),
                     hasMeeting,
                     node.getUpdatedAt()
             );

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import kr.flowmeet.domain.meeting.entity.Meeting;
 import kr.flowmeet.domain.meeting.entity.MeetingParticipant;
 import kr.flowmeet.domain.node.entity.Node;
+import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.node.entity.Tag;
 import kr.flowmeet.domain.user.entity.User;
 
@@ -45,7 +46,7 @@ public record GetNodeResponse(
     public static GetNodeResponse of(
             final Node node,
             final List<Tag> tags,
-            final List<User> assignees,
+            final List<NodeAssignee> assignees,
             final Meeting meeting,
             final List<MeetingParticipant> meetingParticipants,
             final Map<Long, User> userMap

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import kr.flowmeet.domain.common.BaseTimeEntity;
 import kr.flowmeet.domain.node.service.NodeSortType;
 import kr.flowmeet.domain.node.service.NodeValidator;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
@@ -76,7 +75,7 @@ public class NodeFacade {
         Node node = nodeService.findByIdAndProjectId(nodeId, projectId);
         List<Tag> tags = nodeTagService.findAllTagsByNodeId(nodeId);
 
-        List<User> assignees = nodeAssigneeService.findAllUsersByNodeId(nodeId);
+        List<NodeAssignee> assignees = nodeAssigneeService.findAllByNodeId(nodeId);
         Meeting meeting = meetingService.findByNodeId(nodeId)
             .orElse(null);
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeAssigneeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeAssigneeService.java
@@ -27,13 +27,6 @@ public class NodeAssigneeService {
         return nodeAssigneeRepository.findAllWithUserByNodeIdIn(nodeIds);
     }
 
-    public List<User> findAllUsersByNodeId(final Long nodeId) {
-        return findAllByNodeId(nodeId)
-                .stream()
-                .map(NodeAssignee::getUser)
-                .toList();
-    }
-
     public Map<Long, List<NodeAssignee>> findAllByNodeIdsAsMap(final List<Long> nodeIds) {
         return findAllByNodeIds(nodeIds)
                 .stream()


### PR DESCRIPTION
## #️⃣연관된 이슈

#180

## 📝작업 내용

노드 담당자 삭제 API(`DELETE /v1/projects/{projectId}/nodes/{nodeId}/assignees/{assigneeId}`)는 `NodeAssignee.id`를 path variable로 받지만, 그동안 노드 조회 응답에는 `assigneeId`가 포함되지 않아 프론트가 삭제 호출에 필요한 ID를 알 수 없었어요. 이번 PR에서는 모든 노드 조회 응답의 담당자 정보에 `assigneeId`를 함께 내려주도록 보완했어요.

### 1. `AssigneeItem`에 `assigneeId` 필드 추가

- `AssigneeItem`을 `User`가 아닌 `NodeAssignee` 기준으로 생성하도록 팩토리 메서드 시그니처 변경
  - `from(User user)` → `from(NodeAssignee assignee)`
- 응답 필드 순서: `assigneeId` → `userId` → `nickname` → `email` → `profileImageUrl`

### 2. 호출 측 일괄 정리

- `GetFlowchartResponse`, `GetKanbanResponse`, `GetNodeListResponse`에서 `na -> AssigneeItem.from(na.getUser())` 람다를 `AssigneeItem::from` 메서드 참조로 정리
- `GetNodeResponse.of(...)`의 `assignees` 파라미터 타입을 `List<User>` → `List<NodeAssignee>`로 변경
- `NodeFacade#findById`에서 호출하던 `nodeAssigneeService.findAllUsersByNodeId(...)`를 `findAllByNodeId(...)`로 교체
- 더 이상 사용처가 없는 `NodeAssigneeService#findAllUsersByNodeId` 제거

## 💬리뷰 요구사항(선택)

간단한 요구사항 반영이라 바로 머지하도록 하겠습니다!!