### PR TITLE
[Feat/#214] y-websocket 서버 구축 및 배포

### DIFF
--- a/.github/workflows/deploy-wss.yml
+++ b/.github/workflows/deploy-wss.yml
@@ -2,7 +2,7 @@ name: WSS CI/CD
 
 on:
   push:
-    branches: [wss/develop]
+    branches: [backend/develop]
     paths:
       - 'wss/**'
       - '.github/workflows/deploy-wss.yml'

--- a/.github/workflows/deploy-wss.yml
+++ b/.github/workflows/deploy-wss.yml
@@ -1,0 +1,114 @@
+name: WSS CI/CD
+
+on:
+  push:
+    branches: [wss/develop]
+    paths:
+      - 'wss/**'
+      - '.github/workflows/deploy-wss.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-wss-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: flowmeet-wss
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.sha }}
+      image:     ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: meta
+        run: |
+          {
+            echo "sha=${GITHUB_SHA}"
+            echo "image=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./wss
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:latest
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy compose files to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.WSS_EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "wss/docker-compose.yml,wss/docker/nginx/**,wss/docker/scripts/**"
+          target: "/home/ubuntu/wss"
+          strip_components: 1
+
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.WSS_EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /home/ubuntu/wss
+            export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}
+            sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${IMAGE_TAG}/" .env
+
+            echo "::group::Pull & Up"
+            docker compose pull wss
+            docker compose up -d wss
+            echo "::endgroup::"
+
+            echo "::group::Wait for health"
+            for i in $(seq 1 24); do
+              status=$(docker inspect -f '{{.State.Health.Status}}' flowmeet-wss 2>/dev/null || echo "starting")
+              echo "[$i/24] wss health: $status"
+              if [ "$status" = "healthy" ]; then
+                echo "healthy"
+                break
+              fi
+              if [ "$i" -eq 24 ]; then
+                echo "::error::wss did not become healthy within 2 minutes"
+                docker compose logs --tail=200 wss
+                exit 1
+              fi
+              sleep 5
+            done
+            echo "::endgroup::"
+
+            docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .idea/
 docs/
+!wss/docs/
+!wss/docs/**

--- a/wss/.env.example
+++ b/wss/.env.example
@@ -1,0 +1,10 @@
+PORT=1234
+HOST=https://your-domain.com
+
+# nginx / certbot
+DOMAIN=your-domain.com
+CERTBOT_EMAIL=your-email@example.com
+
+# docker-compose (EC2에서만 사용)
+DOCKERHUB_USERNAME=your-dockerhub-username
+IMAGE_TAG=latest

--- a/wss/.gitignore
+++ b/wss/.gitignore
@@ -1,0 +1,7 @@
+.env
+.env.*
+!.env.example
+
+.idea/
+
+node_modules/

--- a/wss/Dockerfile
+++ b/wss/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+WORKDIR /app
+RUN corepack enable pnpm
+COPY --chown=node:node package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY --chown=node:node index.mjs ./
+USER node
+EXPOSE 1234
+CMD ["node", "index.mjs"]

--- a/wss/docker-compose.yml
+++ b/wss/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  wss:
+    image: ${DOCKERHUB_USERNAME}/flowmeet-wss:${IMAGE_TAG:-latest}
+    container_name: flowmeet-wss
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      PORT: 1234
+    expose:
+      - "1234"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('net').connect(1234,'localhost').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))\""]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - wss-net
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: flowmeet-wss-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN}
+    volumes:
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/nginx/conf.d:/etc/nginx/templates:ro
+      - ./docker/certbot/conf:/etc/letsencrypt:ro
+      - ./docker/certbot/www:/var/www/certbot:ro
+    # 인증서 갱신 반영을 위해 6시간마다 nginx reload
+    command: >
+      /bin/sh -c "/docker-entrypoint.d/20-envsubst-on-templates.sh &&
+      { while :; do sleep 6h & wait $${!}; nginx -s reload; done & } &&
+      exec nginx -g 'daemon off;'"
+    depends_on:
+      wss:
+        condition: service_healthy
+    networks:
+      - wss-net
+
+  certbot:
+    image: certbot/certbot:latest
+    container_name: flowmeet-wss-certbot
+    restart: unless-stopped
+    volumes:
+      - ./docker/certbot/conf:/etc/letsencrypt
+      - ./docker/certbot/www:/var/www/certbot
+    # 12시간마다 renew 시도 (최초 발급은 init-letsencrypt.sh 로)
+    entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'
+
+networks:
+  wss-net:
+    driver: bridge

--- a/wss/docker/nginx/conf.d/app.conf.template
+++ b/wss/docker/nginx/conf.d/app.conf.template
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    server_name ${DOMAIN};
+
+    # Let's Encrypt HTTP-01 challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name ${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # WebSocket 연결은 장시간 유지됨
+    proxy_read_timeout  3600s;
+    proxy_send_timeout  3600s;
+    proxy_connect_timeout 10s;
+
+    location / {
+        proxy_pass         http://wss:1234;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade    $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+    }
+}

--- a/wss/docker/nginx/nginx.conf
+++ b/wss/docker/nginx/nginx.conf
@@ -1,0 +1,27 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid       /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    tcp_nopush      on;
+    keepalive_timeout 65;
+
+    server_tokens off;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/wss/docker/scripts/init-letsencrypt.sh
+++ b/wss/docker/scripts/init-letsencrypt.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Let's Encrypt 최초 인증서 발급 스크립트.
+#
+# 동작 순서
+#   1) 더미 self-signed 인증서 생성 → nginx 가 일단 뜰 수 있게 함
+#   2) nginx 기동 (80 포트 오픈, /.well-known/acme-challenge/ 서빙)
+#   3) 더미 인증서 제거
+#   4) certbot 로 실제 인증서 발급
+#   5) nginx reload
+#
+# 사전 조건
+#   - .env 파일에 DOMAIN, CERTBOT_EMAIL 이 채워져 있어야 한다
+#   - 이 호스트(EC2) 80 포트로 ${DOMAIN} 이 DNS 상 연결되어 있어야 한다
+#
+# 사용법: ./docker/scripts/init-letsencrypt.sh
+# 재발급/강제 갱신: ./docker/scripts/init-letsencrypt.sh --force
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if [ ! -f .env ]; then
+  echo ".env 파일이 없습니다. 프로젝트 루트에 .env 를 먼저 만들어 주세요." >&2
+  exit 1
+fi
+
+# .env 로드
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+: "${DOMAIN:?DOMAIN 환경변수가 .env 에 설정되어야 합니다}"
+: "${CERTBOT_EMAIL:?CERTBOT_EMAIL 환경변수가 .env 에 설정되어야 합니다}"
+
+FORCE="${1:-}"
+
+DATA_PATH="./docker/certbot"
+STAGING=0   # 1 로 바꾸면 Let's Encrypt 스테이징 환경 사용 (rate limit 회피)
+
+# 이미 인증서가 있으면 기본적으로 스킵
+if [ -d "$DATA_PATH/conf/live/$DOMAIN" ] && [ "$FORCE" != "--force" ]; then
+  echo "이미 $DOMAIN 인증서가 존재합니다. 재발급하려면 --force 옵션을 붙여 주세요."
+  exit 0
+fi
+
+# 권장 nginx TLS 옵션 / DH 파라미터 내려받기 (certbot 공식)
+if [ ! -e "$DATA_PATH/conf/options-ssl-nginx.conf" ] || [ ! -e "$DATA_PATH/conf/ssl-dhparams.pem" ]; then
+  echo "### 권장 TLS 파라미터 다운로드"
+  mkdir -p "$DATA_PATH/conf"
+  curl -fsSL https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf \
+    > "$DATA_PATH/conf/options-ssl-nginx.conf"
+  curl -fsSL https://ssl-config.mozilla.org/ffdhe2048.txt \
+    > "$DATA_PATH/conf/ssl-dhparams.pem"
+fi
+
+echo "### 더미 인증서 생성 ($DOMAIN)"
+path="/etc/letsencrypt/live/$DOMAIN"
+mkdir -p "$DATA_PATH/conf/live/$DOMAIN"
+
+docker compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:4096 -days 1 \
+    -keyout '$path/privkey.pem' \
+    -out    '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+
+echo "### nginx 기동"
+docker compose up --force-recreate -d nginx
+
+echo "### 더미 인증서 제거"
+docker compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$DOMAIN && \
+  rm -Rf /etc/letsencrypt/archive/$DOMAIN && \
+  rm -Rf /etc/letsencrypt/renewal/$DOMAIN.conf" certbot
+
+echo "### Let's Encrypt 인증서 발급 요청"
+staging_arg=""
+if [ $STAGING -ne 0 ]; then staging_arg="--staging"; fi
+
+docker compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    --email $CERTBOT_EMAIL \
+    -d $DOMAIN \
+    --rsa-key-size 4096 \
+    --agree-tos \
+    --no-eff-email \
+    --force-renewal" certbot
+
+echo "### nginx reload"
+docker compose exec nginx nginx -s reload
+
+echo "완료. wss://$DOMAIN 로 접근해 인증서를 확인하세요."

--- a/wss/docs/ec2-deploy.md
+++ b/wss/docs/ec2-deploy.md
@@ -1,0 +1,230 @@
+# WSS EC2 배포 메뉴얼
+
+## 사전 조건
+
+- EC2 인스턴스 (Ubuntu 22.04 LTS, t3.micro 이상)
+- 보안 그룹 인바운드: **22(SSH), 80(HTTP), 443(HTTPS)** 허용
+- 도메인 DNS A 레코드가 이 EC2 퍼블릭 IP로 연결되어 있어야 함
+- Docker, Docker Compose 설치 완료
+
+---
+
+## 1. EC2 접속
+
+```bash
+ssh -i your-key.pem ubuntu@<EC2_PUBLIC_IP>
+```
+
+---
+
+## 2. Docker 설치 (미설치 시)
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker ubuntu
+newgrp docker
+```
+
+---
+
+## 3. 배포 디렉토리 생성 및 .env 작성
+
+```bash
+mkdir -p /home/ubuntu/wss
+cd /home/ubuntu/wss
+```
+
+`.env` 파일 생성 (`.env.example` 참고):
+
+```bash
+cat > .env <<'EOF'
+PORT=1234
+HOST=https://your-domain.com
+
+DOMAIN=your-domain.com
+CERTBOT_EMAIL=your-email@example.com
+
+DOCKERHUB_USERNAME=your-dockerhub-username
+IMAGE_TAG=latest
+EOF
+```
+
+> `HOST` 와 `DOMAIN` 모두 실제 도메인으로 채운다.  
+> `HOST` 는 Node.js 앱이 사용하는 공개 URL, `DOMAIN` 은 nginx / certbot 이 사용하는 도메인.
+
+---
+
+## 4. Docker Hub 로그인
+
+```bash
+docker login
+```
+
+---
+
+## 5. nginx·certbot 설정 파일 배치
+
+EC2에 `docker-compose.yml` 과 `docker/` 디렉토리가 없는 상태이므로 아래 두 방법 중 하나로 배치한다.
+
+### 옵션 A — 레포 클론 후 복사 (빠름)
+
+```bash
+git clone https://github.com/<org>/<repo>.git /tmp/repo
+cp /tmp/repo/wss/docker-compose.yml /home/ubuntu/wss/
+cp -r /tmp/repo/wss/docker /home/ubuntu/wss/
+rm -rf /tmp/repo
+```
+
+이후 6단계(인증서 발급)로 진행한다.
+
+### 옵션 B — GitHub Actions workflow_dispatch 로 파일 수신
+
+Actions 배포 워크플로우(`deploy-wss.yml`)가 SCP로 파일을 보내 주는 것을 이용한다.  
+단, 워크플로우 마지막에 `docker compose up -d wss` 를 실행하므로 **`.env` 가 EC2에 먼저 있어야** 한다 (3단계 완료 후 진행).
+
+**① GitHub Actions 수동 실행**
+
+GitHub 레포 → Actions 탭 → `WSS CI/CD` → **Run workflow** (브랜치: `wss/develop`)
+
+워크플로우가 완료되면 EC2에 다음이 준비된다:
+
+```
+/home/ubuntu/wss/
+├── docker-compose.yml
+├── docker/
+│   ├── nginx/
+│   └── scripts/
+└── .env                  ← 3단계에서 직접 작성한 파일 (변경 없음)
+```
+
+`wss` 컨테이너는 이미 기동된 상태다.
+
+**② 인증서 발급은 여전히 수동으로 진행 (6단계)**
+
+Actions 은 `wss` 서비스만 올리고 nginx·certbot 은 올리지 않는다.  
+SSH 로 재접속해 6단계부터 이어서 진행한다.
+
+---
+
+## 6. 최초 SSL 인증서 발급
+
+```bash
+cd /home/ubuntu/wss
+chmod +x docker/scripts/init-letsencrypt.sh
+./docker/scripts/init-letsencrypt.sh
+```
+
+스크립트가 하는 일:
+
+1. 더미 self-signed 인증서 생성
+2. nginx 를 80 포트로 기동해 HTTP-01 challenge 준비
+3. 더미 인증서 제거
+4. certbot 으로 Let's Encrypt 실제 인증서 발급
+5. nginx reload
+
+성공 시 출력:
+```
+완료. wss://your-domain.com 로 접근해 인증서를 확인하세요.
+```
+
+> DNS 전파가 덜 됐다면 발급에 실패한다. `nslookup your-domain.com` 으로 IP 가 맞는지 먼저 확인한다.
+
+---
+
+## 7. 전체 스택 기동
+
+```bash
+cd /home/ubuntu/wss
+docker compose up -d
+```
+
+컨테이너 상태 확인:
+
+```bash
+docker compose ps
+```
+
+정상 상태:
+
+```
+NAME                  STATUS
+flowmeet-wss          Up (healthy)
+flowmeet-wss-nginx    Up
+flowmeet-wss-certbot  Up
+```
+
+---
+
+## 8. 동작 확인
+
+브라우저 또는 wscat 으로 확인:
+
+```bash
+# wscat 설치
+npm install -g wscat
+
+# 연결 테스트 (룸 이름: test-room)
+wscat -c wss://your-domain.com/test-room
+```
+
+nginx 로그:
+
+```bash
+docker compose logs -f nginx
+```
+
+WSS 앱 로그:
+
+```bash
+docker compose logs -f wss
+```
+
+---
+
+## 9. GitHub Actions 시크릿 등록
+
+| Secret 키 | 값 |
+|---|---|
+| `WSS_EC2_HOST` | EC2 퍼블릭 IP |
+| `EC2_USER` | `ubuntu` |
+| `EC2_SSH_KEY` | EC2 SSH 프라이빗 키 전체 내용 |
+| `DOCKERHUB_USERNAME` | Docker Hub 유저명 |
+| `DOCKERHUB_TOKEN` | Docker Hub Access Token |
+
+등록 후 `wss/develop` 브랜치에 push 하면 자동 빌드·배포가 진행된다.
+
+---
+
+## 운영 커맨드
+
+### 로그 실시간 확인
+```bash
+docker compose logs -f wss
+docker compose logs -f nginx
+```
+
+### 서비스 재시작
+```bash
+docker compose restart wss
+```
+
+### 인증서 수동 갱신
+```bash
+docker compose run --rm certbot certbot renew
+docker compose exec nginx nginx -s reload
+```
+
+### 인증서 만료일 확인
+```bash
+docker compose run --rm certbot certbot certificates
+```
+
+### 전체 서비스 중지
+```bash
+docker compose down
+```
+
+### 이미지·컨테이너 정리
+```bash
+docker image prune -f
+```

--- a/wss/index.mjs
+++ b/wss/index.mjs
@@ -1,0 +1,109 @@
+import 'dotenv/config';
+import { createServer } from 'http';
+import * as Y from 'yjs';
+import * as awarenessProtocol from 'y-protocols/awareness';
+import * as syncProtocol from 'y-protocols/sync';
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import { WebSocketServer } from 'ws';
+
+const PORT = parseInt(process.env.PORT ?? '1234', 10);
+const HOST = process.env.HOST ?? 'http://localhost';
+
+const MESSAGE_SYNC = 0;
+const MESSAGE_AWARENESS = 1;
+
+// 룸 이름 → { doc: Y.Doc, awareness: Awareness, conns: Set<WebSocket> }
+const rooms = new Map();
+
+function getOrCreateRoom(roomName) {
+  if (rooms.has(roomName)) return rooms.get(roomName);
+
+  const doc = new Y.Doc();
+  const awareness = new awarenessProtocol.Awareness(doc);
+  const conns = new Set();
+
+  // 문서 업데이트를 같은 룸의 모든 클라이언트에 브로드캐스트
+  doc.on('update', (update) => {
+    const msg = encoding.createEncoder();
+    encoding.writeVarUint(msg, MESSAGE_SYNC);
+    syncProtocol.writeUpdate(msg, update);
+    const buf = encoding.toUint8Array(msg);
+    conns.forEach((conn) => conn.readyState === 1 && conn.send(buf));
+  });
+
+  // awareness 변경을 브로드캐스트
+  awareness.on('update', ({ added, updated, removed }) => {
+    const changed = [...added, ...updated, ...removed];
+    const msg = encoding.createEncoder();
+    encoding.writeVarUint(msg, MESSAGE_AWARENESS);
+    encoding.writeVarUint8Array(msg, awarenessProtocol.encodeAwarenessUpdate(awareness, changed));
+    const buf = encoding.toUint8Array(msg);
+    conns.forEach((conn) => conn.readyState === 1 && conn.send(buf));
+  });
+
+  const room = { doc, awareness, conns };
+  rooms.set(roomName, room);
+  return room;
+}
+
+function setupConnection(ws, roomName) {
+  const { doc, awareness, conns } = getOrCreateRoom(roomName);
+  conns.add(ws);
+
+  ws.binaryType = 'arraybuffer';
+
+  // Sync Step 1: 현재 상태 벡터 전송
+  const syncMsg = encoding.createEncoder();
+  encoding.writeVarUint(syncMsg, MESSAGE_SYNC);
+  syncProtocol.writeSyncStep1(syncMsg, doc);
+  ws.send(encoding.toUint8Array(syncMsg));
+
+  // 현재 awareness 상태 전송
+  const states = awareness.getStates();
+  if (states.size > 0) {
+    const awarenessMsg = encoding.createEncoder();
+    encoding.writeVarUint(awarenessMsg, MESSAGE_AWARENESS);
+    encoding.writeVarUint8Array(
+      awarenessMsg,
+      awarenessProtocol.encodeAwarenessUpdate(awareness, Array.from(states.keys())),
+    );
+    ws.send(encoding.toUint8Array(awarenessMsg));
+  }
+
+  ws.on('message', (data) => {
+    const decoder = decoding.createDecoder(new Uint8Array(data));
+    const msgType = decoding.readVarUint(decoder);
+
+    if (msgType === MESSAGE_SYNC) {
+      const reply = encoding.createEncoder();
+      encoding.writeVarUint(reply, MESSAGE_SYNC);
+      syncProtocol.readSyncMessage(decoder, reply, doc, null);
+      if (encoding.length(reply) > 1) ws.send(encoding.toUint8Array(reply));
+    } else if (msgType === MESSAGE_AWARENESS) {
+      awarenessProtocol.applyAwarenessUpdate(awareness, decoding.readVarUint8Array(decoder), ws);
+    }
+  });
+
+  ws.on('close', () => {
+    conns.delete(ws);
+    awarenessProtocol.removeAwarenessStates(awareness, [doc.clientID], null);
+    // 연결이 없으면 룸 정리
+    if (conns.size === 0) rooms.delete(roomName);
+  });
+}
+
+const server = createServer();
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', (ws, req) => {
+  // 쿼리스트링 제거 후 룸 이름 추출 (예: /node-42?token=... → "node-42")
+  const url = new URL(req.url ?? '/', HOST);
+  const roomName = url.pathname.slice(1) || 'default';
+  setupConnection(ws, roomName);
+});
+
+server.listen(PORT, () => {
+  const wsUrl = HOST.replace(/^http/, 'ws');
+  console.log(`Yjs 서버 실행 중: ${wsUrl}:${PORT}`);
+});

--- a/wss/package.json
+++ b/wss/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wss",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.mjs",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.mjs"
+  },
+  "dependencies": {
+    "dotenv": "^17.4.2",
+    "y-websocket": "^3.0.0",
+    "yjs": "^13.6.29"
+  },
+  "devDependencies": {
+    "lib0": "^0.2.117",
+    "wait-on": "^9.0.4",
+    "ws": "^8.20.0",
+    "y-protocols": "^1.0.7"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.18.2"
+}

--- a/wss/pnpm-lock.yaml
+++ b/wss/pnpm-lock.yaml
@@ -1,0 +1,423 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      y-websocket:
+        specifier: ^3.0.0
+        version: 3.0.0(yjs@13.6.30)
+      yjs:
+        specifier: ^13.6.29
+        version: 13.6.30
+    devDependencies:
+      lib0:
+        specifier: ^0.2.117
+        version: 0.2.117
+      wait-on:
+        specifier: ^9.0.4
+        version: 9.0.10
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.1
+      y-protocols:
+        specifier: ^1.0.7
+        version: 1.0.7(yjs@13.6.30)
+
+packages:
+
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.6':
+    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
+  joi@18.2.1:
+    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
+    engines: {node: '>= 20'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  wait-on@9.0.10:
+    resolution: {integrity: sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
+  y-websocket@3.0.0:
+    resolution: {integrity: sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.5.6
+
+  yjs@13.6.30:
+    resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+
+snapshots:
+
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.6': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@standard-schema/spec@1.1.0': {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  asynckit@0.4.0: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
+  dotenv@17.4.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  isomorphic.js@0.2.5: {}
+
+  joi@18.2.1:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.6
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
+
+  lodash@4.18.1: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimist@1.2.8: {}
+
+  ms@2.1.3: {}
+
+  proxy-from-env@2.1.0: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  tslib@2.8.1: {}
+
+  wait-on@9.0.10:
+    dependencies:
+      axios: 1.16.1
+      joi: 18.2.1
+      lodash: 4.18.1
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  ws@8.20.1: {}
+
+  y-protocols@1.0.7(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.30
+
+  y-websocket@3.0.0(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      y-protocols: 1.0.7(yjs@13.6.30)
+      yjs: 13.6.30
+
+  yjs@13.6.30:
+    dependencies:
+      lib0: 0.2.117


### PR DESCRIPTION
## #️⃣연관된 이슈

#214

## 📝작업 내용

실시간 협업 편집을 위한 Yjs WebSocket 서버(`wss/`)를 구현하고, EC2 배포 파이프라인을 구성했습니다.

### WSS 서버 구현

- `y-protocols` 기반 Sync / Awareness 프로토콜 처리
- 룸 단위(`/roomName`)로 문서 상태와 접속자 awareness를 관리
- 룸에 연결이 없어지면 메모리에서 자동 정리

### 환경변수 설정 (dotenv)

- `PORT`: 서버 포트 (기본 `1234`)
- `HOST`: 스킴 포함 공개 URL (예: `https://wss.example.com`)
  - `http://` → `ws://`, `https://` → `wss://` 자동 변환
- `.env.example` 제공

### Docker / nginx 배포 설정

- `Dockerfile`: `node:22-alpine` + pnpm, non-root(`node`) 유저로 실행
- `docker-compose.yml`: `wss` + `nginx` + `certbot` 3-service 구성
- nginx: WebSocket 프록시 (`Upgrade` / `Connection` 헤더, `proxy_buffering off`, 타임아웃 3600s)
- certbot: Let's Encrypt 인증서 자동 갱신 (12h 주기)
- `docker/scripts/init-letsencrypt.sh`: 최초 인증서 발급 스크립트

### CI/CD

- `.github/workflows/deploy-wss.yml` 추가
- 트리거: `backend/develop` 브랜치의 `wss/**` 경로 변경 시
- 기존 `deploy.yml`(API 서버)과 `paths` 필터로 독립 실행 — 같은 브랜치를 쓰더라도 서로 간섭 없음
- Docker Hub 이미지 빌드·푸시 → EC2 SCP → SSH 배포 → 헬스체크 순으로 진행

### 문서

- `wss/docs/ec2-deploy.md`: EC2 초기 세팅부터 인증서 발급, 운영 커맨드까지 포함한 배포 메뉴얼

## 💬리뷰 요구사항(선택)

바로 머지할게요~
