### PR TITLE
[Feat/#188] API Gateway 기반 드래그 노드 AI 분석 기능 구현

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,3 +58,11 @@ DISCORD_ERROR_CHANNEL_ID=
 # ---------- JVM ----------
 # t3.micro 에서 컨테이너 mem_limit(800m) 의 60% 를 힙으로 사용 → Xmx ≈ 480MB
 JAVA_OPTS=-XX:MaxRAMPercentage=60.0 -XX:+ExitOnOutOfMemoryError
+
+# ---------- AWS SQS ----------
+SQS_REQUEST_QUEUE_URL=
+SQS_RESPONSE_QUEUE_URL=
+SQS_REGION=ap-northeast-2
+
+# ---------- AI (API Gateway) ----------
+AI_NODE_ANALYSIS_ENDPOINT_URL=

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeApi.java
@@ -20,6 +20,10 @@ import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
 import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeListResponse;
 import kr.flowmeet.api.node.dto.response.GetNodeResponse;
+import kr.flowmeet.api.node.dto.request.AnalyzeDraggedNodesRequest;
+import kr.flowmeet.api.node.dto.response.AnalyzeDraggedNodesResponse;
+import kr.flowmeet.api.node.dto.request.AnalyzeDraggedNodesRequest;
+import kr.flowmeet.api.node.dto.response.AnalyzeDraggedNodesResponse;
 import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
 import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.api.node.success.NodeSuccessCode;
@@ -141,6 +145,15 @@ public interface NodeApi {
             @UserId Long userId,
             @PathVariable Long projectId,
             @PathVariable Long nodeId
+    );
+
+    @Operation(summary = "드래그 노드 분석", description = "드래그로 선택한 노드들의 회의록을 기반으로 AI 분석을 수행합니다.")
+    @ApiSuccessCode(code = NodeSuccessCode.class, name = "ANALYZE_DRAGGED_NODES")
+    @ApiErrorCode(code = NodeErrorCode.class, names = {"NODE_NOT_FOUND", "NOT_ENOUGH_SUMMARIES_FOR_ANALYSIS"})
+    CommonResponse<AnalyzeDraggedNodesResponse> analyzeDraggedNodes(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody AnalyzeDraggedNodesRequest request
     );
 
     @Operation(summary = "프로젝트 내 검색", description = "노드 제목, 키워드로 검색합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/NodeController.java
@@ -12,12 +12,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
+import kr.flowmeet.api.node.dto.request.AnalyzeDraggedNodesRequest;
 import kr.flowmeet.api.node.dto.request.CreateNodeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeDescriptionRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeKanbanRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeNoteRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeStatusRequest;
 import kr.flowmeet.api.node.dto.request.UpdateNodeTitleRequest;
+import kr.flowmeet.api.node.dto.response.AnalyzeDraggedNodesResponse;
 import kr.flowmeet.api.node.dto.response.GetFlowchartResponse;
 import kr.flowmeet.api.node.dto.response.GetKanbanResponse;
 import kr.flowmeet.api.node.dto.response.GetLinkedNodesResponse;
@@ -176,6 +178,19 @@ public class NodeController implements NodeApi {
     ) {
         RequestNodeSummaryResponse response = nodeFacade.requestNodeSummary(userId, projectId, nodeId);
         return CommonResponse.ok(NodeSuccessCode.REQUEST_NODE_SUMMARY, response);
+    }
+
+    @Override
+    @PostMapping("/nodes/analysis")
+    public CommonResponse<AnalyzeDraggedNodesResponse> analyzeDraggedNodes(
+            @UserId Long userId,
+            @PathVariable Long projectId,
+            @Valid @RequestBody AnalyzeDraggedNodesRequest request
+    ) {
+        return CommonResponse.ok(
+                NodeSuccessCode.ANALYZE_DRAGGED_NODES,
+                nodeFacade.analyzeDraggedNodes(userId, projectId, request.nodeIds())
+        );
     }
 
     @Override

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AnalyzeDraggedNodesRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/request/AnalyzeDraggedNodesRequest.java
@@ -1,0 +1,14 @@
+package kr.flowmeet.api.node.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "드래그 노드 분석 요청")
+public record AnalyzeDraggedNodesRequest(
+        @Schema(description = "분석할 노드 ID 목록 (최소 2개)", example = "[1, 2, 3]")
+        @NotEmpty
+        @Size(min = 2, message = "분석할 노드는 2개 이상 선택해야 해요.")
+        List<Long> nodeIds
+) {}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AnalyzeDraggedNodesResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AnalyzeDraggedNodesResponse.java
@@ -1,0 +1,78 @@
+package kr.flowmeet.api.node.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.flowmeet.external.ai.dto.NodeAnalysisResult;
+
+@Schema(description = "선택한 노드들의 회의록 기반 AI 분석 결과")
+public record AnalyzeDraggedNodesResponse(
+        @Schema(description = "회의 간 연관 관계 (구체화, 시너지, 선행조건 등)")
+        List<MeetingRelationshipItem> meetingRelationships,
+        @Schema(description = "회의에서 도출된 후속 업무의 담당자별 분배 현황")
+        ActionItemsAnalysisItem actionItemsAnalysis,
+        @Schema(description = "회의 내용 기반 AI 발전 아이디어 제안 (마크다운)")
+        String developmentIdeas,
+        @Schema(description = "회의 관계 시각화 Mermaid 코드")
+        String mermaidCode
+) {
+
+    public static AnalyzeDraggedNodesResponse from(final NodeAnalysisResult result) {
+        return new AnalyzeDraggedNodesResponse(
+                result.meetingRelationships().stream()
+                        .map(MeetingRelationshipItem::from)
+                        .toList(),
+                ActionItemsAnalysisItem.from(result.actionItemsAnalysis()),
+                result.developmentIdeas(),
+                result.mermaidCode()
+        );
+    }
+
+    @Schema(description = "회의 간 연관 관계")
+    public record MeetingRelationshipItem(
+            @Schema(description = "기준 회의 제목", example = "비즈니스 모델 전략 회의")
+            String from,
+            @Schema(description = "연관 회의 제목", example = "MVP기능 회의")
+            String to,
+            @Schema(description = "관계 유형 (구체화/변화 발생/시너지/선행조건/대체 가능/상충)", example = "구체화")
+            String relation,
+            @Schema(description = "해당 관계로 판단한 근거")
+            String reason
+    ) {
+        public static MeetingRelationshipItem from(final NodeAnalysisResult.MeetingRelationship relationship) {
+            return new MeetingRelationshipItem(
+                    relationship.from(), relationship.to(), relationship.relation(), relationship.reason()
+            );
+        }
+    }
+
+    @Schema(description = "후속 업무 담당자별 분배 현황")
+    public record ActionItemsAnalysisItem(
+            @Schema(description = "전체 후속 업무 수", example = "15")
+            int totalCount,
+            @Schema(description = "담당자별 업무 배분")
+            Map<String, PersonAnalysisItem> byPerson
+    ) {
+        public static ActionItemsAnalysisItem from(final NodeAnalysisResult.ActionItemsAnalysis analysis) {
+            Map<String, PersonAnalysisItem> byPerson = analysis.byPerson().entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> PersonAnalysisItem.from(e.getValue())
+                    ));
+            return new ActionItemsAnalysisItem(analysis.totalCount(), byPerson);
+        }
+    }
+
+    @Schema(description = "담당자별 업무 배분")
+    public record PersonAnalysisItem(
+            @Schema(description = "배정된 업무 수", example = "5")
+            int count,
+            @Schema(description = "전체 대비 담당 비율 (합산 = 1.0)", example = "0.33")
+            double rate
+    ) {
+        public static PersonAnalysisItem from(final NodeAnalysisResult.PersonAnalysis person) {
+            return new PersonAnalysisItem(person.count(), person.rate());
+        }
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import kr.flowmeet.api.ai.handler.NodeSummaryTextMerger;
+import kr.flowmeet.api.node.dto.response.AnalyzeDraggedNodesResponse;
 import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
 import kr.flowmeet.api.node.event.NodeSummaryRequestEvent;
 import kr.flowmeet.domain.ai.entity.AiTask;
@@ -39,6 +40,8 @@ import kr.flowmeet.domain.node.entity.NodeStatus;
 import kr.flowmeet.domain.node.entity.NodeTag;
 import kr.flowmeet.domain.node.entity.Tag;
 import kr.flowmeet.domain.node.exception.NodeErrorCode;
+import kr.flowmeet.external.ai.NodeAnalysisClient;
+import kr.flowmeet.external.ai.dto.NodeAnalysisResult;
 import kr.flowmeet.domain.node.service.EdgeService;
 import kr.flowmeet.domain.node.service.NodeAssigneeService;
 import kr.flowmeet.domain.node.service.NodeService;
@@ -63,6 +66,7 @@ public class NodeFacade {
     private final UserService userService;
     private final AiTaskService aiTaskService;
     private final ApplicationEventPublisher eventPublisher;
+    private final NodeAnalysisClient nodeAnalysisClient;
 
     public GetFlowchartResponse getFlowchart(final Long userId, final Long projectId) {
         projectPermissionValidator.validate(projectId, userId);
@@ -270,6 +274,46 @@ public class NodeFacade {
         eventPublisher.publishEvent(new NodeSummaryRequestEvent(aiTask.getId(), mergedText));
 
         return RequestNodeSummaryResponse.from(aiTask.getId());
+    }
+
+    // TODO: 추후 노트(noteContent) 포함 여부 검토
+    public AnalyzeDraggedNodesResponse analyzeDraggedNodes(
+            final Long userId,
+            final Long projectId,
+            final List<Long> nodeIds
+    ) {
+        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+
+        List<Node> nodes = nodeService.findAllByIdsAndProjectId(nodeIds, projectId);
+        List<Meeting> meetings = meetingService.findAllByNodeIds(nodeIds);
+
+        String analysisText = buildAnalysisText(nodes, meetings);
+
+        NodeAnalysisResult result = nodeAnalysisClient.analyze(analysisText);
+        return AnalyzeDraggedNodesResponse.from(result);
+    }
+
+    private String buildAnalysisText(final List<Node> nodes, final List<Meeting> meetings) {
+        Map<Long, Meeting> meetingByNodeId = meetings.stream()
+                .filter(m -> m.getSummary() != null)
+                .collect(Collectors.toMap(Meeting::getNodeId, m -> m, (a, b) -> a));
+
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (Node node : nodes) {
+            Meeting meeting = meetingByNodeId.get(node.getId());
+            if (meeting == null) {
+                continue;
+            }
+            sb.append("name: ").append(node.getTitle()).append("\n")
+                    .append("\"").append(meeting.getSummary()).append("\"\n\n");
+            count++;
+        }
+
+        if (count < 2) {
+            throw new BusinessException(NodeErrorCode.NOT_ENOUGH_SUMMARIES_FOR_ANALYSIS);
+        }
+        return sb.toString().trim();
     }
 
     public SearchNodeResponse search(final Long userId, final Long projectId, final String query) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/NodeSuccessCode.java
@@ -20,6 +20,7 @@ public enum NodeSuccessCode implements SuccessCode {
     UPDATE_NODE_STATUS("노드 상태를 변경했어요."),
     GET_LINKED_NODES("연결된 노드를 조회했어요."),
     REQUEST_NODE_SUMMARY("메인 노드 요약을 요청했어요."),
+    ANALYZE_DRAGGED_NODES("드래그 노드 분석을 완료했어요."),
     SEARCH("검색을 완료했어요.");
 
     private final String message;

--- a/backend/flowmeet-api/src/main/resources/config/external.yaml
+++ b/backend/flowmeet-api/src/main/resources/config/external.yaml
@@ -18,6 +18,8 @@ cloud:
       request-queue-url: ${SQS_REQUEST_QUEUE_URL:}
       response-queue-url: ${SQS_RESPONSE_QUEUE_URL:}
       region: ${SQS_REGION:ap-northeast-2}
+    ai:
+      endpoint-url: ${AI_NODE_ANALYSIS_ENDPOINT_URL:}
 
 google:
   meet:

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/exception/NodeErrorCode.java
@@ -10,7 +10,8 @@ import kr.flowmeet.common.exception.ErrorCode;
 public enum NodeErrorCode implements ErrorCode {
     NODE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 노드예요."),
     ACTIVE_MEETING_EXISTS(HttpStatus.CONFLICT, "진행 중인 회의가 있는 노드는 삭제할 수 없어요."),
-    NO_CHILD_SUMMARY(HttpStatus.BAD_REQUEST, "요약할 하위 노드 회의록이 없어요.");
+    NO_CHILD_SUMMARY(HttpStatus.BAD_REQUEST, "요약할 하위 노드 회의록이 없어요."),
+    NOT_ENOUGH_SUMMARIES_FOR_ANALYSIS(HttpStatus.BAD_REQUEST, "분석 가능한 회의 요약이 2개 이상 필요해요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/NodeAnalysisClient.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/NodeAnalysisClient.java
@@ -1,0 +1,85 @@
+package kr.flowmeet.external.ai;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import kr.flowmeet.external.ai.config.NodeAnalysisProperties;
+import kr.flowmeet.external.exception.ExternalException;
+import kr.flowmeet.external.ai.dto.NodeAnalysisResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NodeAnalysisClient {
+
+    private static final String SIGNING_NAME = "execute-api";
+    private static final Region SIGNING_REGION = Region.AP_NORTHEAST_2;
+
+    private final RestClient nodeAnalysisRestClient;
+    private final NodeAnalysisProperties properties;
+    private final AwsCredentialsProvider awsCredentialsProvider;
+
+    public NodeAnalysisResult analyze(final String fileContent) {
+        URI uri = URI.create(properties.getEndpointUrl());
+
+        SdkHttpFullRequest signedRequest = signRequest(uri);
+
+        MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+        bodyBuilder.part("file", toByteArrayResource(fileContent));
+
+        log.info("노드 분석 API 호출 - endpoint: {}", properties.getEndpointUrl());
+
+        try {
+            return nodeAnalysisRestClient.post()
+                    .uri(uri)
+                    .headers(headers -> signedRequest.headers().forEach((key, values) ->
+                            values.forEach(value -> headers.add(key, value))
+                    ))
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(bodyBuilder.build())
+                    .retrieve()
+                    .body(NodeAnalysisResult.class);
+        } catch (Exception e) {
+            log.error("노드 분석 API 호출 실패", e);
+            throw new ExternalException(NodeAnalysisErrorCode.NODE_ANALYSIS_FAILED);
+        }
+    }
+
+    private SdkHttpFullRequest signRequest(final URI uri) {
+        Aws4Signer signer = Aws4Signer.create();
+
+        SdkHttpFullRequest unsignedRequest = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.POST)
+                .uri(uri)
+                .build();
+
+        Aws4SignerParams signerParams = Aws4SignerParams.builder()
+                .awsCredentials(awsCredentialsProvider.resolveCredentials())
+                .signingName(SIGNING_NAME)
+                .signingRegion(SIGNING_REGION)
+                .build();
+
+        return signer.sign(unsignedRequest, signerParams);
+    }
+
+    private ByteArrayResource toByteArrayResource(final String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return "analysis.txt";
+            }
+        };
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/NodeAnalysisErrorCode.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/NodeAnalysisErrorCode.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.external.ai;
+
+import kr.flowmeet.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NodeAnalysisErrorCode implements ErrorCode {
+
+    NODE_ANALYSIS_FAILED(HttpStatus.BAD_GATEWAY, "노드 분석 API 호출에 실패했어요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/NodeAnalysisConfig.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/NodeAnalysisConfig.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.external.ai.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(NodeAnalysisProperties.class)
+public class NodeAnalysisConfig {
+
+    @Bean
+    public RestClient nodeAnalysisRestClient() {
+        return RestClient.create();
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/NodeAnalysisProperties.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/NodeAnalysisProperties.java
@@ -1,0 +1,13 @@
+package kr.flowmeet.external.ai.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "cloud.aws.ai")
+public class NodeAnalysisProperties {
+
+    private final String endpointUrl;
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/NodeAnalysisResult.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/NodeAnalysisResult.java
@@ -1,0 +1,36 @@
+package kr.flowmeet.external.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+public record NodeAnalysisResult(
+        @JsonProperty("meeting_relationships")
+        List<MeetingRelationship> meetingRelationships,
+        @JsonProperty("action_items_analysis")
+        ActionItemsAnalysis actionItemsAnalysis,
+        @JsonProperty("development_ideas")
+        String developmentIdeas,
+        @JsonProperty("mermaid_code")
+        String mermaidCode
+) {
+
+    public record MeetingRelationship(
+            String from,
+            String to,
+            String relation,
+            String reason
+    ) {}
+
+    public record ActionItemsAnalysis(
+            @JsonProperty("total_count")
+            int totalCount,
+            @JsonProperty("by_person")
+            Map<String, PersonAnalysis> byPerson
+    ) {}
+
+    public record PersonAnalysis(
+            int count,
+            double rate
+    ) {}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #188

## 📝작업 내용

### API Gateway 기반 노드 분석 외부 클라이언트

- `NodeAnalysisClient`: SigV4 서명 + multipart/form-data로 API Gateway 호출
- `NodeAnalysisResult`: AI 응답 매핑 DTO (회의 관계, 후속 업무, 발전 아이디어, Mermaid)
- `NodeAnalysisProperties`: 엔드포인트 URL 설정 바인딩
- `NodeAnalysisErrorCode`: 외부 API 호출 실패 에러 코드

### 드래그 노드 분석 API 엔드포인트

- `POST /v1/projects/{projectId}/nodes/analysis` 엔드포인트 추가
- 선택한 노드들의 회의록 요약을 텍스트로 병합하여 AI에 전달
- 요약이 있는 노드 2개 미만이면 `NOT_ENOUGH_SUMMARIES_FOR_ANALYSIS` 에러 반환
- `AnalyzeDraggedNodesRequest` / `AnalyzeDraggedNodesResponse` DTO 추가

### 환경변수

- `.env.example`에 SQS, AI 노드 분석 환경변수 추가
- `external.yaml`에 `cloud.aws.ai.endpoint-url` 설정 추가

## 변경 파일

| 파일 | 변경 |
|------|------|
| `external/.../ai/NodeAnalysisClient.java` | 추가 - SigV4 서명 API Gateway 호출 |
| `external/.../ai/NodeAnalysisErrorCode.java` | 추가 - 외부 호출 실패 에러 코드 |
| `external/.../ai/config/NodeAnalysisConfig.java` | 추가 - RestClient 빈 설정 |
| `external/.../ai/config/NodeAnalysisProperties.java` | 추가 - 엔드포인트 URL 프로퍼티 |
| `external/.../ai/dto/NodeAnalysisResult.java` | 추가 - AI 응답 매핑 DTO |
| `api/.../node/controller/NodeApi.java` | 수정 - Swagger 인터페이스 추가 |
| `api/.../node/controller/NodeController.java` | 수정 - 엔드포인트 추가 |
| `api/.../node/facade/NodeFacade.java` | 수정 - analyzeDraggedNodes() 추가 |
| `api/.../node/success/NodeSuccessCode.java` | 수정 - ANALYZE_DRAGGED_NODES 추가 |
| `api/.../node/dto/request/AnalyzeDraggedNodesRequest.java` | 추가 |
| `api/.../node/dto/response/AnalyzeDraggedNodesResponse.java` | 추가 |
| `domain/.../node/exception/NodeErrorCode.java` | 수정 - NOT_ENOUGH_SUMMARIES_FOR_ANALYSIS 추가 |
| `.env.example` | 수정 - SQS, AI 환경변수 추가 |
| `api/.../resources/config/external.yaml` | 수정 - AI 엔드포인트 설정 추가 |

## 💬참고 사항

> 현재 AI 분석은 회의록(summary) 기반으로만 구현되어 있습니다. 추후 AI 측 확장 시 노트(noteContent)도 분석 텍스트에 포함할 예정입니다.