### PR TITLE
[HOTFIX/#223] RefreshToken 수정시각 추가되지 않던 현상 수정

### DIFF
--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/auth/entity/RefreshToken.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/auth/entity/RefreshToken.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import kr.flowmeet.domain.common.BaseTimeEntity;
+import kr.flowmeet.domain.common.BaseCreatedTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "refresh_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken extends BaseTimeEntity {
+public class RefreshToken extends BaseCreatedTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #223

## 📝작업 내용

### RefreshToken 베이스 엔티티를 `BaseCreatedTimeEntity`로 변경

`RefreshToken`이 `BaseTimeEntity`를 상속하고 있어 `createdAt`과 `updatedAt`이 모두 매핑되고 있었습니다. 그러나 리프레시 토큰은 발급 후 내용이 변경되지 않는 불변 객체이므로 `updatedAt`이 필요하지 않습니다.

**변경 전**

```java
public class RefreshToken extends BaseTimeEntity { ... }
// → createdAt, updatedAt 모두 매핑
```

**변경 후**

```java
public class RefreshToken extends BaseCreatedTimeEntity { ... }
// → createdAt 만 매핑
```

`BaseCreatedTimeEntity`는 `@CreatedDate`로 관리되는 `createdAt` 필드만 갖는 추상 클래스입니다. 이를 상속함으로써 `updatedAt` 컬럼을 ORM 레벨에서 제거해 엔티티 스펙을 실제 사용 패턴에 맞게 좁혔습니다.

## 💬리뷰 요구사항(선택)