### PR TITLE
[Fix/#217] 이메일 인증 API 오류 수정 및 회원가입용 인증 API 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/controller/AuthApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/controller/AuthApi.java
@@ -4,14 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.flowmeet.api.auth.dto.request.RefreshTokenRequest;
+import kr.flowmeet.api.auth.dto.request.SendAuthEmailVerificationRequest;
 import kr.flowmeet.api.auth.dto.request.SignupRequest;
 import kr.flowmeet.api.auth.dto.request.SocialLoginRequest;
+import kr.flowmeet.api.auth.dto.request.VerifyAuthEmailRequest;
 import kr.flowmeet.api.auth.dto.response.TokenResponse;
 import kr.flowmeet.api.auth.success.AuthSuccessCode;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.common.swagger.ApiErrorCode;
 import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.auth.exception.AuthErrorCode;
+import kr.flowmeet.domain.emailverification.exception.EmailVerificationErrorCode;
 import kr.flowmeet.domain.user.entity.SocialProvider;
 import kr.flowmeet.domain.user.exception.UserErrorCode;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,7 +46,23 @@ public interface AuthApi {
     @ApiErrorCode(code = UserErrorCode.class, names = {
             "USER_EMAIL_DUPLICATED", "USER_NICKNAME_DUPLICATED"
     })
+    @ApiErrorCode(code = EmailVerificationErrorCode.class, names = {"EMAIL_VERIFICATION_REQUIRED"})
     CommonResponse<TokenResponse> signup(@Valid @RequestBody SignupRequest request);
+
+    @Operation(
+            summary = "회원가입 이메일 인증 코드 발송",
+            description = "회원가입할 이메일 주소로 6자리 인증 코드를 발송합니다. 코드 유효시간은 5분입니다."
+    )
+    @ApiSuccessCode(code = AuthSuccessCode.class, name = "SEND_EMAIL_VERIFICATION")
+    @ApiErrorCode(code = UserErrorCode.class, names = {"USER_EMAIL_DUPLICATED"})
+    CommonResponse<?> sendEmailVerification(@Valid @RequestBody SendAuthEmailVerificationRequest request);
+
+    @Operation(summary = "회원가입 이메일 인증 코드 검증", description = "발송된 인증 코드로 이메일 소유를 확인합니다.")
+    @ApiSuccessCode(code = AuthSuccessCode.class, name = "VERIFY_EMAIL")
+    @ApiErrorCode(code = EmailVerificationErrorCode.class, names = {
+            "EMAIL_VERIFICATION_NOT_FOUND", "EMAIL_VERIFICATION_CODE_INVALID", "EMAIL_VERIFICATION_CODE_EXPIRED"
+    })
+    CommonResponse<?> verifyEmail(@Valid @RequestBody VerifyAuthEmailRequest request);
 
     @Operation(summary = "토큰 갱신", description = "Refresh Token 으로 Access Token 재발급")
     @ApiSuccessCode(code = AuthSuccessCode.class, name = "REFRESH")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/controller/AuthController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/controller/AuthController.java
@@ -2,8 +2,10 @@ package kr.flowmeet.api.auth.controller;
 
 import jakarta.validation.Valid;
 import kr.flowmeet.api.auth.dto.request.RefreshTokenRequest;
+import kr.flowmeet.api.auth.dto.request.SendAuthEmailVerificationRequest;
 import kr.flowmeet.api.auth.dto.request.SignupRequest;
 import kr.flowmeet.api.auth.dto.request.SocialLoginRequest;
+import kr.flowmeet.api.auth.dto.request.VerifyAuthEmailRequest;
 import kr.flowmeet.api.auth.dto.response.TokenResponse;
 import kr.flowmeet.api.auth.facade.AuthFacade;
 import kr.flowmeet.api.auth.facade.LoginResult;
@@ -56,5 +58,21 @@ public class AuthController implements AuthApi {
     public CommonResponse<?> logout(@UserId Long userId) {
         authFacade.logout(userId);
         return CommonResponse.ok(AuthSuccessCode.LOGOUT);
+    }
+
+    @Override
+    @PostMapping("/signup/email-verifications")
+    public CommonResponse<?> sendEmailVerification(
+            @Valid @RequestBody SendAuthEmailVerificationRequest request
+    ) {
+        authFacade.sendEmailVerification(request.email());
+        return CommonResponse.ok(AuthSuccessCode.SEND_EMAIL_VERIFICATION);
+    }
+
+    @Override
+    @PostMapping("/signup/email-verifications/verify")
+    public CommonResponse<?> verifyEmail(@Valid @RequestBody VerifyAuthEmailRequest request) {
+        authFacade.verifyEmail(request.email(), request.code());
+        return CommonResponse.ok(AuthSuccessCode.VERIFY_EMAIL);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/SendAuthEmailVerificationRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/SendAuthEmailVerificationRequest.java
@@ -1,0 +1,15 @@
+package kr.flowmeet.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
+
+@Schema(description = "회원가입 이메일 인증 코드 발송 요청")
+public record SendAuthEmailVerificationRequest(
+        @Schema(description = "인증할 이메일", example = "flowmin@flowmeet.kr")
+        @NotBlank(message = ValidationMessage.EMAIL_REQUIRED)
+        @Email(message = ValidationMessage.EMAIL_INVALID)
+        String email
+) {
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/VerifyAuthEmailRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/VerifyAuthEmailRequest.java
@@ -1,0 +1,19 @@
+package kr.flowmeet.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.flowmeet.api.common.validation.ValidationMessage;
+
+@Schema(description = "회원가입 이메일 인증 코드 검증 요청")
+public record VerifyAuthEmailRequest(
+        @Schema(description = "인증할 이메일", example = "flowmin@flowmeet.kr")
+        @NotBlank(message = ValidationMessage.EMAIL_REQUIRED)
+        @Email(message = ValidationMessage.EMAIL_INVALID)
+        String email,
+
+        @Schema(description = "인증 코드", example = "123456")
+        @NotBlank(message = ValidationMessage.EMAIL_VERIFICATION_CODE_REQUIRED)
+        String code
+) {
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
@@ -15,6 +15,7 @@ import kr.flowmeet.auth.exception.AuthErrorCode;
 import kr.flowmeet.auth.exception.AuthException;
 import kr.flowmeet.auth.jwt.JwtProvider;
 import kr.flowmeet.domain.auth.service.RefreshTokenService;
+import kr.flowmeet.domain.emailverification.service.EmailVerificationService;
 import kr.flowmeet.domain.user.entity.SocialProvider;
 import kr.flowmeet.domain.user.entity.User;
 import kr.flowmeet.domain.user.service.UserService;
@@ -30,6 +31,7 @@ import kr.flowmeet.external.oauth.dto.SocialUserInfo;
 public class AuthFacade {
 
     private final UserService userService;
+    private final EmailVerificationService emailVerificationService;
     private final RefreshTokenService refreshTokenService;
     private final JwtProvider jwtProvider;
     private final SocialOAuthGateway oauthGateway;
@@ -45,6 +47,7 @@ public class AuthFacade {
                 .orElseGet(() -> handleNewUser(provider, tokens, userInfo));
     }
 
+    @Transactional
     public TokenResponse signup(final SignupRequest request) {
         SocialUserInfo userInfo = oauthGateway.fetchUserInfo(
                 request.socialProvider(), request.socialAccessToken());
@@ -54,6 +57,8 @@ public class AuthFacade {
         if (userService.existsBySocialIdentity(identity)) {
             throw new AuthException(AuthErrorCode.AUTH_SOCIAL_ID_DUPLICATED);
         }
+
+        emailVerificationService.consumeVerified(request.email());
 
         CreateUserCommand command = CreateUserCommand.of(
                 request.socialProvider(),
@@ -76,6 +81,17 @@ public class AuthFacade {
 
         User user = userService.findById(userId);
         return issueTokens(user.getId(), user.getEmail(), user.getNickname());
+    }
+
+    @Transactional
+    public void sendEmailVerification(final String email) {
+        userService.validateEmailNotDuplicated(email);
+        emailVerificationService.issueCode(email);
+    }
+
+    @Transactional
+    public void verifyEmail(final String email, final String code) {
+        emailVerificationService.verify(email, code);
     }
 
     @Transactional

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/success/AuthSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/success/AuthSuccessCode.java
@@ -11,7 +11,9 @@ public enum AuthSuccessCode implements SuccessCode {
     SIGNUP_REQUIRED("회원가입이 필요해요."),
     SIGNUP("회원가입에 성공했어요."),
     REFRESH("토큰을 갱신했어요."),
-    LOGOUT("로그아웃되었어요.");
+    LOGOUT("로그아웃되었어요."),
+    SEND_EMAIL_VERIFICATION("인증 코드를 보냈어요. 메일함을 확인해 주세요."),
+    VERIFY_EMAIL("이메일 인증에 성공했어요.");
 
     private final String message;
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
@@ -40,10 +40,12 @@ public class UserFacade {
             user.updateNickname(request.nickname());
         }
 
-        if (request.email() != null && !request.email().equals(user.getEmail())) {
-            userService.validateEmailChangeable(request.email(), user.getEmail());
-            emailVerificationService.consumeVerified(userId, request.email());
-            user.updateEmail(request.email());
+        String newEmail = request.email();
+
+        if (newEmail != null && !newEmail.equals(user.getEmail())) {
+            userService.validateEmailChangeable(newEmail, user.getEmail());
+            emailVerificationService.consumeVerified(userId, newEmail);
+            user.updateEmail(newEmail);
         }
 
         return UpdateUserResponse.from(user);

--- a/backend/flowmeet-api/src/main/resources/db/migration/V19__make_email_verification_user_id_nullable.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V19__make_email_verification_user_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE email_verifications ALTER COLUMN user_id DROP NOT NULL;

--- a/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/security/SecurityWhiteList.java
+++ b/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/security/SecurityWhiteList.java
@@ -5,6 +5,8 @@ public class SecurityWhiteList {
             "/v1/auth/login/**",
             "/v1/auth/signup",
             "/v1/auth/refresh",
+            "/v1/auth/signup/email-verifications",
+            "/v1/auth/signup/email-verifications/verify",
             "/test/**",
             "/actuator/health",
             "/actuator/health/**"

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/entity/EmailVerification.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/entity/EmailVerification.java
@@ -34,7 +34,7 @@ public class EmailVerification extends BaseCreatedTimeEntity {
     @Column(name = "email_verification_id")
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id")
     private Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/repository/EmailVerificationRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/repository/EmailVerificationRepository.java
@@ -2,9 +2,6 @@ package kr.flowmeet.domain.emailverification.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import kr.flowmeet.domain.emailverification.entity.EmailVerification;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
@@ -17,7 +14,15 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
             Long userId, String email
     );
 
-    @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM EmailVerification ev WHERE ev.userId = :userId AND ev.email = :email")
-    int deleteAllByUserIdAndEmail(@Param("userId") Long userId, @Param("email") String email);
+    void deleteAllByUserIdAndEmail(Long userId, String email);
+
+    Optional<EmailVerification> findTopByUserIdIsNullAndEmailAndVerifiedAtIsNullOrderByCreatedAtDesc(
+            String email
+    );
+
+    Optional<EmailVerification> findTopByUserIdIsNullAndEmailAndVerifiedAtIsNotNullOrderByCreatedAtDesc(
+            String email
+    );
+
+    void deleteAllByUserIdIsNullAndEmail(String email);
 }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/emailverification/service/EmailVerificationService.java
@@ -70,6 +70,49 @@ public class EmailVerificationService {
         emailVerificationRepository.deleteAllByUserIdAndEmail(userId, email);
     }
 
+    @Transactional
+    public EmailVerification issueCode(final String email) {
+        emailVerificationRepository.deleteAllByUserIdIsNullAndEmail(email);
+
+        EmailVerification verification = EmailVerification.builder()
+                .email(email)
+                .code(generateCode())
+                .expiresAt(LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES))
+                .build();
+
+        EmailVerification saved = emailVerificationRepository.save(verification);
+
+        eventPublisher.publishEvent(EmailVerificationIssuedEvent.of(saved.getEmail(), saved.getCode()));
+
+        return saved;
+    }
+
+    @Transactional
+    public void verify(final String email, final String code) {
+        EmailVerification verification = emailVerificationRepository
+                .findTopByUserIdIsNullAndEmailAndVerifiedAtIsNullOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_NOT_FOUND));
+
+        if (verification.isExpired()) {
+            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!verification.matchesCode(code)) {
+            throw new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_CODE_INVALID);
+        }
+
+        verification.markVerified();
+    }
+
+    @Transactional
+    public void consumeVerified(final String email) {
+        emailVerificationRepository
+                .findTopByUserIdIsNullAndEmailAndVerifiedAtIsNotNullOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new BusinessException(EmailVerificationErrorCode.EMAIL_VERIFICATION_REQUIRED));
+
+        emailVerificationRepository.deleteAllByUserIdIsNullAndEmail(email);
+    }
+
     private String generateCode() {
         int value = RANDOM.nextInt(CODE_BOUND);
         return String.format("%0" + CODE_LENGTH + "d", value);


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #217

## 📝작업 내용

### 1. 이메일 변경 미반영 버그 수정

`PATCH /v1/users/me`로 이메일을 변경할 때 200 응답은 오지만 실제로 DB에 반영되지 않는 버그를 수정했습니다.

**원인**

`EmailVerificationRepository.deleteAllByUserIdAndEmail`에 `@Modifying(clearAutomatically = true)`가 선언되어 있어, 벌크 DELETE 실행 후 `EntityManager.clear()`가 호출됐습니다. `UserFacade.updateMe`와 동일한 트랜잭션을 공유하기 때문에 이 시점에 앞서 로드된 `User` 엔티티가 준영속(detached) 상태로 전환되고, 이후 `user.updateEmail()`을 호출해도 dirty checking 대상에서 제외되어 UPDATE 쿼리가 생성되지 않았습니다.

**수정**

`@Modifying` + `@Query`를 제거하고 Spring Data JPA의 derived delete(`void deleteAllByUserIdAndEmail(...)`)로 교체했습니다. Derived delete는 엔티티를 먼저 조회한 뒤 `em.remove()`를 호출하는 방식이라 `EntityManager`를 초기화하지 않습니다.

---

### 2. 회원가입 이메일 인증 API 구현

기존 이메일 인증 플로우(`/v1/users/me/email-verifications`)는 JWT 인증이 필요해 미가입 사용자가 사용할 수 없습니다. 회원가입 전용 인증 엔드포인트를 별도로 추가했습니다.

**새 엔드포인트** (인증 불필요)

| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST | `/v1/auth/signup/email-verifications` | 인증 코드 발송 |
| POST | `/v1/auth/signup/email-verifications/verify` | 인증 코드 검증 |

**테이블 공유 방식**

기존 `email_verifications` 테이블을 그대로 사용하고, `user_id` 컬럼을 nullable로 변경했습니다(V19 마이그레이션). 회원가입 인증 레코드는 `user_id = NULL`로 저장되어 이메일 변경 인증 레코드와 구분됩니다.

**회원가입 플로우 변경**

`POST /v1/auth/signup` 호출 시 내부적으로 `consumeVerified(email)`을 실행합니다. 인증되지 않은 이메일로 가입을 시도하면 `EMAIL_VERIFICATION_REQUIRED` 에러를 반환합니다.

```
POST /v1/auth/signup/email-verifications      ← 코드 발송
POST /v1/auth/signup/email-verifications/verify ← 코드 검증
POST /v1/auth/signup                           ← 회원가입 (인증 소비)
```

## 💬리뷰 요구사항(선택)

- 회원가입 직전 `consumeVerified` 위치가 적절한지 확인 부탁드립니다. 소셜 토큰 검증 → 소셜 ID 중복 확인 → 이메일 인증 소비 → 유저 생성 순서로 배치했습니다.
