### PR TITLE
[Feat/#116] 프로젝트 설정 모달 구현

### DIFF
--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -9,15 +9,17 @@ import {
   IconSetting,
 } from '@wanteddev/wds-icon';
 import { AnimatePresence, motion } from 'framer-motion';
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
+import { useModal } from '@/components/commons/modal/ModalContext';
 import {
   EXAMPLE_PROJECT_SIDEBAR_PROFILE,
   EXAMPLE_SIDEBAR_ALARM_ITEMS,
 } from '@/constants/exampleConstant';
 import { cn } from '@/utils/cn';
 
+import { SettingsModalContent } from './setting-modal';
 import { SidebarAlarmModal } from './SidebarAlarmModal';
 import { SidebarMenuButton } from './SidebarMenuButton';
 import { UserProfileButton } from './UserProfileButton';
@@ -47,6 +49,11 @@ export const ProjectSidebar = ({
   onProfileClick,
 }: ProjectSidebarProps) => {
   const pathname = usePathname();
+  const params = useParams<{ projectId?: string }>();
+  const projectIdRaw = params?.projectId;
+  const projectId = projectIdRaw ? Number(projectIdRaw) : undefined;
+  const isProjectIdValid = projectId !== undefined && !Number.isNaN(projectId);
+  const { openModal, closeModal } = useModal();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isCollapsedInternal, setIsCollapsedInternal] = useState(false);
   const [isAlarmModalOpen, setIsAlarmModalOpen] = useState(false);
@@ -89,6 +96,17 @@ export const ProjectSidebar = ({
   const handleAlarmModalToggle = () => {
     setIsAlarmModalOpen((prev) => !prev);
     onInboxClick?.();
+  };
+
+  const handleSettingClick = () => {
+    onSettingClick?.();
+    if (!isProjectIdValid || projectId === undefined) return;
+    openModal({
+      variant: 'default',
+      closeOnBackdrop: true,
+      closeOnEsc: true,
+      content: <SettingsModalContent projectId={projectId} onClose={closeModal} />,
+    });
   };
 
   return (
@@ -192,7 +210,7 @@ export const ProjectSidebar = ({
                   label="설정"
                   labelWidth={48}
                   labelTransitionDuration={SIDEBAR_LABEL_TRANSITION_DURATION}
-                  onClick={onSettingClick}
+                  onClick={handleSettingClick}
                 />
               </nav>
             )}

--- a/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
@@ -2,6 +2,7 @@
 
 import {
   Avatar,
+  Chip,
   Menu,
   MenuContent,
   MenuList,
@@ -9,7 +10,7 @@ import {
   TextField,
   TextFieldButton,
 } from '@wanteddev/wds';
-import { IconChevronDownSmall } from '@wanteddev/wds-icon';
+import { IconChevronDownSmall, IconClose } from '@wanteddev/wds-icon';
 import { useEffect, useState } from 'react';
 
 import { privateApi } from '@/api';
@@ -65,7 +66,17 @@ interface MembersSettingsPanelProps {
 export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanelProps) => {
   const { openDialog, closeDialog } = useDialog();
   const toast = usePositionedToast();
-  const { email, setEmail, isInvalid, canSend, buildPayload, reset } = useMemberInviteForm();
+  const {
+    email,
+    setEmail,
+    pendingEmails,
+    isCurrentInvalid,
+    canSendAll,
+    commitCurrent,
+    removeEmail,
+    buildPayloads,
+    reset,
+  } = useMemberInviteForm();
 
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [openRoleMenuFor, setOpenRoleMenuFor] = useState<number | null>(null);
@@ -106,19 +117,39 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
     };
   }, [projectId, reloadCounter]);
 
+  const handleEmailKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    commitCurrent();
+  };
+
   const handleInviteSend = async () => {
-    if (!canSend) return;
-    try {
-      await privateApi.project.inviteMember(projectId, buildPayload());
-      reset();
+    if (!canSendAll) return;
+    const payloads = buildPayloads();
+    if (payloads.length === 0) return;
+    // 백엔드 `inviteMember` 가 단일 이메일만 받아 일괄 호출은 클라이언트에서 Promise.all 로 처리.
+    const results = await Promise.allSettled(
+      payloads.map((payload) => privateApi.project.inviteMember(projectId, payload)),
+    );
+    const failures = results.filter((r) => r.status === 'rejected');
+    reset();
+    if (failures.length === 0) {
       toast({
-        content: '초대 메일을 전송했어요',
+        content: `${payloads.length}명에게 초대 메일을 전송했어요`,
         variant: 'normal',
         placement: 'bottom-left',
         duration: 'short',
       });
-    } catch (caught) {
-      console.error('멤버 초대에 실패했어요.', caught);
+    } else {
+      failures.forEach((failure) => {
+        console.error('멤버 초대 일부 실패', (failure as PromiseRejectedResult).reason);
+      });
+      toast({
+        content: `${payloads.length - failures.length}명 전송 완료, ${failures.length}명 실패`,
+        variant: 'cautionary',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
     }
   };
 
@@ -179,20 +210,61 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
           type="email"
           value={email}
           onChange={(event) => setEmail(event.target.value)}
+          onKeyDown={handleEmailKeyDown}
           width="100%"
-          placeholder="초대할 이메일 주소"
-          invalid={isInvalid}
+          placeholder="이메일 주소를 입력하고 Enter 로 추가"
+          invalid={isCurrentInvalid}
           trailingButton={
             <TextFieldButton
               variant="normal"
               onClick={handleInviteSend}
-              disabled={!canSend}
+              disabled={!canSendAll}
               aria-label="멤버 초대 전송"
             >
               전송
             </TextFieldButton>
           }
         />
+
+        {/* 추가된 초대 대기 이메일 Chip 목록 */}
+        {pendingEmails.length > 0 && (
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            {pendingEmails.map((mail) => (
+              <Chip
+                key={mail}
+                size="medium"
+                variant="solid"
+                disableInteraction
+                leadingContent={<Avatar variant="person" size="xsmall" alt={mail} />}
+                trailingContent={
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      removeEmail(mail);
+                    }}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        removeEmail(mail);
+                      }
+                    }}
+                    aria-label={`${mail} 초대 취소`}
+                    className="text-label-alternative hover:text-label-neutral relative z-10 flex h-4 w-4 cursor-pointer items-center justify-center"
+                  >
+                    <IconClose className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                }
+              >
+                <span className="text-caption-1 text-label-alternative font-medium">{mail}</span>
+              </Chip>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* 멤버 목록 */}

--- a/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import {
+  Avatar,
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuTrigger,
+  TextField,
+  TextFieldButton,
+} from '@wanteddev/wds';
+import { IconChevronDownSmall } from '@wanteddev/wds-icon';
+import { useEffect, useState } from 'react';
+
+import { privateApi } from '@/api';
+import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
+import { CustomMenuItem } from '@/components/commons/custom-menu/CustomMemuItem';
+import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
+import { cn } from '@/utils/cn';
+
+import { ProjectDeleteConfirmContent } from './ProjectDeleteConfirmContent';
+import type { ProjectMemberRole } from './SettingsModalContent';
+import { useMemberInviteForm } from './useMemberInviteForm';
+
+interface MemberRow {
+  memberId: number;
+  nickname: string;
+  email: string;
+  profileImageUrl?: string;
+  role: ProjectMemberRole;
+}
+
+const ROLE_LABEL_MAP: Record<ProjectMemberRole, string> = {
+  // OWNER 는 표시 라벨만 "관리자" 로 사용. 백엔드 enum 값은 그대로 OWNER 유지.
+  OWNER: '관리자',
+  MEMBER: '멤버',
+  VIEWER: '뷰어',
+};
+
+/** 일반 멤버에게 변경 가능한 권한 옵션. OWNER 양도는 정책 미정으로 본 PR 범위 밖. */
+const ASSIGNABLE_ROLES: readonly ProjectMemberRole[] = ['MEMBER', 'VIEWER'];
+
+interface MembersSettingsPanelProps {
+  projectId: number;
+  /** 부모(`SettingsModalContent`)에서 한 번 받아 내려주는 현재 사용자의 권한. */
+  myRole: ProjectMemberRole | null;
+}
+
+/**
+ * 설정 모달 - 구성원 탭.
+ *
+ * 권한 분기:
+ * - OWNER  : 모든 멤버 행에 권한 드롭다운 + 삭제 버튼 (해당 행이 OWNER 면 둘 다 X).
+ * - MEMBER : 권한 드롭다운만 표시(권한 변경은 가능), 삭제 버튼 미노출.
+ * - VIEWER : 권한 드롭다운/삭제 모두 미노출. 라벨만 표시.
+ *
+ * 그 외:
+ * - 멤버 목록: `getAllMembers(projectId)` → `MemberRow` 정규화.
+ * - 멤버 초대: `useMemberInviteForm` + `inviteMember(projectId, { email })`.
+ * - 권한 변경: WDS Menu + CustomMenuItem → `updateMemberRole(projectId, memberId, { role })`.
+ *   드롭다운이 모달(z-9999) 뒤로 빠지지 않도록 `MenuContent.sx.zIndex` 명시.
+ * - 멤버 삭제: 컨펌 다이얼로그 → `deleteMember(projectId, memberId)`.
+ * - 멤버 목록 스크롤바: `globals.css` 의 `.custom-scrollbar` 유틸 사용.
+ */
+export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanelProps) => {
+  const { openDialog, closeDialog } = useDialog();
+  const toast = usePositionedToast();
+  const { email, setEmail, isInvalid, canSend, buildPayload, reset } = useMemberInviteForm();
+
+  const [members, setMembers] = useState<MemberRow[]>([]);
+  const [openRoleMenuFor, setOpenRoleMenuFor] = useState<number | null>(null);
+  const [reloadCounter, setReloadCounter] = useState(0);
+  const triggerReload = () => setReloadCounter((c) => c + 1);
+
+  const isViewer = myRole === 'VIEWER';
+  const isOwner = myRole === 'OWNER';
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchMembers = async () => {
+      try {
+        const response = await privateApi.projectMember.getAllMembers(projectId);
+        if (cancelled) return;
+        const list = response.data.data?.members ?? [];
+        const normalized: MemberRow[] = list
+          .filter(
+            (m): m is { memberId: number; role: ProjectMemberRole } & typeof m =>
+              m.memberId !== undefined && m.role !== undefined,
+          )
+          .map((m) => ({
+            memberId: m.memberId,
+            nickname: m.nickname ?? '',
+            email: m.email ?? '',
+            profileImageUrl: m.profileImageUrl,
+            role: m.role,
+          }));
+        setMembers(normalized);
+      } catch (caught) {
+        if (cancelled) return;
+        console.error('멤버 목록 조회에 실패했어요.', caught);
+      }
+    };
+    void fetchMembers();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, reloadCounter]);
+
+  const handleInviteSend = async () => {
+    if (!canSend) return;
+    try {
+      await privateApi.project.inviteMember(projectId, buildPayload());
+      reset();
+      toast({
+        content: '초대 메일을 전송했어요',
+        variant: 'normal',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+    } catch (caught) {
+      console.error('멤버 초대에 실패했어요.', caught);
+    }
+  };
+
+  const handleRoleChange = async (member: MemberRow, nextRole: ProjectMemberRole) => {
+    setOpenRoleMenuFor(null);
+    if (member.role === nextRole) return;
+    try {
+      await privateApi.projectMember.updateMemberRole(projectId, member.memberId, {
+        role: nextRole,
+      });
+      triggerReload();
+      toast({
+        content: '멤버 권한을 변경했어요',
+        variant: 'normal',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+    } catch (caught) {
+      console.error('멤버 권한 변경에 실패했어요.', caught);
+    }
+  };
+
+  const handleMemberDelete = (member: MemberRow) => {
+    openDialog({
+      closeOnBackdrop: true,
+      closeOnEsc: true,
+      content: (
+        <ProjectDeleteConfirmContent
+          projectName={member.nickname || member.email}
+          onConfirm={async () => {
+            try {
+              await privateApi.projectMember.deleteMember(projectId, member.memberId);
+              closeDialog();
+              triggerReload();
+              toast({
+                content: '멤버를 삭제했어요',
+                variant: 'normal',
+                placement: 'bottom-left',
+                duration: 'short',
+              });
+            } catch (caught) {
+              console.error('멤버 삭제에 실패했어요.', caught);
+            }
+          }}
+          onClose={closeDialog}
+        />
+      ),
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      {/* 멤버 초대 */}
+      <div className="flex flex-col gap-2">
+        <span className="text-label-1 text-label-neutral font-normal">멤버 초대</span>
+        <TextField
+          id="project-settings-invite-email"
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          width="100%"
+          placeholder="초대할 이메일 주소"
+          invalid={isInvalid}
+          trailingButton={
+            <TextFieldButton
+              variant="normal"
+              onClick={handleInviteSend}
+              disabled={!canSend}
+              aria-label="멤버 초대 전송"
+            >
+              전송
+            </TextFieldButton>
+          }
+        />
+      </div>
+
+      {/* 멤버 목록 */}
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
+        <span className="text-label-1 text-label-neutral font-normal">멤버 목록</span>
+        <ul className="custom-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-2">
+          {members.map((member) => {
+            const rowIsOwner = member.role === 'OWNER';
+            const showRoleDropdown = !isViewer && !rowIsOwner;
+            const showDeleteButton = isOwner && !rowIsOwner;
+            return (
+              <li
+                key={member.memberId}
+                className="flex items-center justify-between gap-4 rounded-md py-2"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <Avatar
+                    variant="person"
+                    size="small"
+                    src={member.profileImageUrl}
+                    alt={member.nickname || member.email}
+                  />
+                  <div className="flex min-w-0 flex-col">
+                    <span className="text-body-1 text-label-normal truncate font-medium">
+                      {member.nickname || '이름 없음'}
+                    </span>
+                    <span className="text-caption-1 text-label-alternative truncate">
+                      {member.email}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {showRoleDropdown ? (
+                    <Menu
+                      open={openRoleMenuFor === member.memberId}
+                      onOpenChange={(isOpen) =>
+                        setOpenRoleMenuFor(isOpen ? member.memberId : null)
+                      }
+                    >
+                      <MenuTrigger>
+                        <button
+                          type="button"
+                          className={cn(
+                            'text-caption-1 text-label-neutral hover:bg-fill-normal active:bg-fill-strong inline-flex items-center gap-1 rounded-md bg-transparent px-2 py-1 font-medium outline-none transition-colors',
+                            'focus-visible:ring-primary-40 focus-visible:ring-2 focus-visible:ring-offset-2',
+                          )}
+                        >
+                          {ROLE_LABEL_MAP[member.role]}
+                          <IconChevronDownSmall className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </MenuTrigger>
+                      {/* WDS Menu 기본 z-index(11) < 공통 모달(9999). 모달 뒤로 빠지지 않도록 명시. */}
+                      <MenuContent
+                        offset={4}
+                        position="bottom-end"
+                        sx={{ width: '8rem', zIndex: 10000 }}
+                      >
+                        <MenuList>
+                          {ASSIGNABLE_ROLES.map((role) => (
+                            <CustomMenuItem
+                              key={role}
+                              value={role}
+                              onClick={() => handleRoleChange(member, role)}
+                            >
+                              {ROLE_LABEL_MAP[role]}
+                            </CustomMenuItem>
+                          ))}
+                        </MenuList>
+                      </MenuContent>
+                    </Menu>
+                  ) : (
+                    <span className="text-caption-1 text-label-neutral font-medium">
+                      {ROLE_LABEL_MAP[member.role]}
+                    </span>
+                  )}
+                  {showDeleteButton && (
+                    <button
+                      type="button"
+                      onClick={() => handleMemberDelete(member)}
+                      className={cn(
+                        'text-caption-1 text-status-negative hover:bg-fill-normal active:bg-fill-strong rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors',
+                        'focus-visible:ring-primary-40 focus-visible:ring-2 focus-visible:ring-offset-2',
+                      )}
+                    >
+                      삭제
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+MembersSettingsPanel.displayName = 'MembersSettingsPanel';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/NotificationsSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/NotificationsSettingsPanel.tsx
@@ -1,55 +1,72 @@
 'use client';
 
 import { Checkbox, Switch } from '@wanteddev/wds';
-import { useState } from 'react';
 
-import { EXAMPLE_PROJECT_NOTIFICATION_SETTINGS } from '@/constants/exampleConstant';
+import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
+
+import { useProjectNotificationsForm } from './useProjectNotificationsForm';
 
 interface NotificationRowProps {
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
 }
 
-const NotificationRow = ({ label, checked, onCheckedChange }: NotificationRowProps) => {
+const NotificationRow = ({ label, checked, onCheckedChange, disabled }: NotificationRowProps) => {
   return (
     <div className="flex w-40 items-center justify-between gap-2 py-3">
       <span className="text-label-1 text-label-normal">{label}</span>
-      <Switch size="small" checked={checked} onCheckedChange={onCheckedChange} />
+      <Switch
+        size="small"
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+      />
     </div>
   );
 };
 
+interface NotificationsSettingsPanelProps {
+  projectId: number;
+}
+
 /**
  * 설정 모달 - 알림 탭.
  *
- * 알림 설정 관련 API(`getProjectNotificationSettings`/`updateProjectNotificationSettings` 등)가
- * 아직 generated 되지 않아, UI는 #55 톤 그대로 가져오되 토글 상태는 클라이언트 메모리에만
- * 보관한다. 백엔드 스펙 확정 후 별도 작업에서 폼 훅 + privateApi 호출로 전환 예정.
+ * - 마운트 시 `getNotificationSetting(projectId)` → 초기값 로드.
+ * - 각 토글 변경 시 즉시 `updateNotificationSetting(projectId, { [field]: value })` 호출 (낙관적 업데이트).
+ * - 폼 상태/검증/저장은 `useProjectNotificationsForm` 훅에 분리.
  */
-export const NotificationsSettingsPanel = () => {
-  const [meetingEnabled, setMeetingEnabled] = useState<boolean>(
-    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.meetingEnabled,
-  );
-  const [nodeEnabled, setNodeEnabled] = useState<boolean>(
-    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.nodeEnabled,
-  );
-  const [desktopEnabled, setDesktopEnabled] = useState<boolean>(
-    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.channels.desktop,
-  );
-  const [emailEnabled, setEmailEnabled] = useState<boolean>(
-    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.channels.email,
-  );
+export const NotificationsSettingsPanel = ({ projectId }: NotificationsSettingsPanelProps) => {
+  const toast = usePositionedToast();
+  const { settings, isLoaded, setField } = useProjectNotificationsForm({
+    projectId,
+    onSaveError: (message) => {
+      toast({
+        content: message,
+        variant: 'negative',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+    },
+  });
 
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col">
         <NotificationRow
           label="회의 알림"
-          checked={meetingEnabled}
-          onCheckedChange={setMeetingEnabled}
+          checked={settings.meetingEnabled}
+          onCheckedChange={(checked) => void setField('meetingEnabled', checked)}
+          disabled={!isLoaded}
         />
-        <NotificationRow label="노드 알림" checked={nodeEnabled} onCheckedChange={setNodeEnabled} />
+        <NotificationRow
+          label="노드 알림"
+          checked={settings.nodeEnabled}
+          onCheckedChange={(checked) => void setField('nodeEnabled', checked)}
+          disabled={!isLoaded}
+        />
       </div>
 
       <div aria-hidden="true" className="bg-line-normal-normal h-px w-full" />
@@ -60,14 +77,21 @@ export const NotificationsSettingsPanel = () => {
           <label className="flex items-center gap-2 py-3">
             <Checkbox
               size="small"
-              checked={desktopEnabled}
-              onCheckedChange={setDesktopEnabled}
+              checked={settings.desktopEnabled}
+              onCheckedChange={(checked) => void setField('desktopEnabled', checked)}
+              disabled={!isLoaded}
               tight
             />
             <span className="text-caption-1 text-label-normal">데스크톱</span>
           </label>
           <label className="flex items-center gap-2 py-3">
-            <Checkbox size="small" checked={emailEnabled} onCheckedChange={setEmailEnabled} tight />
+            <Checkbox
+              size="small"
+              checked={settings.emailEnabled}
+              onCheckedChange={(checked) => void setField('emailEnabled', checked)}
+              disabled={!isLoaded}
+              tight
+            />
             <span className="text-caption-1 text-label-normal">이메일</span>
           </label>
         </div>

--- a/frontend/src/components/commons/project-sidebar/setting-modal/NotificationsSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/NotificationsSettingsPanel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Checkbox, Switch } from '@wanteddev/wds';
+import { useState } from 'react';
+
+import { EXAMPLE_PROJECT_NOTIFICATION_SETTINGS } from '@/constants/exampleConstant';
+
+interface NotificationRowProps {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+const NotificationRow = ({ label, checked, onCheckedChange }: NotificationRowProps) => {
+  return (
+    <div className="flex w-40 items-center justify-between gap-2 py-3">
+      <span className="text-label-1 text-label-normal">{label}</span>
+      <Switch size="small" checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+};
+
+/**
+ * 설정 모달 - 알림 탭.
+ *
+ * 알림 설정 관련 API(`getProjectNotificationSettings`/`updateProjectNotificationSettings` 등)가
+ * 아직 generated 되지 않아, UI는 #55 톤 그대로 가져오되 토글 상태는 클라이언트 메모리에만
+ * 보관한다. 백엔드 스펙 확정 후 별도 작업에서 폼 훅 + privateApi 호출로 전환 예정.
+ */
+export const NotificationsSettingsPanel = () => {
+  const [meetingEnabled, setMeetingEnabled] = useState<boolean>(
+    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.meetingEnabled,
+  );
+  const [nodeEnabled, setNodeEnabled] = useState<boolean>(
+    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.nodeEnabled,
+  );
+  const [desktopEnabled, setDesktopEnabled] = useState<boolean>(
+    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.channels.desktop,
+  );
+  const [emailEnabled, setEmailEnabled] = useState<boolean>(
+    EXAMPLE_PROJECT_NOTIFICATION_SETTINGS.channels.email,
+  );
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col">
+        <NotificationRow
+          label="회의 알림"
+          checked={meetingEnabled}
+          onCheckedChange={setMeetingEnabled}
+        />
+        <NotificationRow label="노드 알림" checked={nodeEnabled} onCheckedChange={setNodeEnabled} />
+      </div>
+
+      <div aria-hidden="true" className="bg-line-normal-normal h-px w-full" />
+
+      <div className="flex items-center gap-10">
+        <span className="text-label-1 text-static-black">알림 수신 방법</span>
+        <div className="flex items-center gap-5">
+          <label className="flex items-center gap-2 py-3">
+            <Checkbox
+              size="small"
+              checked={desktopEnabled}
+              onCheckedChange={setDesktopEnabled}
+              tight
+            />
+            <span className="text-caption-1 text-label-normal">데스크톱</span>
+          </label>
+          <label className="flex items-center gap-2 py-3">
+            <Checkbox size="small" checked={emailEnabled} onCheckedChange={setEmailEnabled} tight />
+            <span className="text-caption-1 text-label-normal">이메일</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+NotificationsSettingsPanel.displayName = 'NotificationsSettingsPanel';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/ProjectDeleteConfirmContent.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/ProjectDeleteConfirmContent.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { TextField } from '@wanteddev/wds';
+import { useState } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface ProjectDeleteConfirmContentProps {
+  /** 삭제 대상 프로젝트의 이름. placeholder · 검증값 양쪽으로 사용된다. */
+  projectName: string;
+  /** 입력값이 일치한 상태에서 삭제 버튼을 눌렀을 때 호출. */
+  onConfirm: () => void;
+  /** 닫기·취소 시 호출. */
+  onClose: () => void;
+}
+
+/**
+ * 프로젝트 삭제 컨펌 다이얼로그 콘텐츠.
+ *
+ * - 백드롭/ESC/외부 클릭 닫힘은 공통 다이얼로그(`useDialog` + `commons/custom-dialog`)에 위임.
+ * - 사용자가 프로젝트 이름을 정확히 똑같이 입력해야 삭제 버튼이 활성화된다.
+ * - 실제 `privateApi.project.deleteProject` 호출은 부모(`ProjectSettingsPanel`)에서 onConfirm으로 처리.
+ * - WDS Button color에 negative 톤이 없어 native button + 디자인 토큰 클래스로 처리한다.
+ */
+export const ProjectDeleteConfirmContent = ({
+  projectName,
+  onConfirm,
+  onClose,
+}: ProjectDeleteConfirmContentProps) => {
+  const [nameInput, setNameInput] = useState('');
+  const trimmedInput = nameInput.trim();
+  const trimmedTarget = projectName.trim();
+  const canDelete = trimmedTarget.length > 0 && trimmedInput === trimmedTarget;
+  const isInvalid = trimmedInput.length > 0 && !canDelete;
+
+  return (
+    <div className="flex w-90 flex-col gap-4 pb-2">
+      <h3 className="text-headline-1 text-label-normal font-semibold">프로젝트를 삭제하시겠어요?</h3>
+      <p className="text-body-2 text-label-alternative whitespace-pre-line">
+        프로젝트를 삭제하시면 복구할 수 없으며, 모든 정보가 영구적으로 사라져요. 계속 진행하려면
+        프로젝트 이름을 입력해 주세요.
+      </p>
+      <TextField
+        id="project-delete-confirm-name"
+        value={nameInput}
+        onChange={(event) => setNameInput(event.target.value)}
+        placeholder={projectName}
+        width="100%"
+        invalid={isInvalid}
+      />
+      <div className="flex items-center justify-end gap-6 pt-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-body-1 text-label-alternative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          disabled={!canDelete}
+          onClick={onConfirm}
+          className={cn(
+            'text-body-1 rounded-md px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
+            'focus-visible:ring-primary-40',
+            canDelete
+              ? 'text-status-negative hover:bg-fill-normal active:bg-fill-strong bg-transparent'
+              : 'text-label-disable cursor-not-allowed bg-transparent',
+          )}
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+ProjectDeleteConfirmContent.displayName = 'ProjectDeleteConfirmContent';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/ProjectLeaveConfirmContent.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/ProjectLeaveConfirmContent.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface ProjectLeaveConfirmContentProps {
+  /** "나가기" 버튼을 눌렀을 때 호출. 실제 leaveProject 호출은 부모에서 처리. */
+  onConfirm: () => void;
+  /** "취소" 버튼·외부에서 닫을 때 호출. */
+  onClose: () => void;
+}
+
+/**
+ * 프로젝트 나가기 컨펌 다이얼로그 콘텐츠.
+ *
+ * - 백드롭/ESC/외부 클릭 닫힘은 공통 다이얼로그(`useDialog` + `commons/custom-dialog`)에 위임.
+ * - 입력값이 없는 단순 컨펌이라 폼 훅은 분리하지 않는다.
+ * - WDS Button color 가 negative 톤을 지원하지 않아 native button + 디자인 토큰 클래스로 처리.
+ */
+export const ProjectLeaveConfirmContent = ({
+  onConfirm,
+  onClose,
+}: ProjectLeaveConfirmContentProps) => {
+  return (
+    <div className="flex w-90 flex-col gap-4 pb-2">
+      <h3 className="text-headline-1 text-label-normal font-semibold">
+        프로젝트에서 나가시겠어요?
+      </h3>
+      <p className="text-body-2 text-label-alternative">
+        나가면 다시 초대받기 전까지 이 프로젝트에 접근할 수 없어요.
+      </p>
+
+      <div className="flex items-center justify-end gap-6 pt-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-body-1 text-label-alternative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className={cn(
+            'text-body-1 text-status-negative hover:bg-fill-normal active:bg-fill-strong rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors',
+            'focus-visible:ring-primary-40 focus-visible:ring-2 focus-visible:ring-offset-2',
+          )}
+        >
+          나가기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+ProjectLeaveConfirmContent.displayName = 'ProjectLeaveConfirmContent';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/ProjectSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/ProjectSettingsPanel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { TextField, TextFieldContent } from '@wanteddev/wds';
+import { Avatar, TextField, TextFieldContent } from '@wanteddev/wds';
 import { IconLogout, IconTrash } from '@wanteddev/wds-icon';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { privateApi } from '@/api';
 import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
@@ -26,6 +26,7 @@ interface ProjectInfo {
   name: string;
   memberCount: number;
   createdAt: string;
+  profileImageUrl?: string;
 }
 
 const formatCreatedAt = (raw?: string): string => {
@@ -41,18 +42,54 @@ const formatCreatedAt = (raw?: string): string => {
 
 const AUTO_SAVE_DEBOUNCE_MS = 1000;
 
+const PROJECT_IMAGE_MAX_BYTES = 5 * 1024 * 1024; // 5MB
+const PROJECT_IMAGE_ACCEPT = ['image/png', 'image/jpeg', 'image/webp'] as const;
+
+/** 백엔드 envelope 형태에서 에러 코드를 안전하게 꺼낸다. */
+const extractErrorCode = (caught: unknown): string | undefined => {
+  if (typeof caught !== 'object' || caught === null) return undefined;
+  const obj = caught as { error?: { code?: string }; code?: string };
+  return obj.error?.code ?? obj.code;
+};
+
+/** 디버깅용 — Response 로 throw 된 객체에서 status·body 까지 평탄화해 console 에 찍는다. */
+const formatErrorForLog = (caught: unknown): Record<string, unknown> => {
+  if (typeof caught !== 'object' || caught === null) return { caught };
+  const obj = caught as {
+    status?: number;
+    statusText?: string;
+    url?: string;
+    error?: unknown;
+    data?: unknown;
+    code?: string;
+    message?: string;
+  };
+  return {
+    status: obj.status,
+    statusText: obj.statusText,
+    url: obj.url,
+    error: obj.error,
+    data: obj.data,
+    code: obj.code,
+    message: caught instanceof Error ? caught.message : obj.message,
+    name: caught instanceof Error ? caught.name : undefined,
+  };
+};
+
 /**
  * 설정 모달 - 프로젝트 탭.
  *
  * 권한 분기:
- * - 소유자(OWNER)만 이름 변경, 프로젝트 삭제 가능.
- * - 소유자 외(MEMBER/VIEWER)는 이름 입력 비활성, 하단 액션은 "프로젝트 나가기"로 노출.
+ * - 소유자(OWNER)만 이름 변경, 프로필 이미지 업로드, 프로젝트 삭제 가능.
+ * - 소유자 외(MEMBER/VIEWER)는 이름·이미지 입력 비활성, 하단 액션은 "프로젝트 나가기"로 노출.
  *
  * 그 외:
- * - 마운트 시 `privateApi.project.getProject` 로 이름·멤버 수·생성일 표시.
+ * - 마운트 시 `privateApi.project.getProject` 로 이름·구성원 수·생성일·프로필 이미지 표시.
  * - 이름은 별도 저장 버튼 없이 1초 debounce 후 자동 저장(`updateProject`).
+ * - 프로필 이미지: 클라이언트 사전 검증(5MB / png·jpeg·webp) → `updateProfileImage1` (multipart) 호출.
+ *   응답 `data: null` 이라 `getProject` 재로드로 화면 갱신.
  * - 프로젝트 삭제는 컨펌 다이얼로그 → `deleteProject` → `/projects` 이동.
- * - 프로젝트 나가기는 단순 `leaveProject` → `/projects` 이동.
+ * - 프로젝트 나가기는 컨펌 다이얼로그 → `leaveProject` → `/projects` 이동.
  */
 export const ProjectSettingsPanel = ({
   projectId,
@@ -69,6 +106,16 @@ export const ProjectSettingsPanel = ({
 
   const isOwner = myRole === 'OWNER';
   const canEditName = isOwner;
+  const canUploadImage = isOwner;
+
+  // Avatar 가 WDS 컴포넌트라 `<label htmlFor>` 의 click 위임이 일관되지 않을 수 있어
+  // 명시적 ref 로 보유하고 Avatar wrapper 클릭 시 직접 `input.click()` 을 호출한다.
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAvatarClick = () => {
+    if (!canUploadImage) return;
+    fileInputRef.current?.click();
+  };
 
   const { name, setName, canSave, maxLength } = useProjectInfoForm({
     initialName: info?.name ?? '',
@@ -81,10 +128,14 @@ export const ProjectSettingsPanel = ({
         const response = await privateApi.project.getProject(projectId);
         if (cancelled) return;
         const data = response.data.data;
+        // generated `GetProjectResponse` 에는 `profileImageUrl` 필드가 누락돼 있다.
+        // 실제 응답에 들어올 수 있어 안전하게 1회 우회 cast — 백엔드 스펙에 명시되면 cast 제거.
+        const profileImageUrl = (data as { profileImageUrl?: string } | undefined)?.profileImageUrl;
         setInfo({
           name: data?.name ?? '',
           memberCount: data?.memberCount ?? 0,
           createdAt: formatCreatedAt(data?.createdAt),
+          profileImageUrl,
         });
       } catch (caught) {
         if (cancelled) return;
@@ -127,6 +178,89 @@ export const ProjectSettingsPanel = ({
       clearTimeout(timer);
     };
   }, [name, canSave, canEditName, projectId, toast]);
+
+  const handleProjectImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // 같은 파일을 다시 선택해도 onChange 가 발화되도록 input value 를 리셋한다.
+    event.target.value = '';
+    if (!file || !canUploadImage) return;
+
+    // 클라이언트 사전 검증 (백엔드: png/jpeg/webp, 최대 5MB)
+    const isAllowedType = PROJECT_IMAGE_ACCEPT.includes(
+      file.type as (typeof PROJECT_IMAGE_ACCEPT)[number],
+    );
+    if (!isAllowedType) {
+      toast({
+        content: 'PNG·JPEG·WEBP 파일만 업로드할 수 있어요',
+        variant: 'negative',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+      return;
+    }
+    if (file.size > PROJECT_IMAGE_MAX_BYTES) {
+      toast({
+        content: '파일 크기는 5MB 이하여야 해요',
+        variant: 'negative',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+      return;
+    }
+
+    const formData = new FormData();
+    // 명세 기준 multipart part name 은 `file`.
+    // 사용자 프로필 업로드는 명세상 `file` 이지만 실구현이 `profileImage` 였으므로,
+    // 만약 이 호출에서 `MissingServletRequestPartException 'profileImage'` 가 뜨면 키를 맞춰 정정.
+    formData.append('file', file);
+
+    try {
+      // generated 시그니처가 `data: number` 로 잘못 추출돼 있어 1회 cast.
+      // Swagger 가 multipart file 정의를 잡아주면 cast 제거 가능.
+      await privateApi.project.updateProfileImage1(projectId, formData as unknown as number);
+      triggerReload();
+      toast({
+        content: '프로젝트 이미지를 변경했어요',
+        variant: 'normal',
+        placement: 'bottom-left',
+        duration: 'short',
+      });
+    } catch (caught) {
+      const code = extractErrorCode(caught);
+      const status = (caught as { status?: number } | null | undefined)?.status;
+      if (code === 'FILE_SIZE_EXCEEDED') {
+        toast({
+          content: '파일 크기가 제한을 초과했어요',
+          variant: 'negative',
+          placement: 'bottom-left',
+          duration: 'short',
+        });
+      } else if (code === 'FILE_INVALID_TYPE') {
+        toast({
+          content: '지원하지 않는 파일 형식이에요',
+          variant: 'negative',
+          placement: 'bottom-left',
+          duration: 'short',
+        });
+      } else if (status === 500) {
+        toast({
+          content: '서버에서 처리하지 못했어요. 잠시 후 다시 시도해 주세요',
+          variant: 'negative',
+          placement: 'bottom-left',
+          duration: 'short',
+        });
+        console.error('프로젝트 이미지 업로드 - 서버 500', formatErrorForLog(caught));
+      } else {
+        toast({
+          content: '프로젝트 이미지 업로드에 실패했어요',
+          variant: 'negative',
+          placement: 'bottom-left',
+          duration: 'short',
+        });
+        console.error('프로젝트 이미지 업로드 실패', formatErrorForLog(caught));
+      }
+    }
+  };
 
   const handleDeleteProjectClick = () => {
     if (!info) return;
@@ -189,28 +323,63 @@ export const ProjectSettingsPanel = ({
   return (
     <div className="flex h-full flex-col justify-between gap-8">
       <div className="flex flex-col gap-6">
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
-          <label
-            htmlFor="project-settings-name"
-            className="text-label-1 text-label-neutral font-semibold"
-          >
-            이름
-          </label>
-          <TextField
-            id="project-settings-name"
-            value={name}
-            maxLength={maxLength}
-            onChange={(event) => setName(event.target.value)}
-            width="100%"
-            disabled={!canEditName}
-            trailingContent={
-              <TextFieldContent variant="text">
-                <span className="text-caption-1 text-label-alternative font-medium">
-                  {name.length}/{maxLength}
-                </span>
-              </TextFieldContent>
-            }
-          />
+        {/* 프로필 + 이름 (가로 배치) */}
+        <div className="flex items-center gap-8">
+          {/*
+            WDS Avatar 가 data-interaction="true" 일 때 자체 wrapper(button) + absolute overlay 를
+            만들어서 외부 div role=button 의 onClick/hover 가 이벤트 hit 우선순위에서 밀린다.
+            해결: Avatar 는 그대로 표시만 하고, Avatar 위에 absolute z-10 투명 button 을 별도로
+            올려서 클릭 영역을 명확하게 가져간다. button 은 inline 형제이므로 중첩 문제도 없음.
+          */}
+          <div className="relative inline-flex shrink-0 overflow-hidden rounded-3xl">
+            <Avatar
+              variant="company"
+              size={84}
+              src={info?.profileImageUrl}
+              alt={info?.name ?? '프로젝트'}
+            />
+            {canUploadImage && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleAvatarClick}
+                  aria-label="프로젝트 이미지 변경"
+                  className="hover:bg-label-normal/20 focus-visible:ring-primary-40 absolute inset-0 z-10 cursor-pointer rounded-3xl border-none bg-transparent outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-offset-2"
+                />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={PROJECT_IMAGE_ACCEPT.join(',')}
+                  className="sr-only"
+                  onChange={handleProjectImageChange}
+                />
+              </>
+            )}
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <label
+              htmlFor="project-settings-name"
+              className="text-label-1 text-label-neutral font-semibold"
+            >
+              이름
+            </label>
+            <TextField
+              id="project-settings-name"
+              value={name}
+              maxLength={maxLength}
+              onChange={(event) => setName(event.target.value)}
+              width="100%"
+              disabled={!canEditName}
+              trailingContent={
+                <TextFieldContent variant="text">
+                  <span className="text-caption-1 text-label-alternative font-medium">
+                    {name.length}/{maxLength}
+                  </span>
+                </TextFieldContent>
+              }
+            />
+          </div>
         </div>
 
         <div className="flex flex-col gap-1">

--- a/frontend/src/components/commons/project-sidebar/setting-modal/ProjectSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/ProjectSettingsPanel.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { TextField, TextFieldContent } from '@wanteddev/wds';
+import { IconLogout, IconTrash } from '@wanteddev/wds-icon';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { privateApi } from '@/api';
+import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
+import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
+
+import { ProjectDeleteConfirmContent } from './ProjectDeleteConfirmContent';
+import { ProjectLeaveConfirmContent } from './ProjectLeaveConfirmContent';
+import type { ProjectMemberRole } from './SettingsModalContent';
+import { useProjectInfoForm } from './useProjectInfoForm';
+
+interface ProjectSettingsPanelProps {
+  projectId: number;
+  /** 부모(`SettingsModalContent`)에서 한 번 받아 내려주는 현재 사용자의 권한. */
+  myRole: ProjectMemberRole | null;
+  /** 모달을 닫는 함수. 프로젝트 삭제·나가기 등 모달 자체를 닫을 때 사용한다. */
+  onSettingsClose: () => void;
+}
+
+interface ProjectInfo {
+  name: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+const formatCreatedAt = (raw?: string): string => {
+  if (!raw) return '-';
+  try {
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return raw;
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+  } catch {
+    return raw;
+  }
+};
+
+const AUTO_SAVE_DEBOUNCE_MS = 1000;
+
+/**
+ * 설정 모달 - 프로젝트 탭.
+ *
+ * 권한 분기:
+ * - 소유자(OWNER)만 이름 변경, 프로젝트 삭제 가능.
+ * - 소유자 외(MEMBER/VIEWER)는 이름 입력 비활성, 하단 액션은 "프로젝트 나가기"로 노출.
+ *
+ * 그 외:
+ * - 마운트 시 `privateApi.project.getProject` 로 이름·멤버 수·생성일 표시.
+ * - 이름은 별도 저장 버튼 없이 1초 debounce 후 자동 저장(`updateProject`).
+ * - 프로젝트 삭제는 컨펌 다이얼로그 → `deleteProject` → `/projects` 이동.
+ * - 프로젝트 나가기는 단순 `leaveProject` → `/projects` 이동.
+ */
+export const ProjectSettingsPanel = ({
+  projectId,
+  myRole,
+  onSettingsClose,
+}: ProjectSettingsPanelProps) => {
+  const router = useRouter();
+  const { openDialog, closeDialog } = useDialog();
+  const toast = usePositionedToast();
+
+  const [info, setInfo] = useState<ProjectInfo | null>(null);
+  const [reloadCounter, setReloadCounter] = useState(0);
+  const triggerReload = () => setReloadCounter((c) => c + 1);
+
+  const isOwner = myRole === 'OWNER';
+  const canEditName = isOwner;
+
+  const { name, setName, canSave, maxLength } = useProjectInfoForm({
+    initialName: info?.name ?? '',
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchInfo = async () => {
+      try {
+        const response = await privateApi.project.getProject(projectId);
+        if (cancelled) return;
+        const data = response.data.data;
+        setInfo({
+          name: data?.name ?? '',
+          memberCount: data?.memberCount ?? 0,
+          createdAt: formatCreatedAt(data?.createdAt),
+        });
+      } catch (caught) {
+        if (cancelled) return;
+        console.error('프로젝트 상세 조회에 실패했어요.', caught);
+      }
+    };
+    void fetchInfo();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, reloadCounter]);
+
+  // 이름 자동 저장: OWNER 권한 + 마지막 입력 후 1초가 지나면 updateProject 호출.
+  useEffect(() => {
+    if (!canEditName || !canSave) return;
+
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      const saveName = async () => {
+        try {
+          await privateApi.project.updateProject(projectId, { name: name.trim() });
+          if (cancelled) return;
+          triggerReload();
+          toast({
+            content: '프로젝트 이름을 수정했어요',
+            variant: 'normal',
+            placement: 'bottom-left',
+            duration: 'short',
+          });
+        } catch (caught) {
+          if (cancelled) return;
+          console.error('프로젝트 이름 수정에 실패했어요.', caught);
+        }
+      };
+      void saveName();
+    }, AUTO_SAVE_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [name, canSave, canEditName, projectId, toast]);
+
+  const handleDeleteProjectClick = () => {
+    if (!info) return;
+    openDialog({
+      closeOnBackdrop: true,
+      closeOnEsc: true,
+      content: (
+        <ProjectDeleteConfirmContent
+          projectName={info.name}
+          onConfirm={async () => {
+            try {
+              await privateApi.project.deleteProject(projectId);
+              closeDialog();
+              onSettingsClose();
+              router.push('/projects');
+              toast({
+                content: '프로젝트를 삭제했어요',
+                variant: 'normal',
+                placement: 'bottom-left',
+                duration: 'short',
+              });
+            } catch (caught) {
+              console.error('프로젝트 삭제에 실패했어요.', caught);
+            }
+          }}
+          onClose={closeDialog}
+        />
+      ),
+    });
+  };
+
+  const handleLeaveProjectClick = () => {
+    openDialog({
+      closeOnBackdrop: true,
+      closeOnEsc: true,
+      content: (
+        <ProjectLeaveConfirmContent
+          onConfirm={async () => {
+            try {
+              await privateApi.projectMember.leaveProject(projectId);
+              closeDialog();
+              onSettingsClose();
+              router.push('/projects');
+              toast({
+                content: '프로젝트에서 나갔어요',
+                variant: 'normal',
+                placement: 'bottom-left',
+                duration: 'short',
+              });
+            } catch (caught) {
+              console.error('프로젝트 나가기에 실패했어요.', caught);
+            }
+          }}
+          onClose={closeDialog}
+        />
+      ),
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col justify-between gap-8">
+      <div className="flex flex-col gap-6">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <label
+            htmlFor="project-settings-name"
+            className="text-label-1 text-label-neutral font-semibold"
+          >
+            이름
+          </label>
+          <TextField
+            id="project-settings-name"
+            value={name}
+            maxLength={maxLength}
+            onChange={(event) => setName(event.target.value)}
+            width="100%"
+            disabled={!canEditName}
+            trailingContent={
+              <TextFieldContent variant="text">
+                <span className="text-caption-1 text-label-alternative font-medium">
+                  {name.length}/{maxLength}
+                </span>
+              </TextFieldContent>
+            }
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <p className="text-label-1 text-label-alternative font-medium">
+            구성원 수: {info?.memberCount ?? 0}명
+          </p>
+          <p className="text-label-1 text-label-alternative font-medium">
+            프로젝트 생성일: {info?.createdAt ?? '-'}
+          </p>
+        </div>
+      </div>
+
+      <div>
+        {isOwner ? (
+          <button
+            type="button"
+            onClick={handleDeleteProjectClick}
+            disabled={!info}
+            className="text-body-1 text-status-negative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 inline-flex items-center gap-2 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <IconTrash className="text-status-negative h-4 w-4" aria-hidden="true" />
+            프로젝트 삭제
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleLeaveProjectClick}
+            disabled={myRole === null}
+            className="text-body-1 text-status-negative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 inline-flex items-center gap-2 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <IconLogout className="text-status-negative h-4 w-4" aria-hidden="true" />
+            프로젝트 나가기
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ProjectSettingsPanel.displayName = 'ProjectSettingsPanel';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/SettingsModalContent.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/SettingsModalContent.tsx
@@ -83,7 +83,9 @@ export const SettingsModalContent = ({ projectId, onClose }: SettingsModalConten
           {activeTab === 'members' && (
             <MembersSettingsPanel projectId={projectId} myRole={myRole} />
           )}
-          {activeTab === 'notifications' && <NotificationsSettingsPanel />}
+          {activeTab === 'notifications' && (
+            <NotificationsSettingsPanel projectId={projectId} />
+          )}
         </div>
       </section>
     </div>

--- a/frontend/src/components/commons/project-sidebar/setting-modal/SettingsModalContent.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/SettingsModalContent.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { IconClose } from '@wanteddev/wds-icon';
+import { useEffect, useState } from 'react';
+
+import { privateApi } from '@/api';
+
+import { MembersSettingsPanel } from './MembersSettingsPanel';
+import { NotificationsSettingsPanel } from './NotificationsSettingsPanel';
+import { ProjectSettingsPanel } from './ProjectSettingsPanel';
+import { SettingsSidebarNav } from './SettingsSidebarNav';
+import { TAB_TITLE_MAP, type SettingsTab } from './types';
+
+export type ProjectMemberRole = 'VIEWER' | 'MEMBER' | 'OWNER';
+
+interface SettingsModalContentProps {
+  projectId: number;
+  onClose: () => void;
+}
+
+/**
+ * 프로젝트 설정 모달의 레이아웃 셸 (탭 사이드바 + 본문).
+ *
+ * - 자식 패널들에서 권한 분기 UI(소유자만 삭제·다른 권한은 나가기 등)가 필요해
+ *   여기서 `getProject` 한 번 호출해 `myRole` 만 추출해 자식에게 prop으로 내려준다.
+ * - 패널 내부에서 별도로 `getProject` 를 호출해야 하는 경우(이름·구성원 수 등 비교적
+ *   변동이 잦은 메타데이터)는 자체 fetch 를 유지한다.
+ */
+export const SettingsModalContent = ({ projectId, onClose }: SettingsModalContentProps) => {
+  const [activeTab, setActiveTab] = useState<SettingsTab>('project');
+  const [myRole, setMyRole] = useState<ProjectMemberRole | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchMyRole = async () => {
+      try {
+        const response = await privateApi.project.getProject(projectId);
+        if (cancelled) return;
+        const role = response.data.data?.myRole;
+        if (role === 'OWNER' || role === 'MEMBER' || role === 'VIEWER') {
+          setMyRole(role);
+        }
+      } catch (caught) {
+        if (cancelled) return;
+        console.error('내 권한 조회에 실패했어요.', caught);
+      }
+    };
+    void fetchMyRole();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  return (
+    <div className="-m-12 flex h-144 items-stretch gap-8 pr-12">
+      <aside className="bg-background-normal-alternative w-50 shrink-0 overflow-hidden p-6">
+        <SettingsSidebarNav activeTab={activeTab} onTabChange={setActiveTab} />
+      </aside>
+
+      <section className="flex min-h-0 flex-1 flex-col gap-8 py-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-heading-1 text-label-normal font-medium">
+            {TAB_TITLE_MAP[activeTab]}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="닫기"
+            className="text-label-alternative hover:text-label-neutral flex h-6 w-6 items-center justify-center border-none bg-transparent p-0"
+          >
+            <IconClose className="h-6 w-6" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {activeTab === 'project' && (
+            <ProjectSettingsPanel
+              projectId={projectId}
+              myRole={myRole}
+              onSettingsClose={onClose}
+            />
+          )}
+          {activeTab === 'members' && (
+            <MembersSettingsPanel projectId={projectId} myRole={myRole} />
+          )}
+          {activeTab === 'notifications' && <NotificationsSettingsPanel />}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+SettingsModalContent.displayName = 'SettingsModalContent';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/SettingsSidebarNav.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/SettingsSidebarNav.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { IconBell, IconFolder, IconPersons } from '@wanteddev/wds-icon';
+import type { ComponentType, SVGProps } from 'react';
+
+import { cn } from '@/utils/cn';
+
+import type { SettingsTab } from './types';
+
+interface TabItem {
+  id: SettingsTab;
+  label: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+}
+
+const TABS: readonly TabItem[] = [
+  { id: 'project', label: '프로젝트', icon: IconFolder },
+  { id: 'members', label: '구성원', icon: IconPersons },
+  { id: 'notifications', label: '알림', icon: IconBell },
+];
+
+interface SettingsSidebarNavProps {
+  activeTab: SettingsTab;
+  onTabChange: (tab: SettingsTab) => void;
+}
+
+/**
+ * 설정 모달 좌측 탭 네비게이션.
+ * 본문 패널들과 `activeTab` 상태를 공유한다.
+ */
+export const SettingsSidebarNav = ({ activeTab, onTabChange }: SettingsSidebarNavProps) => {
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <h3 className="text-caption-1 text-static-black font-semibold">설정</h3>
+      <nav className="flex flex-col gap-4">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = tab.id === activeTab;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onTabChange(tab.id)}
+              className={cn(
+                'flex items-center gap-2 rounded-md border-none bg-transparent p-0 py-2 text-left',
+                'text-label-neutral hover:text-label-normal',
+                isActive && 'text-label-normal font-medium',
+              )}
+            >
+              <Icon
+                className={cn(
+                  'h-6 w-6 shrink-0',
+                  isActive ? 'text-label-normal' : 'text-label-alternative',
+                )}
+                aria-hidden="true"
+              />
+              <span className="text-body-1 flex-1">{tab.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+};
+
+SettingsSidebarNav.displayName = 'SettingsSidebarNav';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/index.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/index.ts
@@ -1,0 +1,1 @@
+export { SettingsModalContent } from './SettingsModalContent';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/types.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/types.ts
@@ -1,0 +1,7 @@
+export type SettingsTab = 'project' | 'members' | 'notifications';
+
+export const TAB_TITLE_MAP: Record<SettingsTab, string> = {
+  project: '프로젝트 설정',
+  members: '멤버 설정',
+  notifications: '알림 설정',
+};

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useMemberInviteForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useMemberInviteForm.ts
@@ -5,34 +5,64 @@ import { useCallback, useState } from 'react';
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
- * 멤버 초대 입력 폼 훅.
- * - `email` / `setEmail` : TextField와 양방향 바인딩.
- * - `isValid`            : 이메일 형식 자체가 유효한지.
- * - `isInvalid`          : 사용자가 입력했지만 형식이 아닌 상태 (TextField invalid 표시용).
- * - `canSend`            : 전송 버튼 활성 여부 (=`isValid`).
- * - `buildPayload`       : `privateApi.project.inviteMember` 에 그대로 넘길 `{ email }` 형태.
+ * 멤버 초대 다중 입력 폼 훅.
+ *
+ * - `email` / `setEmail` : 현재 입력 중인 이메일.
+ * - `pendingEmails`      : 사용자가 엔터로 추가해 둔 초대 대기 이메일 목록 (Chip 으로 렌더).
+ * - `isCurrentValid`     : 현재 입력값이 이메일 형식이면서 아직 목록에 없는지.
+ * - `isCurrentInvalid`   : 입력했지만 형식이 아닌 상태 (TextField invalid 표시용).
+ * - `canSendAll`         : 전송 가능 — 목록에 1개 이상 또는 현재 입력값이 유효 (전송 시 자동 추가).
+ * - `commitCurrent`      : 현재 입력값을 목록에 추가 (Enter 키, blur 등에서 호출).
+ * - `removeEmail(email)` : Chip close 트리거.
+ * - `buildPayloads`      : `privateApi.project.inviteMember` 에 그대로 보낼 `{ email }[]`.
+ * - `reset`              : 전송 후 모달 안에서 초기화.
  */
 export const useMemberInviteForm = () => {
   const [email, setEmail] = useState('');
+  const [pendingEmails, setPendingEmails] = useState<readonly string[]>([]);
 
   const trimmed = email.trim();
-  const isValid = EMAIL_PATTERN.test(trimmed);
-  const isInvalid = trimmed.length > 0 && !isValid;
-  const canSend = isValid;
+  const isCurrentValid =
+    EMAIL_PATTERN.test(trimmed) && !pendingEmails.includes(trimmed);
+  const isCurrentInvalid = trimmed.length > 0 && !EMAIL_PATTERN.test(trimmed);
 
-  const buildPayload = useCallback(() => ({ email: trimmed }), [trimmed]);
+  const commitCurrent = useCallback(() => {
+    if (!isCurrentValid) return false;
+    setPendingEmails((prev) => [...prev, trimmed]);
+    setEmail('');
+    return true;
+  }, [isCurrentValid, trimmed]);
+
+  const removeEmail = useCallback((target: string) => {
+    setPendingEmails((prev) => prev.filter((item) => item !== target));
+  }, []);
+
+  const canSendAll = pendingEmails.length > 0 || isCurrentValid;
+
+  /**
+   * 전송 직전에 호출 — 현재 입력값이 유효하면 목록에 추가하고 최종 목록을 반환한다.
+   * 이미 전송 직전 commit 이 끝났다는 가정으로 buildPayloads 도 같은 식으로 계산한다.
+   */
+  const buildPayloads = useCallback(() => {
+    const finalList = isCurrentValid ? [...pendingEmails, trimmed] : [...pendingEmails];
+    return finalList.map((mail) => ({ email: mail }));
+  }, [isCurrentValid, pendingEmails, trimmed]);
 
   const reset = useCallback(() => {
     setEmail('');
+    setPendingEmails([]);
   }, []);
 
   return {
     email,
     setEmail,
-    isValid,
-    isInvalid,
-    canSend,
-    buildPayload,
+    pendingEmails,
+    isCurrentValid,
+    isCurrentInvalid,
+    canSendAll,
+    commitCurrent,
+    removeEmail,
+    buildPayloads,
     reset,
   };
 };

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useMemberInviteForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useMemberInviteForm.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * 멤버 초대 입력 폼 훅.
+ * - `email` / `setEmail` : TextField와 양방향 바인딩.
+ * - `isValid`            : 이메일 형식 자체가 유효한지.
+ * - `isInvalid`          : 사용자가 입력했지만 형식이 아닌 상태 (TextField invalid 표시용).
+ * - `canSend`            : 전송 버튼 활성 여부 (=`isValid`).
+ * - `buildPayload`       : `privateApi.project.inviteMember` 에 그대로 넘길 `{ email }` 형태.
+ */
+export const useMemberInviteForm = () => {
+  const [email, setEmail] = useState('');
+
+  const trimmed = email.trim();
+  const isValid = EMAIL_PATTERN.test(trimmed);
+  const isInvalid = trimmed.length > 0 && !isValid;
+  const canSend = isValid;
+
+  const buildPayload = useCallback(() => ({ email: trimmed }), [trimmed]);
+
+  const reset = useCallback(() => {
+    setEmail('');
+  }, []);
+
+  return {
+    email,
+    setEmail,
+    isValid,
+    isInvalid,
+    canSend,
+    buildPayload,
+    reset,
+  };
+};

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useProjectInfoForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useProjectInfoForm.ts
@@ -9,7 +9,8 @@ interface UseProjectInfoFormParams {
   maxLength?: number;
 }
 
-const DEFAULT_NAME_MAX_LENGTH = 20;
+// 디자인 시안 기준 50자.
+const DEFAULT_NAME_MAX_LENGTH = 50;
 
 /**
  * 프로젝트 설정 패널의 "이름 수정" 폼 훅.

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useProjectInfoForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useProjectInfoForm.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface UseProjectInfoFormParams {
+  /** 서버에서 받은 현재 프로젝트 이름. 변경 비교 기준이 된다. */
+  initialName: string;
+  /** 입력 가능한 최대 글자 수. */
+  maxLength?: number;
+}
+
+const DEFAULT_NAME_MAX_LENGTH = 20;
+
+/**
+ * 프로젝트 설정 패널의 "이름 수정" 폼 훅.
+ * - `name` / `setName` : TextField와 양방향 바인딩.
+ * - `isValid` : 이름이 비어있지 않은지.
+ * - `canSave` : 유효 + 기존 이름과 다른 경우.
+ * - `buildPayload` : `privateApi.project.updateProject` 에 그대로 보낼 `{ name }` 형태.
+ *
+ * `initialName`이 비동기로 들어오는 경우(첫 fetch 완료 시점)에도 동기화되도록
+ * `useEffect`로 prop 변경을 반영한다.
+ */
+export const useProjectInfoForm = ({
+  initialName,
+  maxLength = DEFAULT_NAME_MAX_LENGTH,
+}: UseProjectInfoFormParams) => {
+  const [name, setName] = useState(initialName);
+
+  useEffect(() => {
+    setName(initialName);
+  }, [initialName]);
+
+  const trimmed = name.trim();
+  const isValid = trimmed.length > 0 && trimmed.length <= maxLength;
+  const canSave = isValid && trimmed !== initialName.trim();
+
+  const buildPayload = useCallback(() => ({ name: trimmed }), [trimmed]);
+
+  const reset = useCallback(() => {
+    setName(initialName);
+  }, [initialName]);
+
+  return {
+    name,
+    setName,
+    isValid,
+    canSave,
+    maxLength,
+    buildPayload,
+    reset,
+  };
+};

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useProjectNotificationsForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useProjectNotificationsForm.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { privateApi } from '@/api';
+
+/** 백엔드 envelope 형태에서 에러 코드를 안전하게 꺼낸다. */
+const extractErrorCode = (caught: unknown): string | undefined => {
+  if (typeof caught !== 'object' || caught === null) return undefined;
+  const obj = caught as { error?: { code?: string }; code?: string };
+  return obj.error?.code ?? obj.code;
+};
+
+interface NotificationSettings {
+  meetingEnabled: boolean;
+  nodeEnabled: boolean;
+  desktopEnabled: boolean;
+  emailEnabled: boolean;
+}
+
+interface UseProjectNotificationsFormParams {
+  projectId: number;
+  /** 토글 저장 성공 시 호출. */
+  onSaveSuccess?: () => void;
+  /** 토글 저장 실패 시 사용자에게 보여줄 메시지를 받는다. */
+  onSaveError?: (message: string) => void;
+}
+
+const DEFAULT_SETTINGS: NotificationSettings = {
+  meetingEnabled: false,
+  nodeEnabled: false,
+  desktopEnabled: false,
+  emailEnabled: false,
+};
+
+/**
+ * 프로젝트 알림 설정 폼 훅.
+ *
+ * - 마운트 시 `privateApi.notificationSetting.getNotificationSetting(projectId)` 으로 초기값 로드.
+ * - 각 토글 변경(`setField`) 시 즉시 `updateNotificationSetting` 호출(다이얼로그 닫힘 등 디바운스 없이 즉시 반영).
+ *   요청 실패 시 `onSaveError` 로 사용자 메시지를 위임하고, 클라이언트 상태도 이전 값으로 롤백한다.
+ * - 응답 `data` 가 들어오면 그 값으로 동기화 — 서버가 정규화한 최종 상태를 반영.
+ */
+export const useProjectNotificationsForm = ({
+  projectId,
+  onSaveSuccess,
+  onSaveError,
+}: UseProjectNotificationsFormParams) => {
+  const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchSettings = async () => {
+      try {
+        const response = await privateApi.notificationSetting.getNotificationSetting(projectId);
+        if (cancelled) return;
+        const data = response.data.data;
+        setSettings({
+          meetingEnabled: data?.meetingEnabled ?? false,
+          nodeEnabled: data?.nodeEnabled ?? false,
+          desktopEnabled: data?.desktopEnabled ?? false,
+          emailEnabled: data?.emailEnabled ?? false,
+        });
+        setIsLoaded(true);
+      } catch (caught) {
+        if (cancelled) return;
+        // 신규 프로젝트는 알림 설정 row 가 아직 없어 404 가 정상 케이스다.
+        // 기본값으로 토글이 활성화되어, 첫 토글 시 PATCH 가 upsert 로 동작하길 기대.
+        if (extractErrorCode(caught) === 'NOTIFICATION_SETTING_NOT_FOUND') {
+          setIsLoaded(true);
+          return;
+        }
+        console.error('알림 설정 조회에 실패했어요.', caught);
+      }
+    };
+    void fetchSettings();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const setField = useCallback(
+    async <K extends keyof NotificationSettings>(field: K, value: NotificationSettings[K]) => {
+      // 낙관적 업데이트 — 즉시 토글 반영, 실패 시 롤백.
+      const prevValue = settings[field];
+      setSettings((prev) => ({ ...prev, [field]: value }));
+      try {
+        const response = await privateApi.notificationSetting.updateNotificationSetting(projectId, {
+          [field]: value,
+        });
+        const data = response.data.data;
+        if (data) {
+          setSettings({
+            meetingEnabled: data.meetingEnabled ?? false,
+            nodeEnabled: data.nodeEnabled ?? false,
+            desktopEnabled: data.desktopEnabled ?? false,
+            emailEnabled: data.emailEnabled ?? false,
+          });
+        }
+        onSaveSuccess?.();
+      } catch (caught) {
+        // 롤백
+        setSettings((prev) => ({ ...prev, [field]: prevValue }));
+        const code = extractErrorCode(caught);
+        if (code === 'NOTIFICATION_SETTING_NOT_FOUND') {
+          // 백엔드가 PATCH 로 자동 생성(upsert) 하지 않는다면 신규 프로젝트에선 토글 자체가 거부된다.
+          // 사용자에게는 일반화된 메시지로 안내하고, 콘솔 로그로 백엔드 후속 조치 신호를 남긴다.
+          onSaveError?.('알림 설정이 아직 준비되지 않았어요. 잠시 후 다시 시도해 주세요');
+        } else {
+          onSaveError?.('알림 설정 저장에 실패했어요');
+        }
+        console.error('알림 설정 저장에 실패했어요.', caught);
+      }
+    },
+    [projectId, settings, onSaveSuccess, onSaveError],
+  );
+
+  return {
+    settings,
+    isLoaded,
+    setField,
+  };
+};

--- a/frontend/src/constants/exampleConstant.ts
+++ b/frontend/src/constants/exampleConstant.ts
@@ -308,3 +308,14 @@ export const EXAMPLE_FLOWCHART_DATA = {
     },
   ],
 };
+
+// 프로젝트 설정 모달 - 알림 탭 초기값 더미.
+// 알림 설정 관련 API가 아직 generated 되지 않아, UI는 그대로 두고 클라이언트 상태로만 동작한다.
+export const EXAMPLE_PROJECT_NOTIFICATION_SETTINGS = {
+  meetingEnabled: true,
+  nodeEnabled: false,
+  channels: {
+    desktop: false,
+    email: false,
+  },
+} as const;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/utilities";
 @import "tailwindcss/theme";
 @import './variables.css';
+@import './scrollbar.css';
 @import 'pretendard/dist/web/variable/pretendardvariable.css';
 @import 'pretendard/dist/web/static/pretendard.css';
 @plugin "@tailwindcss/typography";
@@ -358,9 +359,19 @@
   letter-spacing: var(--typography---caption2---letter-spacing);
 }
 
-/* WDS 내 primary FlowMeet 색상으로 변경 */
-:root {
+/* WDS 내 primary FlowMeet 색상으로 변경.
+   WDS 내부에서 `addOpacity(theme.semantic.primary.normal, ...)` 가
+   `rgba(var(--semantic-primary-normal-rgb), α)` 로 풀리기 때문에
+   hex와 함께 -rgb 변형도 같이 잡아둬야 TextField 포커스 테두리·Switch 활성 등이
+   FlowMeet 컬러로 그려진다.
+
+   주의: WDS `global.css` 가 같은 `:root` 셀렉터로 자체 `--semantic-primary-normal`(=#0066FF)을
+   먼저 등록한다. Tailwind v4 cascade layer에서 우리 user CSS 가 layered, WDS CSS 가 unlayered
+   상태로 처리되면 unlayered 가 우선해 단순 `:root` 로는 덮이지 않는다.
+   `html:root` 로 specificity 를 한 단계 올려 확실히 덮는다. */
+html:root {
   --semantic-primary-normal: #03C98F;
+  --semantic-primary-normal-rgb: 3, 201, 143;
 }
 
 body {

--- a/frontend/src/styles/scrollbar.css
+++ b/frontend/src/styles/scrollbar.css
@@ -1,0 +1,25 @@
+/* 공통 스크롤바 — 콘텐츠 위에 얇게 얹히는 형태.
+   `overflow-y-auto` 나 컨테이너 패딩은 호출부에서 제어할 수 있도록 빼두고,
+   여기서는 스크롤바 색·두께·라운드 처리만 담는다.
+   사용 예) <ul className="custom-scrollbar overflow-y-auto pr-2" />
+*/
+@layer components {
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--color-label-alternative) 20%, transparent) transparent;
+    scrollbar-gutter: stable;
+  }
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 0.375rem;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background-color: color-mix(in srgb, var(--color-label-alternative) 20%, transparent);
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in srgb, var(--color-label-alternative) 45%, transparent);
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#116 

## 📝작업 내용
프로젝트 설정 모달 구현 및 백엔드 API 연동.

- `SettingsModalContent.tsx` — 모달 shell. 탭 상태 + `myRole` 한 번 조회 후 패널에 내려보내기
- `SettingsSidebarNav.tsx` — 좌측 탭 네비게이션 (프로젝트 / 구성원 / 알림)
- `ProjectSettingsPanel.tsx` — 프로젝트 탭. 이름 자동 저장, 이미지 업로드, 삭제/나가기
- `MembersSettingsPanel.tsx` — 구성원 탭. 멤버 목록, 이메일 초대, 권한 변경, 삭제
- `NotificationsSettingsPanel.tsx` — 알림 탭. 4개 토글
- `ProjectDeleteConfirmContent.tsx` — 프로젝트 삭제 컨펌 다이얼로그
- `ProjectLeaveConfirmContent.tsx` — 프로젝트 나가기 컨펌 다이얼로그
- `useProjectInfoForm.ts` — 프로젝트 이름 폼 상태/검증/payload 생성
- `useMemberInviteForm.ts` — 이메일 초대 입력 + 대기 Chip 관리
- `useProjectNotificationsForm.ts` — 알림 토글
- `types.ts` — 패널 간 공유하는 `ProjectMemberRole` 등 타입
- `index.ts` — 공개 export 모음


### 스크린샷 (선택)
<img width="830" height="604" alt="스크린샷 2026-05-12 오전 10 43 13" src="https://github.com/user-attachments/assets/4c4c3810-65e0-4513-b2dc-61cec47e32da" />
<img width="824" height="597" alt="스크린샷 2026-05-12 오전 10 43 01" src="https://github.com/user-attachments/assets/2d665f3f-1994-422c-b611-b2f99b1eba52" />
<img width="824" height="592" alt="스크린샷 2026-05-12 오전 10 42 54" src="https://github.com/user-attachments/assets/2e75376c-9d91-4a02-894c-8ac2587995be" />
<img width="836" height="596" alt="스크린샷 2026-05-12 오전 10 42 38" src="https://github.com/user-attachments/assets/4ac79b16-80be-4376-96b1-ee7957ae47f6" />

## 💬리뷰 요구사항(선택)
- 초대 대기는 아직 백엔드 엔드포인트가 없어서 이후에 수정해도 괜찮을까요?