### PR TITLE
[Feat/#215] 메인 노드의 경우 회의 X + 요약본만 보여주도록 수정

### DIFF
--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -18,9 +18,11 @@ interface EditorProps {
   fragment?: XmlFragment | null;
   /** 로컬 변경 발생 후 디바운스 저장 콜백 */
   onUpdate?: (markdown: string) => void;
+  /** false 전달 시 읽기 전용 (기본값: true) */
+  editable?: boolean;
 }
 
-export default function Editor({ content, fragment, onUpdate }: EditorProps) {
+export default function Editor({ content, fragment, onUpdate, editable = true }: EditorProps) {
   const onUpdateRef = useRef(onUpdate);
   onUpdateRef.current = onUpdate;
 
@@ -34,6 +36,7 @@ export default function Editor({ content, fragment, onUpdate }: EditorProps) {
         Placeholder.configure({ placeholder: '내용을 입력하세요.' }),
         ...(fragment ? [Collaboration.configure({ fragment })] : []),
       ],
+      editable,
       content: fragment ? undefined : (content ?? ''),
       onUpdate({ editor: e, transaction }) {
         if (isChangeOrigin(transaction)) return;

--- a/frontend/src/components/node-datail/note/NodeNoteTab.tsx
+++ b/frontend/src/components/node-datail/note/NodeNoteTab.tsx
@@ -17,6 +17,8 @@ export default function NodeNoteTab({ nodeId, projectId }: NodeNoteTabProps) {
   const yjsCtx = useYjsContext();
   const fragment = yjsCtx?.ydoc.getXmlFragment(YJS_FIELDS.note) ?? null;
 
+  const isMainNode = !nodeDetail?.parentId;
+
   const handleUpdate = (markdown: string) => {
     if (!nodeId) return;
     updateNote(markdown, {
@@ -26,11 +28,15 @@ export default function NodeNoteTab({ nodeId, projectId }: NodeNoteTabProps) {
 
   return (
     <main className="flex">
-      <Editor
-        content={nodeDetail?.noteContent}
-        fragment={fragment}
-        onUpdate={handleUpdate}
-      />
+      {isMainNode ? (
+        <Editor content={nodeDetail?.mainSummary} editable={false} />
+      ) : (
+        <Editor
+          content={nodeDetail?.noteContent}
+          fragment={fragment}
+          onUpdate={handleUpdate}
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #215 

## 📝작업 내용

- 기존에 메인 노드가 서브노드와 동일하게 동작하고 있어, 노드 요약본만 렌더링하도록 변경하였습니다. 

### 스크린샷 (선택)

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/38254649-c0a7-4b4b-a775-b6adf517c750" />

