### PR TITLE
[Fix/#222] 닉네임 중복 검증 수정

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/user/facade/UserFacade.java
@@ -36,7 +36,6 @@ public class UserFacade {
         User user = userService.findById(userId);
 
         if (request.nickname() != null) {
-            userService.validateNicknameNotDuplicated(request.nickname(), user.getNickname());
             user.updateNickname(request.nickname());
         }
 

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,6 @@ import kr.flowmeet.common.exception.ErrorCode;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없어요."),
-    USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임이에요."),
     USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 이메일이에요."),
     USER_EMAIL_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "지금 사용 중인 이메일이에요. 다른 이메일을 입력해 주세요."),
     USER_IS_PROJECT_OWNER(HttpStatus.BAD_REQUEST, "소유 중인 프로젝트가 있어서 탈퇴할 수 없어요. 프로젝트 소유권을 넘기거나 프로젝트를 삭제한 후 다시 시도해 주세요.");

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/service/UserService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/service/UserService.java
@@ -48,18 +48,6 @@ public class UserService {
         return userRepository.findByEmail(email);
     }
 
-    public void validateNicknameNotDuplicated(final String nickname, final String currentNickname) {
-        if (!nickname.equals(currentNickname) && userRepository.existsByNickname(nickname)) {
-            throw new BusinessException(UserErrorCode.USER_NICKNAME_DUPLICATED);
-        }
-    }
-
-    public void validateNicknameNotDuplicated(final String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            throw new BusinessException(UserErrorCode.USER_NICKNAME_DUPLICATED);
-        }
-    }
-
     public void validateEmailNotDuplicated(final String email) {
         userRepository.findByEmail(email).ifPresent(existing -> {
             throw new BusinessException(UserErrorCode.USER_EMAIL_DUPLICATED);
@@ -88,7 +76,6 @@ public class UserService {
 
     @Transactional
     public User create(final CreateUserCommand command) {
-        validateNicknameNotDuplicated(command.nickname());
         validateEmailNotDuplicated(command.email());
 
         User user = User.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #222

## 📝작업 내용

### 1. 닉네임 중복 검증 제거

회원가입 및 프로필 수정 시 닉네임 중복 여부를 검증하던 로직을 제거했습니다.

**변경 전 동작**

- `POST /v1/auth/signup`: 닉네임이 이미 사용 중이면 `USER_NICKNAME_DUPLICATED(409)` 반환
- `PATCH /v1/users/me`: 기존 닉네임과 다른 값으로 변경 시 중복 여부 검증 후 `USER_NICKNAME_DUPLICATED(409)` 반환

**변경 후 동작**

닉네임 중복 검증 없이 그대로 저장합니다. 닉네임은 고유하지 않아도 되는 값으로 정책이 변경되었습니다.

**제거된 항목**

| 위치 | 제거 내용 |
|------|-----------|
| `UserService` | `validateNicknameNotDuplicated(String)` / `validateNicknameNotDuplicated(String, String)` 메서드 |
| `UserService.create()` | `validateNicknameNotDuplicated(command.nickname())` 호출 |
| `UserFacade.updateMe()` | `userService.validateNicknameNotDuplicated(request.nickname(), user.getNickname())` 호출 |
| `UserErrorCode` | `USER_NICKNAME_DUPLICATED` 에러 코드 |

## 💬리뷰 요구사항(선택)

바로 머지할게요~
