### PR TITLE
[Feat/#236] AI 에이전트 MCP Tool 구현

### DIFF
--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -33,6 +33,12 @@ class Agent:
     async def run(self, user_message: str) -> str:
 
         self.conversation_history = self.conversation_history[-MAX_HISTORY:]
+        # tool_call/response 쌍 중간에서 잘리면 Gemini 오류 발생 — 텍스트 user 메시지부터 시작
+        while self.conversation_history and (
+            self.conversation_history[0].role != "user"
+            or any(p.function_response is not None for p in self.conversation_history[0].parts)
+        ):
+            self.conversation_history.pop(0)
 
         # 대화 히스토리에 사용자 메시지 추가
         self.conversation_history.append(

--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -14,7 +14,10 @@ class Agent:
         self.model = "gemini-2.5-flash"
         self.conversation_history = []
         self._tools = None
- 
+
+    async def close(self):
+        pass
+
     async def _get_gemini_tools(self) -> list[types.Tool]:
         mcp_tools = await self.mcp_client.list_tools()
  
@@ -51,7 +54,7 @@ class Agent:
                 config=types.GenerateContentConfig(
                     tools=self._tools,
                     thinking_config=types.ThinkingConfig(
-                        thinking_budget=512 #응답 너무 느리면 0으로 변경 가능
+                        thinking_budget=512 # 응답 너무 느리면 0으로 변경 가능
                     ),
                 ),
             )

--- a/ai/agent/client.py
+++ b/ai/agent/client.py
@@ -1,9 +1,9 @@
-import asyncio
 from contextlib import AsyncExitStack
 from typing import Any
- 
+
+import httpx
 from mcp import ClientSession
-from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
  
  
 class MCPClient:
@@ -11,15 +11,18 @@ class MCPClient:
         self.session: ClientSession | None = None
         self.exit_stack = AsyncExitStack()
  
-    async def connect_sse(self, url: str):
-        read, write = await self.exit_stack.enter_async_context(
-            sse_client(url)
+    async def connect(self, url: str, token: str):
+        http_client = await self.exit_stack.enter_async_context(
+            httpx.AsyncClient(headers={"Authorization": f"Bearer {token}"})
+        )
+        read, write, _ = await self.exit_stack.enter_async_context(
+            streamable_http_client(url, http_client=http_client)
         )
         self.session = await self.exit_stack.enter_async_context(
             ClientSession(read, write)
         )
         await self.session.initialize()
-        print("[MCP] SSE 서버 연결 완료")
+        print("[MCP] Streamable HTTP 서버 연결 완료")
  
     async def list_tools(self) -> list[dict]:
         if not self.session:

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -1,20 +1,22 @@
 import asyncio
+import os
 from client import MCPClient
 from agent import Agent
 import sys
- 
- 
+
+
 async def main():
+    token = os.environ["FLOWMEET_JWT"]
     mcp_client = MCPClient()
- 
+
     try:
-        await mcp_client.connect_sse("http://localhost:8082/sse")
+        await mcp_client.connect("http://localhost:8082/mcp", token)
  
         agent = Agent(mcp_client=mcp_client)
  
         while True:
-            user_input = await asyncio.get_running_loop().run_in_executor(None, sys.stdin.readline)
-            user_input = user_input.strip()
+            raw = await asyncio.get_running_loop().run_in_executor(None, sys.stdin.buffer.readline)
+            user_input = raw.decode("utf-8", errors="replace").strip()
 
             if user_input.lower() in ("exit", "quit"):
                 break

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -1,38 +1,39 @@
 import os
 import uuid
 import asyncio
-from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from client import MCPClient
 from agent import Agent
 
-MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "")
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://localhost:8082/mcp")
 SESSION_TTL_MINUTES = 30
 
-mcp_client: MCPClient = None
-sessions: dict[str, dict] = {}  # {session_id: {"agent", "last_active", "lock"}}
+sessions: dict[str, dict] = {}  # {session_id: {"agent", "mcp_client", "last_active", "lock"}}
 
 
-async def get_or_create_session(session_id: str) -> dict:
+async def get_or_create_session(session_id: str, token: str) -> dict:
     now = datetime.utcnow()
 
     # 만료 세션 정리
     expired = [sid for sid, s in sessions.items()
                if now - s["last_active"] > timedelta(minutes=SESSION_TTL_MINUTES)]
     for sid in expired:
-        await sessions[sid]["agent"].close()
+        await sessions[sid]["mcp_client"].close()
         del sessions[sid]
 
     if session_id not in sessions:
+        mcp_client = MCPClient()
+        await mcp_client.connect(MCP_SERVER_URL, token)
         sessions[session_id] = {
             "agent": Agent(mcp_client=mcp_client),
+            "mcp_client": mcp_client,
             "last_active": now,
-            "lock": asyncio.Lock(), 
+            "lock": asyncio.Lock(),
         }
     else:
         sessions[session_id]["last_active"] = now
@@ -40,16 +41,7 @@ async def get_or_create_session(session_id: str) -> dict:
     return sessions[session_id]
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    global mcp_client
-    mcp_client = MCPClient()
-    await mcp_client.connect_sse(MCP_SERVER_URL)  # mcp server url 추가해주세요
-    yield
-    await mcp_client.close()
-
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
 
 
@@ -63,18 +55,21 @@ class ChatResponse(BaseModel):
     session_id: str
 
 
-@app.get("/health") #서버 상태 확인용
+@app.get("/health")
 async def health():
     return {"status": "ok", "active_sessions": len(sessions)}
 
 
 @app.post("/chat", response_model=ChatResponse)
-async def chat(body: ChatRequest):
+async def chat(body: ChatRequest, authorization: str = Header(None)):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authorization 헤더가 필요합니다.")
     if not body.message.strip():
         raise HTTPException(status_code=400, detail="message가 비어있습니다.")
 
+    token = authorization.removeprefix("Bearer ")
     session_id = body.session_id or str(uuid.uuid4())
-    session = await get_or_create_session(session_id)
+    session = await get_or_create_session(session_id, token)
 
     async with session["lock"]:
         response = await session["agent"].run(body.message)

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -1,32 +1,82 @@
+import os
+import uuid
 import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
 from client import MCPClient
 from agent import Agent
-import sys
- 
- 
-async def main():
-    mcp_client = MCPClient()
- 
-    try:
-        await mcp_client.connect_sse("")  #mcp server url 추가해주세요
- 
-        agent = Agent(mcp_client=mcp_client)
- 
-        while True:
-            user_input = await asyncio.get_running_loop().run_in_executor(None, sys.stdin.readline)
-            user_input = user_input.strip()
 
-            if user_input.lower() in ("exit", "quit"):
-                break
-            if not user_input:
-                continue
- 
-            response = await agent.run(user_input)
-            print(f"Agent: {response}\n")
- 
-    finally:
-        await mcp_client.close()
- 
- 
-if __name__ == "__main__":
-    asyncio.run(main())
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "")
+SESSION_TTL_MINUTES = 30
+
+mcp_client: MCPClient = None
+sessions: dict[str, dict] = {}  # {session_id: {"agent", "last_active", "lock"}}
+
+
+async def get_or_create_session(session_id: str) -> dict:
+    now = datetime.utcnow()
+
+    # 만료 세션 정리
+    expired = [sid for sid, s in sessions.items()
+               if now - s["last_active"] > timedelta(minutes=SESSION_TTL_MINUTES)]
+    for sid in expired:
+        await sessions[sid]["agent"].close()
+        del sessions[sid]
+
+    if session_id not in sessions:
+        sessions[session_id] = {
+            "agent": Agent(mcp_client=mcp_client),
+            "last_active": now,
+            "lock": asyncio.Lock(), 
+        }
+    else:
+        sessions[session_id]["last_active"] = now
+
+    return sessions[session_id]
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global mcp_client
+    mcp_client = MCPClient()
+    await mcp_client.connect_sse(MCP_SERVER_URL)  # mcp server url 추가해주세요
+    yield
+    await mcp_client.close()
+
+
+app = FastAPI(lifespan=lifespan)
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    session_id: str
+
+
+@app.get("/health") #서버 상태 확인용
+async def health():
+    return {"status": "ok", "active_sessions": len(sessions)}
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(body: ChatRequest):
+    if not body.message.strip():
+        raise HTTPException(status_code=400, detail="message가 비어있습니다.")
+
+    session_id = body.session_id or str(uuid.uuid4())
+    session = await get_or_create_session(session_id)
+
+    async with session["lock"]:
+        response = await session["agent"].run(body.message)
+
+    return ChatResponse(response=response, session_id=session_id)

--- a/ai/agent/requirements.txt
+++ b/ai/agent/requirements.txt
@@ -1,2 +1,4 @@
-mcp
+fastapi
+uvicorn[standard]
 google-genai
+mcp

--- a/ai/agent/tools/tool_schema_v2.py
+++ b/ai/agent/tools/tool_schema_v2.py
@@ -1,0 +1,38 @@
+tool_schema = [
+    {
+        "name": "get_flowchart",
+        "description": "프로젝트의 플로우차트를 조회합니다. 전체 노드 목록과 노드 간 연결선(엣지) 목록을 반환합니다. 엣지에는 edgeId, startNodeId, endNodeId가 포함되어 있어 연결선 삭제 시 edgeId를 찾는 데 사용하세요.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
+            },
+            "required": ["projectId"],
+            "additionalProperties": False
+        }
+    },
+    {
+        "name": "get_nodes",
+        "description": "프로젝트 내 전체 노드 목록을 조회합니다. 각 노드의 nodeId, 제목, 상태를 확인할 수 있습니다. 노드 제목으로 nodeId를 찾아야 할 때 사용하세요.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
+            },
+            "required": ["projectId"],
+            "additionalProperties": False
+        }
+    },
+    {
+        "name": "get_project_members",
+        "description": "프로젝트의 멤버 목록을 조회합니다. 각 멤버의 userId, 이메일, 닉네임, 역할(OWNER/MEMBER/VIEWER)을 반환합니다. 회의 생성 시 참가자 userId를 확인하거나, 요청한 사용자가 프로젝트 멤버인지 확인할 때 사용하세요. 멤버가 아닌 경우 먼저 초대를 안내하세요.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
+            },
+            "required": ["projectId"],
+            "additionalProperties": False
+        }
+    }
+]

--- a/backend/flowmeet-domain/build.gradle
+++ b/backend/flowmeet-domain/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     // Database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // QueryDSL (OpenFeign fork — Jakarta-only)
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.1'

--- a/mcp-server/build.gradle
+++ b/mcp-server/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.ai:spring-ai-bom:1.0.0'
+        mavenBom 'org.springframework.ai:spring-ai-bom:1.1.0'
     }
 }
 

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/McpServerApplication.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/McpServerApplication.java
@@ -1,7 +1,10 @@
 package kr.flowmeet.mcpserver;
 
 import kr.flowmeet.mcpserver.config.GeminiCompatibleToolCallbackProvider;
+import kr.flowmeet.mcpserver.tool.MeetingTools;
+import kr.flowmeet.mcpserver.tool.NodeTools;
 import kr.flowmeet.mcpserver.tool.PingTool;
+import kr.flowmeet.mcpserver.tool.ProjectTools;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.boot.SpringApplication;
@@ -16,9 +19,14 @@ public class McpServerApplication {
     }
 
     @Bean
-    public ToolCallbackProvider toolCallbackProvider(PingTool pingTool) {
+    public ToolCallbackProvider toolCallbackProvider(
+            PingTool pingTool,
+            NodeTools nodeTools,
+            MeetingTools meetingTools,
+            ProjectTools projectTools
+    ) {
         ToolCallbackProvider original = MethodToolCallbackProvider.builder()
-                .toolObjects(pingTool)
+                .toolObjects(pingTool, nodeTools, meetingTools, projectTools)
                 .build();
         return new GeminiCompatibleToolCallbackProvider(original);
     }

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/config/BackendClientConfig.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/config/BackendClientConfig.java
@@ -1,0 +1,17 @@
+package kr.flowmeet.mcpserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class BackendClientConfig {
+
+    @Bean
+    public RestClient backendRestClient(@Value("${backend.url}") String backendUrl) {
+        return RestClient.builder()
+                .baseUrl(backendUrl)
+                .build();
+    }
+}

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/MeetingTools.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/MeetingTools.java
@@ -1,0 +1,33 @@
+package kr.flowmeet.mcpserver.tool;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingTools {
+
+    private final RestClient backendRestClient;
+
+    @Tool(name = "create_meeting", description = "특정 노드에 회의를 생성하고 화상 회의 링크를 발급합니다.")
+    public String createMeeting(Long projectId, Long nodeId, String startedAt, List<Long> participantUserIds, boolean isPushEnabled) {
+        return backendRestClient.post()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}/meetings", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of(
+                        "startedAt", startedAt,
+                        "participantUserIds", participantUserIds,
+                        "isPushEnabled", isPushEnabled
+                ))
+                .retrieve()
+                .body(String.class);
+    }
+
+}

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/NodeTools.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/NodeTools.java
@@ -1,0 +1,133 @@
+package kr.flowmeet.mcpserver.tool;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class NodeTools {
+
+    private final RestClient backendRestClient;
+
+    @Tool(name = "create_node", description = "프로젝트에 새로운 노드를 생성합니다. type 값: MAIN(최상위 노드), SUB(하위 노드, parentId 필수).")
+    public String createNode(Long projectId, String title, String type, @Nullable String description, @Nullable Long parentId) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("title", title);
+        body.put("type", type);
+        if (description != null) body.put("description", description);
+        if (parentId != null) body.put("parentId", parentId);
+
+        return backendRestClient.post()
+                .uri("/v1/projects/{projectId}/nodes", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "get_flowchart", description = "프로젝트의 플로우차트를 조회합니다. 전체 노드 목록과 노드 간 연결선(엣지) 목록을 반환합니다. 엣지에는 edgeId, startNodeId, endNodeId가 포함되어 있어 연결선 삭제 시 edgeId를 찾는 데 사용하세요.")
+    public String getFlowchart(Long projectId) {
+        return backendRestClient.get()
+                .uri("/v1/projects/{projectId}/nodes", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "get_nodes", description = "프로젝트 내 전체 노드 목록을 조회합니다. 각 노드의 nodeId, 제목, 상태를 확인할 수 있습니다. 노드 제목으로 nodeId를 찾아야 할 때 사용하세요.")
+    public String getNodes(Long projectId) {
+        return backendRestClient.get()
+                .uri("/v1/projects/{projectId}/nodes/list", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "get_node", description = "특정 노드의 상세 정보를 조회합니다. 노드의 제목, 설명, 진행 상태, 담당자, 태그, 연결된 회의 정보 등을 확인할 수 있습니다.")
+    public String getNode(Long projectId, Long nodeId) {
+        return backendRestClient.get()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "update_node_title", description = "프로젝트 내 특정 노드의 제목을 수정합니다.")
+    public String updateNodeTitle(Long projectId, Long nodeId, String title) {
+        return backendRestClient.patch()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}/title", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("title", title))
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "update_node_description", description = "프로젝트 내 특정 노드의 설명을 수정합니다.")
+    public String updateNodeDescription(Long projectId, Long nodeId, String description) {
+        return backendRestClient.patch()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}/description", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("description", description))
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "update_node_status", description = "프로젝트 내 특정 노드의 상태를 수정합니다. 가능한 값: WAITING, IN_PROGRESS, DONE")
+    public String updateNodeStatus(Long projectId, Long nodeId, String status) {
+        return backendRestClient.patch()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}/status", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("status", status))
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "add_assignee", description = "특정 노드에 담당자를 추가합니다. 담당자로 지정할 사용자는 해당 프로젝트의 멤버여야 합니다.")
+    public String addAssignee(Long projectId, Long nodeId, Long userId) {
+        return backendRestClient.post()
+                .uri("/v1/projects/{projectId}/nodes/{nodeId}/assignees", projectId, nodeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("userId", userId))
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "create_edge", description = "두 노드 사이에 연결선을 생성합니다.")
+    public String createEdge(Long projectId, Long startNodeId, Long endNodeId, @Nullable String comment) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("startNodeId", startNodeId);
+        body.put("endNodeId", endNodeId);
+        if (comment != null) body.put("comment", comment);
+
+        return backendRestClient.post()
+                .uri("/v1/projects/{projectId}/edges", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "delete_edge", description = "두 노드 사이의 연결선을 삭제합니다.")
+    public String deleteEdge(Long projectId, Long edgeId) {
+        var response = backendRestClient.delete()
+                .uri("/v1/projects/{projectId}/edges/{edgeId}", projectId, edgeId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .toEntity(String.class);
+        return response.getBody() != null ? response.getBody() : "삭제 완료";
+    }
+
+}

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/ProjectTools.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/ProjectTools.java
@@ -1,0 +1,47 @@
+package kr.flowmeet.mcpserver.tool;
+
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectTools {
+
+    private final RestClient backendRestClient;
+
+    @Tool(name = "get_project_members", description = "프로젝트의 멤버 목록을 조회합니다. 각 멤버의 userId, 이메일, 닉네임, 역할(OWNER/MEMBER/VIEWER)을 반환합니다. 회의 생성 시 참가자 userId를 확인하거나, 요청한 사용자가 프로젝트 멤버인지 확인할 때 사용하세요. 멤버가 아닌 경우 먼저 초대를 안내하세요.")
+    public String getProjectMembers(Long projectId) {
+        return backendRestClient.get()
+                .uri("/v1/projects/{projectId}/members", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "invite_member", description = "프로젝트에 새로운 멤버를 이메일로 초대합니다. 초대받은 사용자의 이메일로 초대 링크가 전송됩니다.")
+    public String inviteMember(Long projectId, String email) {
+        return backendRestClient.post()
+                .uri("/v1/projects/{projectId}/invite", projectId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("email", email))
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Tool(name = "remove_project_member", description = "프로젝트에서 멤버를 삭제합니다. OWNER 권한을 가진 사용자만 실행할 수 있습니다.")
+    public String removeProjectMember(Long projectId, Long memberId) {
+        var response = backendRestClient.delete()
+                .uri("/v1/projects/{projectId}/members/{memberId}", projectId, memberId)
+                .header("Authorization", ToolAuthExtractor.extractAuth())
+                .retrieve()
+                .toEntity(String.class);
+        return response.getBody() != null ? response.getBody() : "삭제 완료";
+    }
+
+}

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/ToolAuthExtractor.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/ToolAuthExtractor.java
@@ -1,0 +1,17 @@
+package kr.flowmeet.mcpserver.tool;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class ToolAuthExtractor {
+
+    private ToolAuthExtractor() {
+    }
+
+    static String extractAuth() {
+        HttpServletRequest request = ((ServletRequestAttributes)
+                RequestContextHolder.currentRequestAttributes()).getRequest();
+        return request.getHeader("Authorization");
+    }
+}

--- a/mcp-server/src/main/resources/application.yaml
+++ b/mcp-server/src/main/resources/application.yaml
@@ -5,9 +5,10 @@ spring:
         name: flowmeet-mcp-server
         version: 1.0.0
         type: SYNC
-        protocol: SSE
-        sse-endpoint: /sse
-        sse-message-endpoint: /mcp/message
+        protocol: STREAMABLE
 
 server:
   port: 8082
+
+backend:
+  url: http://localhost:8080


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #236

## 📝작업 내용

### MCP 서버 Streamable HTTP 전환

- Spring AI BOM 1.0.0 → 1.1.0 업그레이드
- 전송 방식을 SSE에서 MCP 2025-03-26 표준인 **Streamable HTTP**로 변경 (단일 `/mcp` 엔드포인트)
- 백엔드 통신용 `RestClient` Bean 등록 (`BackendClientConfig`)

### JWT 포워딩 구조

- `ToolAuthExtractor`: `RequestContextHolder`로 현재 요청의 `Authorization` 헤더를 추출해 백엔드 API 호출 시 그대로 전달
- 사용자 JWT가 Agent → MCP Server → Backend 흐름으로 포워딩되어 기존 인증/인가 구조 재사용

### MCP 툴 구현

**Node**
- `get_flowchart`: 노드 + 엣지 전체 조회 (edgeId 탐색용)
- `get_nodes`: 노드 목록 조회 (nodeId 탐색용)
- `get_node`: 노드 상세 조회
- `create_node`: MAIN/SUB 노드 생성
- `update_node_title` / `update_node_description` / `update_node_status`: 노드 수정
- `add_assignee`: 담당자 추가
- `create_edge` / `delete_edge`: 연결선 생성/삭제

**Meeting**
- `create_meeting`: 노드에 회의 생성 및 화상 링크 발급

**Project**
- `get_project_members`: 멤버 목록 조회 (userId/memberId 탐색용, 회의 참가자 매핑 및 초대 전 멤버 확인 용도)
- `invite_member`: 이메일로 멤버 초대
- `remove_project_member`: 멤버 삭제

### AI Agent Streamable HTTP 클라이언트

- `client.py`: `httpx.AsyncClient` 기반 Streamable HTTP MCP 클라이언트로 전환
- `agent.py`: 대화 히스토리 truncation 시 tool call/response 쌍이 분리되는 버그 수정 (`INVALID_ARGUMENT` 오류 원인)

### 툴 스키마 참고 문서

- `tool_schema_v1.py`: 초기 툴 스키마 정의 (기존)
- `tool_schema_v2.py`: 추가된 툴 스키마 기록 (`get_flowchart`, `get_nodes`, `get_project_members`)
- Flyway 마이그레이션처럼 변경 이력을 단계별로 관리하는 용도

## 변경 파일

| 파일 | 변경 |
|------|------|
| `mcp-server/build.gradle` | 수정 - Spring AI BOM 1.1.0 업그레이드 |
| `mcp-server/.../application.yaml` | 수정 - Streamable HTTP 설정 |
| `mcp-server/.../config/BackendClientConfig.java` | 추가 - 백엔드 RestClient Bean |
| `mcp-server/.../tool/ToolAuthExtractor.java` | 추가 - JWT 포워딩 유틸리티 |
| `mcp-server/.../tool/NodeTools.java` | 추가 - 노드 관련 툴 10개 |
| `mcp-server/.../tool/MeetingTools.java` | 추가 - 회의 생성 툴 |
| `mcp-server/.../tool/ProjectTools.java` | 추가 - 프로젝트 멤버 툴 3개 |
| `mcp-server/.../McpServerApplication.java` | 수정 - 전체 툴 등록 |
| `ai/agent/client.py` | 수정 - Streamable HTTP 클라이언트 |
| `ai/agent/main.py` | 수정 - MCP 연결 URL |
| `ai/agent/agent.py` | 수정 - 대화 히스토리 버그 수정 |
| `ai/agent/tools/tool_schema_v2.py` | 추가 - 툴 스키마 v2 |
| `backend/flowmeet-domain/build.gradle` | 수정 - 로컬 테스트용 MySQL 드라이버 추가 |

### 스크린샷
- 로컬 환경에서 주요 툴(create_node, get_node, update_node_status, invite_member) 동작 확인하였습니다.
<img width="932" height="195" alt="image" src="https://github.com/user-attachments/assets/b9e9c953-7431-4c60-a180-f73a57112819" />
<img width="1032" height="284" alt="image" src="https://github.com/user-attachments/assets/a7449109-b288-45f5-965e-babec11bed71" />
<img width="1028" height="88" alt="image" src="https://github.com/user-attachments/assets/d0d5ec9f-4350-45a1-83c6-a94ee0128a8a" />

## 💬참고 사항
@ovepje2004 v2에서 추가된 3개의 툴은 통합 테스트 중 발견한 누락 사항입니다.
- `get_flowchart`: 연결선 삭제 시 `edgeId`가 필요한데 기존 툴로는 조회할 방법이 없었습니다.
- `get_nodes`: 유저가 "기능개발 노드 상태 바꿔줘"처럼 노드 이름으로 명령할 때 Agent가 `nodeId`를 찾을 수단이 없었습니다.
- `get_project_members`: 회의 생성·담당자 추가 시 유저는 이메일/이름만 알고 `userId`는 모르기 때문에 멤버 목록으로 매핑이 필요했습니다.

## 💬논의 사항
실제 서비스 이용자는 `projectId` 같은 내부 식별자를 알 수 없습니다. 현재 Agent는 프로젝트 컨텍스트 없이 동작하기 때문에 테스트 시 "프로젝트 1번에 노드 만들어줘"처럼 직접 명시해야 했습니다.

백엔드의 채팅 메시지 전송 엔드포인트(`POST /v1/projects/{projectId}/chats/{chatSessionId}/messages`)에 이미 `projectId`가 path variable로 포함되어 있습니다. 백엔드가 AI Agent 호출 시 이를 함께 전달하고, AI Agent가 시스템 프롬프트에 주입하는 방식으로 해결할 수 있습니다.

```
당신은 프로젝트 {projectId}의 AI 어시스턴트입니다.
```

이렇게 하면 유저는 현재 열려 있는 프로젝트 안에서 "노드 만들어줘"라고만 해도 되며, 프론트엔드 변경은 불필요합니다. 더 좋은 방법이 있다면 의견 부탁드립니다.