### PR TITLE
[Feat/#232] 구글 미트 OAuth2 연동

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/SignupRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/request/SignupRequest.java
@@ -18,6 +18,9 @@ public record SignupRequest(
         @NotBlank(message = "소셜 access token은 필수로 입력해 주세요.")
         String socialAccessToken,
 
+        @Schema(description = "소셜 refresh token (로그인 응답으로 받은 값, 없으면 null)", example = "1//0gLY...")
+        String socialRefreshToken,
+
         @Schema(description = "닉네임(최대 20자)", example = "수민")
         @NotBlank(message = ValidationMessage.NICKNAME_REQUIRED)
         @Size(max = 20, message = ValidationMessage.NICKNAME_MAX_LENGTH)

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/response/SignupRequiredResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/dto/response/SignupRequiredResponse.java
@@ -11,13 +11,22 @@ public record SignupRequiredResponse(
         @Schema(description = "소셜 access token", example = "ya29.a0AfH6SMB...")
         String socialAccessToken,
 
+        @Schema(description = "소셜 refresh token (회원가입 시 그대로 전달)", example = "1//0gLY...")
+        String socialRefreshToken,
+
         @Schema(description = "소셜 계정의 표시 이름", example = "황수민")
         String name,
 
         @Schema(description = "소셜 계정 이메일", example = "tnals655@kookmin.ac.kr")
         String email
 ) {
-    public static SignupRequiredResponse of(SocialProvider socialProvider, String socialAccessToken, String name, String email) {
-        return new SignupRequiredResponse(socialProvider, socialAccessToken, name, email);
+    public static SignupRequiredResponse of(
+            SocialProvider socialProvider,
+            String socialAccessToken,
+            String socialRefreshToken,
+            String name,
+            String email
+    ) {
+        return new SignupRequiredResponse(socialProvider, socialAccessToken, socialRefreshToken, name, email);
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
@@ -71,6 +71,7 @@ public class AuthFacade {
         );
 
         User saved = userService.create(command);
+        userService.updateGoogleRefreshToken(saved.getId(), request.socialRefreshToken());
 
         return issueTokens(saved.getId(), saved.getEmail(), saved.getNickname());
     }
@@ -114,6 +115,7 @@ public class AuthFacade {
         SignupRequiredResponse data = SignupRequiredResponse.of(
                 provider,
                 tokens.accessToken(),
+                tokens.refreshToken(),
                 userInfo.name(),
                 userInfo.email()
         );

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/facade/MeetingFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/facade/MeetingFacade.java
@@ -18,6 +18,8 @@ import kr.flowmeet.domain.project.entity.ProjectMember;
 import kr.flowmeet.domain.project.entity.ProjectMemberRole;
 import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
+import kr.flowmeet.domain.user.entity.User;
+import kr.flowmeet.domain.user.service.UserService;
 import kr.flowmeet.api.meeting.event.MeetingEndedEvent;
 import kr.flowmeet.domain.transcript.service.MeetingTranscriptService;
 import kr.flowmeet.external.meeting.MeetingRoomProvider;
@@ -39,6 +41,7 @@ public class MeetingFacade {
     private final NodeValidator nodeValidator;
     private final ProjectPermissionValidator projectPermissionValidator;
     private final ProjectMemberService projectMemberService;
+    private final UserService userService;
     private final MeetingRoomProvider meetingRoomProvider;
     private final MeetingTranscriptService meetingTranscriptService;
     private final AiTaskService aiTaskService;
@@ -55,8 +58,9 @@ public class MeetingFacade {
         projectPermissionValidator.validateAllAreMembers(projectId, request.participantUserIds());
         meetingService.validateCreatable(nodeId, request.startedAt());
 
+        User host = userService.findById(userId);
         Node node = nodeService.findByIdAndProjectId(nodeId, projectId);
-        MeetingRoom room = meetingRoomProvider.create(toCreateRoomCommand(node, request.startedAt(), null));
+        MeetingRoom room = meetingRoomProvider.create(toCreateRoomCommand(node, request.startedAt(), host.getGoogleRefreshToken()));
 
         //Meeting 생성 실패 시, 외부로 호출해서 생성한 회의실 삭제
         try {
@@ -99,11 +103,13 @@ public class MeetingFacade {
 
         ProjectMember projectMember = projectMemberService.findByProjectIdAndUserId(projectId, userId);
         String externalEventId = meeting.getExternalEventId();
+        Long hostId = meeting.getCreatedById();
 
         meetingService.delete(projectMember, meeting);
 
         if (externalEventId != null && !externalEventId.isBlank()) {
-            meetingRoomProvider.delete(externalEventId, null);
+            User host = userService.findById(hostId);
+            meetingRoomProvider.delete(externalEventId, host.getGoogleRefreshToken());
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #232

## 📝작업 내용

### 1. 배경

Google Meet 생성 시 서비스 계정 + Domain-Wide Delegation 방식을 시도했으나 Google Workspace 도메인이 없으면 사용 불가한 문제가 있었습니다. 이를 **회의 생성자(host) 본인의 Google OAuth2 refresh token으로 캘린더 이벤트를 생성하는 방식**으로 전환했습니다.

---

### 2. 신규 가입 시 Google refresh token 유실 수정

기존 로그인 흐름에서 기존 회원(`handleExistingUser`)은 refresh token이 저장됐지만, **신규 가입 흐름에서는 refresh token이 유실**되는 문제가 있었습니다.

**원인**

`login()` → `handleNewUser()` → `SignupRequiredResponse`에 `accessToken`만 포함되고, 프론트엔드가 `signup()`을 호출할 때 refresh token을 전달할 방법이 없었습니다.

**수정**

- `SignupRequiredResponse`에 `socialRefreshToken` 필드 추가 → 프론트엔드가 받아서 보관
- `SignupRequest`에 `socialRefreshToken` 필드 추가 (nullable) → 가입 시 백엔드로 전달
- `AuthFacade.signup()`: 유저 생성 후 `userService.updateGoogleRefreshToken()` 호출

**가입 플로우**

```
POST /v1/auth/login (GOOGLE)
  └─ 신규 유저 → 응답: { socialAccessToken, socialRefreshToken, ... }

POST /v1/auth/signup
  └─ 요청: { socialAccessToken, socialRefreshToken, nickname, email }
  └─ 가입 완료 후 googleRefreshToken DB 저장
```

> 프론트엔드는 Google OAuth URL 생성 시 `access_type=offline&prompt=consent`와 `calendar.events` 스코프를 포함해야 refresh token이 발급됩니다.

---

### 3. MeetingFacade - null 하드코딩 제거 및 실제 토큰 전달

기존에는 Google Meet API 호출 시 `hostRefreshToken`을 `null`로 하드코딩하고 `GOOGLE_MEET_ENABLED=false`로 비활성화해 두었습니다.

**수정**

- `MeetingFacade`에 `UserService` 의존성 추가
- `createMeeting()`: `userId`로 host 유저를 조회해 `googleRefreshToken` 전달
- `deleteMeeting()`: `meeting.getCreatedById()`로 회의 원 생성자를 조회해 `googleRefreshToken` 전달
  - 삭제 요청자와 Google Calendar 이벤트 소유자(생성자)가 다를 수 있기 때문에 `userId` 대신 `createdById` 사용

---

### 4. 활성화 방법

`.env`에서 아래 값을 채운 뒤 서버를 재시작하면 실제 Google Meet 방이 생성됩니다.

```
GOOGLE_MEET_ENABLED=true
OAUTH2_GOOGLE_CLIENT_ID=...
OAUTH2_GOOGLE_CLIENT_SECRET=...
```

`GOOGLE_MEET_ENABLED=false`(기본값)이면 `LocalMeetingRoomProvider`로 폴백되어 stub URL이 발급됩니다.

## 💬리뷰 요구사항(선택)

- `deleteMeeting`에서 삭제 요청자가 아닌 회의 생성자(`createdById`)의 토큰을 사용하는 방식이 적절한지 확인 부탁드립니다. Google Calendar 이벤트는 생성자 계정에 귀속되기 때문에 이 방식을 선택했습니다.
- refresh token을 평문으로 저장하고 있습니다. 추후 암호화 이슈를 별도로 관리할 예정입니다.