### PR TITLE
[Feat/#185] AI 요약 결과 도메인 저장 및 메인 노드 요약 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/LlmResponseHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/LlmResponseHandler.java
@@ -1,0 +1,82 @@
+package kr.flowmeet.api.ai.handler;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.flowmeet.api.node.event.NodeSummaryRequestEvent;
+import kr.flowmeet.domain.ai.entity.AiTask;
+import kr.flowmeet.domain.ai.entity.AiTaskType;
+import kr.flowmeet.domain.ai.service.AiTaskService;
+import kr.flowmeet.domain.meeting.entity.Meeting;
+import kr.flowmeet.domain.meeting.service.MeetingService;
+import kr.flowmeet.domain.node.entity.Node;
+import kr.flowmeet.domain.node.service.NodeService;
+import kr.flowmeet.external.sqs.dto.LlmResponseMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LlmResponseHandler {
+
+    private final AiTaskService aiTaskService;
+    private final MeetingService meetingService;
+    private final NodeService nodeService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public AiTask completeAndSave(final LlmResponseMessage response) {
+        AiTask task = aiTaskService.complete(response.jobId());
+
+        if (response.result() == null) {
+            log.warn("LLM 응답에 result가 없음 - jobId: {}", response.jobId());
+            return task;
+        }
+
+        if (response.isSubSummary()) {
+            String summary = response.result().get("summary").asText();
+            String mermaidCode = response.result().get("mermaid_code").asText();
+            meetingService.saveSummary(task.getReferenceId(), summary, mermaidCode);
+            try {
+                tryTriggerMainSummary(task);
+            } catch (Exception e) {
+                log.error("main-summary 자동 트리거 실패 - jobId: {}", task.getId(), e);
+            }
+        } else if (response.isMainSummary()) {
+            String summary = response.result().asText();
+            nodeService.saveSummary(task.getReferenceId(), summary);
+        }
+
+        return task;
+    }
+
+    private void tryTriggerMainSummary(final AiTask task) {
+        Meeting meeting = meetingService.findById(task.getReferenceId());
+        Node node = nodeService.findById(meeting.getNodeId());
+
+        if (node.getParentId() == null) {
+            return;
+        }
+
+        List<Node> childNodes = nodeService.findAllByParentId(node.getParentId());
+        List<Long> childNodeIds = childNodes.stream().map(Node::getId).toList();
+        List<Meeting> meetings = meetingService.findAllByNodeIds(childNodeIds);
+
+        Map<Long, Meeting> meetingByNodeId = meetings.stream()
+                .collect(Collectors.toMap(Meeting::getNodeId, m -> m, (a, b) -> a));
+
+        String mergedText = NodeSummaryTextMerger.merge(childNodes, meetingByNodeId);
+        if (mergedText.isEmpty()) {
+            return;
+        }
+
+        AiTask mainTask = aiTaskService.create(task.getUserId(), node.getParentId(), AiTaskType.MAIN_SUMMARY);
+        eventPublisher.publishEvent(new NodeSummaryRequestEvent(mainTask.getId(), mergedText));
+        log.info("sub-summary 완료 → main-summary 자동 트리거 - parentNodeId: {}, jobId: {}",
+                node.getParentId(), mainTask.getId());
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/NodeSummaryTextMerger.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/NodeSummaryTextMerger.java
@@ -1,0 +1,24 @@
+package kr.flowmeet.api.ai.handler;
+
+import java.util.List;
+import java.util.Map;
+import kr.flowmeet.domain.meeting.entity.Meeting;
+import kr.flowmeet.domain.node.entity.Node;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NodeSummaryTextMerger {
+
+    public static String merge(final List<Node> childNodes, final Map<Long, Meeting> meetingByNodeId) {
+        StringBuilder textBuilder = new StringBuilder();
+        for (Node child : childNodes) {
+            Meeting meeting = meetingByNodeId.get(child.getId());
+            if (meeting != null && meeting.getSummary() != null) {
+                textBuilder.append("name: ").append(child.getTitle())
+                        .append(" \"").append(meeting.getSummary()).append("\"  ");
+            }
+        }
+        return textBuilder.toString().trim();
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
@@ -1,13 +1,19 @@
 package kr.flowmeet.api.ai.listener;
 
+import java.io.IOException;
+import java.util.Map;
 import tools.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.annotation.SqsListener;
+import kr.flowmeet.api.ai.handler.LlmResponseHandler;
+import kr.flowmeet.api.notification.sse.SseEmitterStore;
+import kr.flowmeet.domain.ai.entity.AiTask;
 import kr.flowmeet.domain.ai.service.AiTaskService;
 import kr.flowmeet.external.sqs.dto.LlmResponseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
 @Component
@@ -17,6 +23,8 @@ public class LlmResponseListener {
 
     private final ObjectMapper objectMapper;
     private final AiTaskService aiTaskService;
+    private final LlmResponseHandler llmResponseHandler;
+    private final SseEmitterStore sseEmitterStore;
 
     @SqsListener("${cloud.aws.sqs.response-queue-url}")
     public void handle(final String payload) {
@@ -26,24 +34,33 @@ public class LlmResponseListener {
 
             if (!response.isSuccess()) {
                 log.error("LLM 처리 실패 - jobId: {}, error: {}", response.jobId(), response.error());
-                aiTaskService.fail(response.jobId(), response.error());
+                AiTask failedTask = aiTaskService.fail(response.jobId(), response.error());
+                notifyUser(failedTask);
                 return;
             }
 
-            if (response.isSubSummary()) {
-                String summary = response.result().get("summary").asText();
-                String mermaidCode = response.result().get("mermaid_code").asText();
-                aiTaskService.complete(response.jobId(), summary, mermaidCode);
-            } else {
-                String result = response.result().asText();
-                aiTaskService.complete(response.jobId(), result, null);
-            }
+            AiTask completedTask = llmResponseHandler.completeAndSave(response);
 
             log.info("LLM 처리 완료 - jobId: {}, taskType: {}", response.jobId(), response.taskType());
+            notifyUser(completedTask);
         } catch (Exception e) {
             log.error("LLM 응답 처리 실패 - payload: {}", payload, e);
             tryMarkFailed(payload, e);
         }
+    }
+
+    private void notifyUser(final AiTask task) {
+        sseEmitterStore.findByUserId(task.getUserId())
+                .ifPresent(emitter -> {
+                    try {
+                        emitter.send(SseEmitter.event()
+                                .name("ai-task-done")
+                                .data(Map.of("jobId", task.getId())));
+                    } catch (IOException e) {
+                        sseEmitterStore.remove(task.getUserId());
+                        log.debug("[SSE] AI 결과 알림 전송 실패, 연결 제거: userId={}", task.getUserId());
+                    }
+                });
     }
 
     private void tryMarkFailed(final String payload, final Exception cause) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -20,6 +20,7 @@ import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
 import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
+import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.api.node.success.NodeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
@@ -128,6 +129,15 @@ public interface NodeApi {
     @ApiSuccessCode(code = NodeSuccessCode.class, name = "GET_LINKED_NODES")
     @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND"})
     CommonResponse<GetLinkedNodesResponse> getLinkedNodes(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
+    );
+
+    @Operation(summary = "메인 노드 요약 요청", description = "하위 노드의 회의록 요약을 종합하여 메인 노드 요약을 요청합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "REQUEST_NODE_SUMMARY")
+    @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND", "NO_CHILD_SUMMARY"})
+    CommonResponse<RequestNodeSummaryResponse> requestNodeSummary(
             @UserId Long userId,
             @PathVariable Long projectId,
             @PathVariable Long nodeId

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -23,6 +23,7 @@ import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
 import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
+import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.api.node.facade.NodeFacade;
 import kr.flowmeet.api.node.success.NodeSuccessCode;
@@ -164,6 +165,17 @@ public class NodeController implements NodeApi {
                 NodeSuccessCode.GET_LINKED_NODES,
                 nodeFacade.getLinkedNodes(userId, projectId, nodeId)
         );
+    }
+
+    @Override
+    @PostMapping("/nodes/{nodeId}/summary")
+    public CommonResponse<RequestNodeSummaryResponse> requestNodeSummary(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId
+    ) {
+        RequestNodeSummaryResponse response = nodeFacade.requestNodeSummary(userId, projectId, nodeId);
+        return CommonResponse.ok(NodeSuccessCode.REQUEST_NODE_SUMMARY, response);
     }
 
     @Override

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetNodeResponse.java
@@ -37,6 +37,8 @@ public record GetNodeResponse(
         List<AssigneeItem> assignees,
         @Schema(description = "연결된 회의 정보 (없으면 null)")
         MeetingItem meeting,
+        @Schema(description = "하위 노드 회의록을 종합한 AI 요약 (하위 노드가 없거나 생성 전이라면 null)")
+        String summary,
         @Schema(description = "생성 시각", example = "2026-03-01T09:00:00")
         LocalDateTime createdAt,
         @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
@@ -64,6 +66,7 @@ public record GetNodeResponse(
                 tags.stream().map(TagItem::from).toList(),
                 assignees.stream().map(AssigneeItem::from).toList(),
                 meeting != null ? MeetingItem.of(meeting, meetingParticipants, userMap) : null,
+                node.getSummary(),
                 node.getCreatedAt(),
                 node.getUpdatedAt()
         );
@@ -83,8 +86,10 @@ public record GetNodeResponse(
             LocalDateTime pushNotifyAt,
             @Schema(description = "화상 회의 링크", example = "https://meet.google.com/abc-defg-hij")
             String meetingUrl,
-            @Schema(description = "AI 요약 (생성 전이라면 null)")
+            @Schema(description = "회의록 AI 요약 (생성 전이라면 null)")
             String summary,
+            @Schema(description = "Mermaid 다이어그램 코드 (생성 전이라면 null)")
+            String mermaidCode,
             @Schema(description = "참여자 목록")
             List<ParticipantItem> participants,
             @Schema(description = "회의 생성자")
@@ -106,6 +111,7 @@ public record GetNodeResponse(
                     meeting.getPushNotifyAt(),
                     meeting.getMeetingUrl(),
                     meeting.getSummary(),
+                    meeting.getMermaidCode(),
                     participants.stream()
                             .map(p -> ParticipantItem.of(p, userMap.get(p.getUserId())))
                             .toList(),

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/RequestNodeSummaryResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/RequestNodeSummaryResponse.java
@@ -1,0 +1,13 @@
+package kr.flowmeet.api.node.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메인 노드 요약 요청 응답")
+public record RequestNodeSummaryResponse(
+        @Schema(description = "AI 요약 작업 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        String jobId
+) {
+    public static RequestNodeSummaryResponse from(final String jobId) {
+        return new RequestNodeSummaryResponse(jobId);
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/event/NodeSummaryRequestEvent.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/event/NodeSummaryRequestEvent.java
@@ -1,0 +1,7 @@
+package kr.flowmeet.api.node.event;
+
+public record NodeSummaryRequestEvent(
+        String jobId,
+        String text
+) {
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/event/NodeSummaryRequestEventListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/event/NodeSummaryRequestEventListener.java
@@ -1,0 +1,29 @@
+package kr.flowmeet.api.node.event;
+
+import kr.flowmeet.domain.ai.service.AiTaskService;
+import kr.flowmeet.external.sqs.SqsMessageSender;
+import kr.flowmeet.external.sqs.dto.LlmRequestMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NodeSummaryRequestEventListener {
+
+    private final SqsMessageSender sqsMessageSender;
+    private final AiTaskService aiTaskService;
+
+    @TransactionalEventListener
+    public void handle(final NodeSummaryRequestEvent event) {
+        try {
+            log.info("메인 노드 요약 요청 이벤트 수신 - jobId: {}", event.jobId());
+            sqsMessageSender.send(new LlmRequestMessage(event.jobId(), "main-summary", event.text()));
+        } catch (Exception e) {
+            log.error("SQS 발행 실패 - jobId: {}", event.jobId(), e);
+            aiTaskService.fail(event.jobId(), e.getMessage());
+        }
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -5,11 +5,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import kr.flowmeet.api.ai.handler.NodeSummaryTextMerger;
+import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
+import kr.flowmeet.api.node.event.NodeSummaryRequestEvent;
+import kr.flowmeet.domain.ai.entity.AiTask;
+import kr.flowmeet.domain.ai.entity.AiTaskType;
+import kr.flowmeet.domain.ai.service.AiTaskService;
 import kr.flowmeet.domain.node.service.NodeSortType;
 import kr.flowmeet.domain.node.service.NodeValidator;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
@@ -21,6 +28,7 @@ import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
+import kr.flowmeet.domain.common.exception.BusinessException;
 import kr.flowmeet.domain.meeting.entity.Meeting;
 import kr.flowmeet.domain.meeting.entity.MeetingParticipant;
 import kr.flowmeet.domain.meeting.service.MeetingService;
@@ -30,6 +38,7 @@ import kr.flowmeet.domain.node.entity.NodeAssignee;
 import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.entity.NodeTag;
 import kr.flowmeet.domain.node.entity.Tag;
+import kr.flowmeet.domain.node.exception.NodeErrorCode;
 import kr.flowmeet.domain.node.service.EdgeService;
 import kr.flowmeet.domain.node.service.NodeAssigneeService;
 import kr.flowmeet.domain.node.service.NodeService;
@@ -52,6 +61,8 @@ public class NodeFacade {
     private final ProjectPermissionValidator projectPermissionValidator;
     private final NodeValidator nodeValidator;
     private final UserService userService;
+    private final AiTaskService aiTaskService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public GetFlowchartResponse getFlowchart(final Long userId, final Long projectId) {
         projectPermissionValidator.validate(projectId, userId);
@@ -230,6 +241,35 @@ public class NodeFacade {
         List<Edge> edges = edgeService.findAllLinkedByNodeId(projectId, nodeId);
 
         return GetLinkedNodesResponse.of(nodeId, edges);
+    }
+
+    // TODO: 추후 노트(noteContent) 포함 여부 검토
+    @Transactional
+    public RequestNodeSummaryResponse requestNodeSummary(
+            final Long userId,
+            final Long projectId,
+            final Long nodeId
+    ) {
+        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+
+        nodeValidator.validateIsIn(nodeId, projectId);
+        List<Node> childNodes = nodeService.findAllByParentId(nodeId);
+
+        List<Long> childNodeIds = childNodes.stream().map(Node::getId).toList();
+        List<Meeting> meetings = meetingService.findAllByNodeIds(childNodeIds);
+
+        Map<Long, Meeting> meetingByNodeId = meetings.stream()
+                .collect(Collectors.toMap(Meeting::getNodeId, m -> m, (a, b) -> a));
+
+        String mergedText = NodeSummaryTextMerger.merge(childNodes, meetingByNodeId);
+        if (mergedText.isEmpty()) {
+            throw new BusinessException(NodeErrorCode.NO_CHILD_SUMMARY);
+        }
+
+        AiTask aiTask = aiTaskService.create(userId, nodeId, AiTaskType.MAIN_SUMMARY);
+        eventPublisher.publishEvent(new NodeSummaryRequestEvent(aiTask.getId(), mergedText));
+
+        return RequestNodeSummaryResponse.from(aiTask.getId());
     }
 
     public SearchNodeResponse search(final Long userId, final Long projectId, final String query) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
@@ -19,6 +19,7 @@ public enum NodeSuccessCode implements SuccessCode {
     UPDATE_NODE_KANBAN("칸반 카드를 옮겼어요."),
     UPDATE_NODE_STATUS("노드 상태를 변경했어요."),
     GET_LINKED_NODES("연결된 노드를 조회했어요."),
+    REQUEST_NODE_SUMMARY("메인 노드 요약을 요청했어요."),
     SEARCH("검색을 완료했어요.");
 
     private final String message;

--- a/backend/flowmeet-api/src/main/resources/db/migration/V16__add_ai_tasks.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V16__add_ai_tasks.sql
@@ -7,8 +7,6 @@ CREATE TABLE ai_tasks (
     reference_id BIGINT       NOT NULL,
     task_type    VARCHAR(50)  NOT NULL,
     status       VARCHAR(50)  NOT NULL,
-    result       TEXT,
-    mermaid_code TEXT,
     error_message VARCHAR(500),
     created_at   TIMESTAMP    NOT NULL,
     updated_at   TIMESTAMP    NOT NULL,

--- a/backend/flowmeet-api/src/main/resources/db/migration/V17__add_mermaid_code_to_meetings.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V17__add_mermaid_code_to_meetings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE meetings ADD COLUMN mermaid_code TEXT;
+
+ALTER TABLE nodes ADD COLUMN summary TEXT;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
@@ -44,12 +44,6 @@ public class AiTask extends BaseTimeEntity {
     @Column(nullable = false)
     private AiTaskStatus status;
 
-    @Column(columnDefinition = "TEXT")
-    private String result;
-
-    @Column(name = "mermaid_code", columnDefinition = "TEXT")
-    private String mermaidCode;
-
     @Column(name = "error_message")
     private String errorMessage;
 
@@ -66,10 +60,8 @@ public class AiTask extends BaseTimeEntity {
         this.status = AiTaskStatus.PROCESSING;
     }
 
-    public void complete(final String result, final String mermaidCode) {
+    public void complete() {
         this.status = AiTaskStatus.COMPLETED;
-        this.result = result;
-        this.mermaidCode = mermaidCode;
     }
 
     public void fail(final String errorMessage) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
@@ -35,14 +35,16 @@ public class AiTaskService {
     }
 
     @Transactional
-    public void complete(final String jobId, final String result, final String mermaidCode) {
+    public AiTask complete(final String jobId) {
         AiTask task = findById(jobId);
-        task.complete(result, mermaidCode);
+        task.complete();
+        return task;
     }
 
     @Transactional
-    public void fail(final String jobId, final String errorMessage) {
+    public AiTask fail(final String jobId, final String errorMessage) {
         AiTask task = findById(jobId);
         task.fail(errorMessage);
+        return task;
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/entity/Meeting.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/entity/Meeting.java
@@ -72,6 +72,9 @@ public class Meeting extends BaseSoftDeleteEntity {
     @Column(columnDefinition = "TEXT")
     private String summary;
 
+    @Column(name = "mermaid_code", columnDefinition = "TEXT")
+    private String mermaidCode;
+
     @Column(name = "reminder_sent", nullable = false)
     private boolean reminderSent;
 
@@ -130,5 +133,10 @@ public class Meeting extends BaseSoftDeleteEntity {
 
     public void end() {
         this.status = MeetingStatus.ENDED;
+    }
+
+    public void saveSummary(final String summary, final String mermaidCode) {
+        this.summary = summary;
+        this.mermaidCode = mermaidCode;
     }
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
@@ -189,6 +189,12 @@ public class MeetingService {
         meetingParticipantRepository.saveAll(participants);
     }
 
+    @Transactional
+    public void saveSummary(final Long meetingId, final String summary, final String mermaidCode) {
+        Meeting meeting = findById(meetingId);
+        meeting.saveSummary(summary, mermaidCode);
+    }
+
     private void validateNoDuplicate(final Long nodeId) {
         if (meetingRepository.existsByNodeId(nodeId)) {
             throw new BusinessException(MeetingErrorCode.MEETING_ALREADY_EXISTS);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/entity/Node.java
@@ -79,6 +79,9 @@ public class Node extends BaseSoftDeleteEntity {
     @Column(name = "sort_order", nullable = false)
     private int sortOrder;
 
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
     @Builder
     public Node(Long projectId, Long parentId, String number, String title, String description,
                 NodeType type, String noteContent, NodeStatus status, int sortOrder) {
@@ -118,6 +121,10 @@ public class Node extends BaseSoftDeleteEntity {
 
     public void updateStatus(final NodeStatus status) {
         this.status = status;
+    }
+
+    public void saveSummary(final String summary) {
+        this.summary = summary;
     }
 
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
@@ -9,7 +9,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 @RequiredArgsConstructor
 public enum NodeErrorCode implements ErrorCode {
     NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 노드예요."),
-    ACTIVE_MEETING_EXISTS(HttpStatus.CONFLICT, "진행 중인 회의가 있는 노드는 삭제할 수 없어요.");
+    ACTIVE_MEETING_EXISTS(HttpStatus.CONFLICT, "진행 중인 회의가 있는 노드는 삭제할 수 없어요."),
+    NO_CHILD_SUMMARY(HttpStatus.BAD_REQUEST, "요약할 하위 노드 회의록이 없어요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
@@ -33,6 +33,15 @@ public class NodeService {
     private final NodeAssigneeRepository nodeAssigneeRepository;
     private final NodeTagRepository nodeTagRepository;
 
+    public Node findById(final Long nodeId) {
+        return nodeRepository.findById(nodeId)
+                .orElseThrow(() -> new BusinessException(NodeErrorCode.NODE_NOT_FOUND));
+    }
+
+    public List<Node> findAllByParentId(final Long parentId) {
+        return nodeRepository.findAllByParentId(parentId);
+    }
+
     public Node findByIdAndProjectId(final Long nodeId, final Long projectId) {
         return nodeRepository.findByIdAndProjectId(nodeId, projectId)
                 .orElseThrow(() -> new BusinessException(NodeErrorCode.NODE_NOT_FOUND));
@@ -190,5 +199,11 @@ public class NodeService {
         Node node = findByIdAndProjectId(nodeId, projectId);
 
         node.updateStatus(command.status());
+    }
+
+    @Transactional
+    public void saveSummary(final Long nodeId, final String summary) {
+        Node node = findById(nodeId);
+        node.saveSummary(summary);
     }
 }

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmResponseMessage.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/sqs/dto/LlmResponseMessage.java
@@ -20,4 +20,8 @@ public record LlmResponseMessage(
     public boolean isSubSummary() {
         return "sub-summary".equals(taskType);
     }
+
+    public boolean isMainSummary() {
+        return "main-summary".equals(taskType);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #185

## 📝작업 내용

### AiTask 구조 변경

- AiTask에서 `result`, `mermaidCode` 필드 제거 → 상태 추적 전용으로 변경
- `complete()` 메서드에서 result 파라미터 제거
- V16 마이그레이션에서 해당 컬럼 제거

### AI 요약 결과 도메인 직접 저장

- sub-summary 결과 → `Meeting.summary`, `Meeting.mermaidCode`에 저장
- main-summary 결과 → `Node.summary`에 저장
- `LlmResponseHandler` 추가: AiTask 완료 + 도메인 저장을 단일 트랜잭션으로 처리
- `LlmResponseListener`는 메시지 수신 + SSE 알림만 담당 (비즈니스 로직은 Handler에 위임)
- `NodeSummaryTextMerger` 추출: 하위 노드 회의록 텍스트 병합 로직 공통화

### 메인 노드 요약 요청 API + 자동 트리거

- `POST /v1/projects/{projectId}/nodes/{nodeId}/summary` 엔드포인트 추가
- sub-summary 완료 시 상위 노드에 대해 main-summary 자동 트리거
- `NodeSummaryRequestEvent` + `@TransactionalEventListener`로 트랜잭션 커밋 후 SQS 발행

### 기존 API 응답 필드 추가

- `GetNodeResponse`에 `summary` 필드 추가
- `GetNodeResponse.MeetingItem`에 `summary`, `mermaidCode` 필드 추가

### 방어 로직

- `Collectors.toMap()` duplicate key 방어 (merge function 추가)
- `response.result()` null 체크 (result 없으면 경고 로그 후 early return)
- `tryTriggerMainSummary()` 예외 격리 (try-catch로 sub-summary 저장 롤백 방지)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `domain/.../ai/entity/AiTask.java` | 수정 - result, mermaidCode 필드 제거 |
| `domain/.../ai/service/AiTaskService.java` | 수정 - complete() 파라미터 제거 |
| `domain/.../meeting/entity/Meeting.java` | 수정 - mermaidCode 필드, saveSummary() 추가 |
| `domain/.../meeting/service/MeetingService.java` | 수정 - saveSummary() 추가 |
| `domain/.../node/entity/Node.java` | 수정 - summary 필드, saveSummary() 추가 |
| `domain/.../node/service/NodeService.java` | 수정 - findById, findAllByParentId, saveSummary() 추가 |
| `domain/.../node/exception/NodeErrorCode.java` | 수정 - NO_CHILD_SUMMARY 추가 |
| `external/.../sqs/dto/LlmResponseMessage.java` | 수정 - isMainSummary() 추가 |
| `api/.../ai/handler/LlmResponseHandler.java` | 추가 - taskType 분기 + 도메인 저장 |
| `api/.../ai/handler/NodeSummaryTextMerger.java` | 추가 - 텍스트 병합 유틸 |
| `api/.../ai/listener/LlmResponseListener.java` | 수정 - Handler 위임으로 변경 |
| `api/.../node/controller/NodeApi.java` | 수정 - 메인 노드 요약 요청 Swagger |
| `api/.../node/controller/NodeController.java` | 수정 - 엔드포인트 추가 |
| `api/.../node/facade/NodeFacade.java` | 수정 - requestNodeSummary() 추가 |
| `api/.../node/success/NodeSuccessCode.java` | 수정 - REQUEST_NODE_SUMMARY 추가 |
| `api/.../node/dto/response/GetNodeResponse.java` | 수정 - summary, mermaidCode 필드 추가 |
| `api/.../node/dto/response/RequestNodeSummaryResponse.java` | 추가 |
| `api/.../node/event/NodeSummaryRequestEvent.java` | 추가 |
| `api/.../node/event/NodeSummaryRequestEventListener.java` | 추가 |
| `V16__add_ai_tasks.sql` | 수정 - result, mermaid_code 컬럼 제거 |
| `V17__add_mermaid_code_to_meetings.sql` | 추가 - meetings.mermaid_code, nodes.summary |

## 💬논의 사항(선택)

- `GetNodeResponse.summary`는 하위 노드 회의록을 종합한 AI 요약이라 서브 노드에서는 항상 null입니다. 네이밍이 헷갈릴 수 있는데, `mainSummary` 등으로 분리하는 게 나을지 의견 부탁드립니다.
