### PR TITLE
[Feat/#207] mcp client를 fastapi로 wrapping

### DIFF
--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -14,7 +14,10 @@ class Agent:
         self.model = "gemini-2.5-flash"
         self.conversation_history = []
         self._tools = None
- 
+
+    async def close(self):
+        pass
+
     async def _get_gemini_tools(self) -> list[types.Tool]:
         mcp_tools = await self.mcp_client.list_tools()
  
@@ -51,7 +54,7 @@ class Agent:
                 config=types.GenerateContentConfig(
                     tools=self._tools,
                     thinking_config=types.ThinkingConfig(
-                        thinking_budget=512 #응답 너무 느리면 0으로 변경 가능
+                        thinking_budget=512 # 응답 너무 느리면 0으로 변경 가능
                     ),
                 ),
             )

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -1,32 +1,82 @@
+import os
+import uuid
 import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
 from client import MCPClient
 from agent import Agent
-import sys
- 
- 
-async def main():
-    mcp_client = MCPClient()
- 
-    try:
-        await mcp_client.connect_sse("")  #mcp server url 추가해주세요
- 
-        agent = Agent(mcp_client=mcp_client)
- 
-        while True:
-            user_input = await asyncio.get_running_loop().run_in_executor(None, sys.stdin.readline)
-            user_input = user_input.strip()
 
-            if user_input.lower() in ("exit", "quit"):
-                break
-            if not user_input:
-                continue
- 
-            response = await agent.run(user_input)
-            print(f"Agent: {response}\n")
- 
-    finally:
-        await mcp_client.close()
- 
- 
-if __name__ == "__main__":
-    asyncio.run(main())
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "")
+SESSION_TTL_MINUTES = 30
+
+mcp_client: MCPClient = None
+sessions: dict[str, dict] = {}  # {session_id: {"agent", "last_active", "lock"}}
+
+
+async def get_or_create_session(session_id: str) -> dict:
+    now = datetime.utcnow()
+
+    # 만료 세션 정리
+    expired = [sid for sid, s in sessions.items()
+               if now - s["last_active"] > timedelta(minutes=SESSION_TTL_MINUTES)]
+    for sid in expired:
+        await sessions[sid]["agent"].close()
+        del sessions[sid]
+
+    if session_id not in sessions:
+        sessions[session_id] = {
+            "agent": Agent(mcp_client=mcp_client),
+            "last_active": now,
+            "lock": asyncio.Lock(), 
+        }
+    else:
+        sessions[session_id]["last_active"] = now
+
+    return sessions[session_id]
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global mcp_client
+    mcp_client = MCPClient()
+    await mcp_client.connect_sse(MCP_SERVER_URL)  # mcp server url 추가해주세요
+    yield
+    await mcp_client.close()
+
+
+app = FastAPI(lifespan=lifespan)
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    session_id: str
+
+
+@app.get("/health") #서버 상태 확인용
+async def health():
+    return {"status": "ok", "active_sessions": len(sessions)}
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(body: ChatRequest):
+    if not body.message.strip():
+        raise HTTPException(status_code=400, detail="message가 비어있습니다.")
+
+    session_id = body.session_id or str(uuid.uuid4())
+    session = await get_or_create_session(session_id)
+
+    async with session["lock"]:
+        response = await session["agent"].run(body.message)
+
+    return ChatResponse(response=response, session_id=session_id)

--- a/ai/agent/requirements.txt
+++ b/ai/agent/requirements.txt
@@ -1,2 +1,4 @@
-mcp
+fastapi
+uvicorn[standard]
 google-genai
+mcp


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #207 

## 📝작업 내용

> AWS EC2/ECS에 올리기 위해 MCP client 관련 코드를 웹 API 서버(FastAPI)로 래핑하였습니다.

생성한 endpoint
- /health : 서버 상태 체크 용도
- /chat : 이전의 main과 동일한 역할 수행

main.py의 return ChatResponse(response=response, session_id=session_id)가 
기존 main.py의 print(f"Agent: {response}\n")를 대체합니다.
API 호출한 쪽에서 response 필드로 받으면 됩니다.

session_id를 분리하여 Agent가 싱글톤 하나로 히스토리를 공유하는 이슈를 보완했습니다.

세션 초기화 기능 확장 가능성을 고려하여 Agent.close() 추가하였으나, 현재 TTL을 통해 일정 시간이 지나면 자동 만료됨 + 아직 삭제할 리소스 없음과 같은 이유로 형식만 구현해두었습니다.

requirement.txt를 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 