### PR TITLE
[Fix/#235] Google OAuth 설정 변경 및 빌드 에러 수정

### DIFF
--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -842,6 +842,11 @@ export interface SignupRequest {
    */
   socialAccessToken: string;
   /**
+   * 소셜 refresh token (로그인 응답으로 받은 값, 없으면 null)
+   * @example "1//0gLY..."
+   */
+  socialRefreshToken?: string;
+  /**
    * 닉네임(최대 20자)
    * @minLength 0
    * @maxLength 20
@@ -891,6 +896,34 @@ export interface TokenResponse {
    * @example "eyJhbGciOiJIUzI1NiJ9..."
    */
   refreshToken?: string;
+}
+
+/** 회원가입 이메일 인증 코드 발송 요청 */
+export interface SendAuthEmailVerificationRequest {
+  /**
+   * 인증할 이메일
+   * @format email
+   * @minLength 1
+   * @example "flowmin@flowmeet.kr"
+   */
+  email: string;
+}
+
+/** 회원가입 이메일 인증 코드 검증 요청 */
+export interface VerifyAuthEmailRequest {
+  /**
+   * 인증할 이메일
+   * @format email
+   * @minLength 1
+   * @example "flowmin@flowmeet.kr"
+   */
+  email: string;
+  /**
+   * 인증 코드
+   * @minLength 1
+   * @example "123456"
+   */
+  code: string;
 }
 
 /** 토큰 갱신 요청 */
@@ -1945,6 +1978,11 @@ export interface ParticipantItem {
    * @example "홍길동"
    */
   nickname?: string;
+  /**
+   * 이메일
+   * @example "test@flowmeet.kr"
+   */
+  email?: string;
   /**
    * 프로필 이미지 URL
    * @example "https://cdn.flowmit.com/profiles/10.png"
@@ -5794,6 +5832,103 @@ export class Api<
         }
       >({
         path: `/v1/auth/signup`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 회원가입할 이메일 주소로 6자리 인증 코드를 발송합니다. 코드 유효시간은 5분입니다.
+     *
+     * @tags Auth
+     * @name SendEmailVerification1
+     * @summary 회원가입 이메일 인증 코드 발송
+     * @request POST:/v1/auth/signup/email-verifications
+     * @secure
+     */
+    sendEmailVerification1: (
+      data: SendAuthEmailVerificationRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /**
+           * HTTP 상태 코드
+           * @format int32
+           * @example 200
+           */
+          status?: object;
+          /**
+           * 응답 코드
+           * @example "SEND_EMAIL_VERIFICATION"
+           */
+          code?: object;
+          /**
+           * 응답 메시지
+           * @example "인증 코드를 보냈어요. 메일함을 확인해 주세요."
+           */
+          message?: object;
+          /** 응답 데이터 */
+          data?: object;
+        },
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/auth/signup/email-verifications`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 발송된 인증 코드로 이메일 소유를 확인합니다.
+     *
+     * @tags Auth
+     * @name VerifyEmail1
+     * @summary 회원가입 이메일 인증 코드 검증
+     * @request POST:/v1/auth/signup/email-verifications/verify
+     * @secure
+     */
+    verifyEmail1: (data: VerifyAuthEmailRequest, params: RequestParams = {}) =>
+      this.request<
+        {
+          /**
+           * HTTP 상태 코드
+           * @format int32
+           * @example 200
+           */
+          status?: object;
+          /**
+           * 응답 코드
+           * @example "VERIFY_EMAIL"
+           */
+          code?: object;
+          /**
+           * 응답 메시지
+           * @example "이메일 인증에 성공했어요."
+           */
+          message?: object;
+          /** 응답 데이터 */
+          data?: object;
+        },
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/auth/signup/email-verifications/verify`,
         method: "POST",
         body: data,
         secure: true,

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -2,11 +2,13 @@
 
 import { Loading } from '@wanteddev/wds';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
-import { authStorage } from '@/api/authStorage';
+import { useEffect, useRef, Suspense } from 'react';
 import { toastStore } from '@/components/commons/custom-toast/toastStore';
+import { useAuth } from '@/contexts/AuthContext';
 import { verifyOAuthState } from '@/lib/oauth';
 import { useLoginGoogleMutation } from '@/queries/auth';
+
+export const dynamic = 'force-dynamic';
 
 let toastCount = 0;
 function showToast(content: string, variant: 'positive' | 'negative' = 'negative') {
@@ -18,10 +20,11 @@ function showToast(content: string, variant: 'positive' | 'negative' = 'negative
   });
 }
 
-export default function AuthCallbackPage() {
+function CallbackContent() {
   const params = useSearchParams();
   const router = useRouter();
   const hasProcessed = useRef(false);
+  const { login } = useAuth();
   const loginMutation = useLoginGoogleMutation();
 
   useEffect(() => {
@@ -50,7 +53,7 @@ export default function AuthCallbackPage() {
           if (data.code === 'LOGIN') {
             // 가입된 유저
             if (data.data?.accessToken && data.data?.refreshToken) {
-              authStorage.setTokens(data.data.accessToken, data.data.refreshToken);
+              login(data.data.accessToken, data.data.refreshToken);
               router.replace('/projects');
             } else {
               showToast(data.message);
@@ -71,11 +74,19 @@ export default function AuthCallbackPage() {
         },
       },
     );
-  }, [params, router, loginMutation]);
+  }, [params, router, loginMutation, login]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">
       <Loading />
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <CallbackContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -1,21 +1,18 @@
 'use client';
 
-import { FormField, FormLabel, FormControl, TextField, TextFieldContent, TextFieldButton, Button } from '@wanteddev/wds';
+import { FormField, FormLabel, FormControl, TextField, Button } from '@wanteddev/wds';
 import type { Theme } from '@wanteddev/wds-engine';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect, useMemo } from 'react';
-import { authStorage } from '@/api/authStorage';
+import { EmailVerificationFields } from '@/components/auth/EmailVerificationFields';
 import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
-import { useCountdown } from '@/hooks/useCountdown';
-import {
-  useSignupMutation,
-  useSendEmailVerificationMutation,
-  useVerifyEmailCodeMutation,
-} from '@/queries/auth';
+import { useAuth } from '@/contexts/AuthContext';
+import { useSignupMutation } from '@/queries/auth';
 
 interface SignupPending {
   socialProvider: string;
   socialAccessToken: string;
+  socialRefreshToken: string;
   name: string;
   email: string;
 }
@@ -34,20 +31,14 @@ const getSignupPending = (): SignupPending | null => {
 
 export default function SignupPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const toast = usePositionedToast();
   const signupMutation = useSignupMutation();
-  const sendEmailMutation = useSendEmailVerificationMutation();
-  const verifyEmailMutation = useVerifyEmailCodeMutation();
 
   const pending = useMemo<SignupPending | null>(() => getSignupPending(), []);
   const [name, setName] = useState(pending?.name || '');
-  const [email, setEmail] = useState(pending?.email || '');
-  const [verificationCode, setVerificationCode] = useState('');
   const [isEmailVerified, setIsEmailVerified] = useState(false);
   const [verifiedEmail, setVerifiedEmail] = useState('');
-  const [isCodeSent, setIsCodeSent] = useState(false);
-  const [verificationError, setVerificationError] = useState(false);
-  const { timeLeft, start: startTimer, reset: resetTimer, formatTime } = useCountdown();
 
   useEffect(() => {
     if (!pending) {
@@ -55,108 +46,24 @@ export default function SignupPage() {
     }
   }, [router, pending]);
 
-  const handleSendVerification = () => {
-    if (!pending) return;
-
-    sendEmailMutation.mutate(
-      { email: email.trim() },
-      {
-        onSuccess: (data) => {
-          if (data.code === 'SEND_EMAIL_VERIFICATION') {
-            setIsCodeSent(true);
-            setIsEmailVerified(false);
-            setVerifiedEmail('');
-            setVerificationError(false);
-            setVerificationCode('');
-            startTimer(300);
-            toast({
-              content: data.message,
-              variant: 'positive',
-              placement: 'top-center',
-            });
-          } else {
-            toast({
-              content: data.message,
-              variant: 'negative',
-              placement: 'top-center',
-            });
-          }
-        },
-        onError: (error) => {
-          toast({
-            content: error.message,
-            variant: 'negative',
-            placement: 'top-center',
-          });
-        },
-      },
-    );
-  };
-
-  const { mutate: verifyEmail, isPending: isVerifying } = verifyEmailMutation;
-
-  useEffect(() => {
-    if (verificationCode.length !== 6) return;
-    if (isEmailVerified || !isCodeSent || timeLeft === 0 || isVerifying) return;
-    if (verificationError) return;
-    if (!pending) return;
-
-    verifyEmail(
-      {
-        email: email.trim(),
-        code: verificationCode.trim(),
-      },
-      {
-        onSuccess: (data) => {
-          if (data.code === 'VERIFY_EMAIL') {
-            setIsEmailVerified(true);
-            setVerifiedEmail(email.trim());
-            setVerificationError(false);
-            toast({
-              content: data.message,
-              variant: 'positive',
-              placement: 'top-center',
-            });
-          } else {
-            setVerificationError(true);
-            setIsEmailVerified(false);
-            toast({
-              content: data.message,
-              variant: 'negative',
-              placement: 'top-center',
-            });
-          }
-        },
-        onError: (error) => {
-          setVerificationError(true);
-          setIsEmailVerified(false);
-          toast({
-            content: error.message,
-            variant: 'negative',
-            placement: 'top-center',
-          });
-        },
-      },
-    );
-  }, [verificationCode, isEmailVerified, isCodeSent, timeLeft, isVerifying, verificationError, pending, email, verifyEmail, toast]);
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!pending || email.trim() !== verifiedEmail) return;
+    if (!pending || !verifiedEmail) return;
 
     signupMutation.mutate(
       {
         socialProvider: pending.socialProvider,
         socialAccessToken: pending.socialAccessToken,
+        socialRefreshToken: pending.socialRefreshToken,
         nickname: name.trim(),
-        email: email.trim(),
+        email: verifiedEmail,
       },
       {
         onSuccess: (data) => {
           if (data.code === 'SUCCESS' || data.code === 'SIGNUP') {
             if (data.data?.accessToken && data.data?.refreshToken) {
               sessionStorage.removeItem('signup_pending');
-              authStorage.setTokens(data.data.accessToken, data.data.refreshToken);
+              login(data.data.accessToken, data.data.refreshToken);
               router.replace('/projects');
             } else {
               toast({
@@ -245,98 +152,21 @@ export default function SignupPage() {
               </FormControl>
             </FormField>
 
-            <div className="flex flex-col gap-2">
-              <FormField>
-                <FormLabel
-                  htmlFor="email"
-                  variant="label1"
-                  sx={(theme: Theme) => ({
-                    color: theme.semantic.label.neutral,
-                  })}
-                >
-                  이메일
-                </FormLabel>
-                <FormControl>
-                  <TextField
-                    id="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value);
-                      setIsEmailVerified(false);
-                      setVerifiedEmail('');
-                      setIsCodeSent(false);
-                      setVerificationCode('');
-                      setVerificationError(false);
-                      resetTimer();
-                    }}
-                    placeholder="이메일을 입력해 주세요."
-                    type="email"
-                    required
-                    width="100%"
-                    trailingButton={
-                      <TextFieldButton
-                        onClick={handleSendVerification}
-                        disabled={sendEmailMutation.isPending || !email.trim()}
-                      >
-                        {isCodeSent ? '재전송' : '인증하기'}
-                      </TextFieldButton>
-                    }
-                  />
-                </FormControl>
-              </FormField>
-
-              <FormField className="gap-2">
-                <FormControl>
-                  <TextField
-                    value={verificationCode}
-                    onChange={(e) => {
-                      const newValue = e.target.value.replace(/\D/g, '').slice(0, 6);
-                      setVerificationCode(newValue);
-                      setVerificationError(false);
-                    }}
-                    placeholder="인증번호를 입력해 주세요."
-                    disabled={isEmailVerified}
-                    invalid={verificationError}
-                    positive={isEmailVerified}
-                    width="100%"
-                    maxLength={6}
-                    trailingContent={
-                      <>
-                        {isCodeSent && timeLeft === 0 && (
-                          <TextFieldContent variant="text" color="semantic.status.negative">
-                            만료됨
-                          </TextFieldContent>
-                        )}
-                      </>
-                    }
-                  />
-                </FormControl>
-                {isCodeSent && timeLeft > 0 && (
-                  <div className={verificationError || isEmailVerified ? "flex items-center justify-between" : "flex justify-end"}>
-                    {verificationError && (
-                      <p className="text-caption-1 text-status-negative">
-                        인증번호가 잘못되었어요.
-                      </p>
-                    )}
-                    {isEmailVerified && (
-                      <p className="text-caption-1 text-label-alternative">인증에 성공했어요.</p>
-                    )}
-                    <p className="text-caption-1 text-label-normal tabular-nums">
-                      유효시간 {formatTime(timeLeft)}
-                    </p>
-                  </div>
-                )}
-              </FormField>
-            </div>
+            <EmailVerificationFields
+              initialEmail={pending?.email}
+              onVerificationChange={(verified, email) => {
+                setIsEmailVerified(verified);
+                setVerifiedEmail(email);
+              }}
+            />
 
             <Button
               type="submit"
               disabled={
                 signupMutation.isPending ||
                 !name.trim() ||
-                !email.trim() ||
                 !isEmailVerified ||
-                email.trim() !== verifiedEmail
+                !verifiedEmail
               }
               variant="solid"
               color="primary"

--- a/frontend/src/components/auth/EmailVerificationFields.tsx
+++ b/frontend/src/components/auth/EmailVerificationFields.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { FormField, FormLabel, FormControl, TextField, TextFieldContent, TextFieldButton } from '@wanteddev/wds';
+import type { Theme } from '@wanteddev/wds-engine';
+import { useState, useEffect } from 'react';
+import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
+import { useCountdown } from '@/hooks/useCountdown';
+import { useSendEmailVerificationMutation, useVerifyEmailCodeMutation } from '@/queries/auth';
+
+interface EmailVerificationFieldsProps {
+  initialEmail?: string;
+  onVerificationChange: (isVerified: boolean, verifiedEmail: string) => void;
+}
+
+export function EmailVerificationFields({ initialEmail = '', onVerificationChange }: EmailVerificationFieldsProps) {
+  const toast = usePositionedToast();
+  const sendEmailMutation = useSendEmailVerificationMutation();
+  const verifyEmailMutation = useVerifyEmailCodeMutation();
+
+  const [email, setEmail] = useState(initialEmail);
+  const [verificationCode, setVerificationCode] = useState('');
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [verificationError, setVerificationError] = useState(false);
+  const { timeLeft, start: startTimer, reset: resetTimer, formatTime } = useCountdown();
+
+  const handleSendVerification = () => {
+    sendEmailMutation.mutate(
+      { email: email.trim() },
+      {
+        onSuccess: (data) => {
+          if (data.code === 'SEND_EMAIL_VERIFICATION') {
+            setIsCodeSent(true);
+            setIsEmailVerified(false);
+            setVerificationError(false);
+            setVerificationCode('');
+            startTimer(300);
+            onVerificationChange(false, '');
+            toast({
+              content: data.message,
+              variant: 'positive',
+              placement: 'top-center',
+            });
+          } else {
+            toast({
+              content: data.message,
+              variant: 'negative',
+              placement: 'top-center',
+            });
+          }
+        },
+        onError: (error) => {
+          toast({
+            content: error.message,
+            variant: 'negative',
+            placement: 'top-center',
+          });
+        },
+      },
+    );
+  };
+
+  const { mutate: verifyEmail, isPending: isVerifying } = verifyEmailMutation;
+
+  useEffect(() => {
+    if (verificationCode.length !== 6) return;
+    if (isEmailVerified || !isCodeSent || timeLeft === 0 || isVerifying) return;
+    if (verificationError) return;
+
+    verifyEmail(
+      {
+        email: email.trim(),
+        code: verificationCode.trim(),
+      },
+      {
+        onSuccess: (data) => {
+          if (data.code === 'VERIFY_EMAIL') {
+            setIsEmailVerified(true);
+            setVerificationError(false);
+            onVerificationChange(true, email.trim());
+            toast({
+              content: data.message,
+              variant: 'positive',
+              placement: 'top-center',
+            });
+          } else {
+            setVerificationError(true);
+            setIsEmailVerified(false);
+            toast({
+              content: data.message,
+              variant: 'negative',
+              placement: 'top-center',
+            });
+          }
+        },
+        onError: (error) => {
+          setVerificationError(true);
+          setIsEmailVerified(false);
+          toast({
+            content: error.message,
+            variant: 'negative',
+            placement: 'top-center',
+          });
+        },
+      },
+    );
+  }, [verificationCode, isEmailVerified, isCodeSent, timeLeft, isVerifying, verificationError, email, verifyEmail, toast, onVerificationChange]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FormField>
+        <FormLabel
+          htmlFor="email"
+          variant="label1"
+          sx={(theme: Theme) => ({
+            color: theme.semantic.label.neutral,
+          })}
+        >
+          이메일
+        </FormLabel>
+        <FormControl>
+          <TextField
+            id="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setIsEmailVerified(false);
+              setIsCodeSent(false);
+              setVerificationCode('');
+              setVerificationError(false);
+              resetTimer();
+              onVerificationChange(false, '');
+            }}
+            placeholder="이메일을 입력해 주세요."
+            type="email"
+            required
+            width="100%"
+            trailingButton={
+              <TextFieldButton
+                onClick={handleSendVerification}
+                disabled={sendEmailMutation.isPending || !email.trim()}
+              >
+                {isCodeSent ? '재전송' : '인증하기'}
+              </TextFieldButton>
+            }
+          />
+        </FormControl>
+      </FormField>
+
+      <FormField className="gap-2">
+        <FormControl>
+          <TextField
+            value={verificationCode}
+            onChange={(e) => {
+              const newValue = e.target.value.replace(/\D/g, '').slice(0, 6);
+              setVerificationCode(newValue);
+              setVerificationError(false);
+            }}
+            placeholder="인증번호를 입력해 주세요."
+            disabled={isEmailVerified}
+            invalid={verificationError}
+            positive={isEmailVerified}
+            width="100%"
+            maxLength={6}
+            trailingContent={
+              <>
+                {isCodeSent && timeLeft === 0 && (
+                  <TextFieldContent variant="text" color="semantic.status.negative">
+                    만료됨
+                  </TextFieldContent>
+                )}
+              </>
+            }
+          />
+        </FormControl>
+        {isCodeSent && timeLeft > 0 && (
+          <div className={verificationError || isEmailVerified ? "flex items-center justify-between" : "flex justify-end"}>
+            {verificationError && (
+              <p className="text-caption-1 text-status-negative">
+                인증번호가 잘못되었어요.
+              </p>
+            )}
+            {isEmailVerified && (
+              <p className="text-caption-1 text-label-alternative">인증에 성공했어요.</p>
+            )}
+            <p className="text-caption-1 text-label-normal tabular-nums">
+              유효시간 {formatTime(timeLeft)}
+            </p>
+          </div>
+        )}
+      </FormField>
+    </div>
+  );
+}

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -15,7 +15,7 @@ export function buildGoogleOAuthUrl(config: OAuthConfig): string {
     client_id: GOOGLE_CLIENT_ID,
     redirect_uri: redirectUri,
     response_type: 'code',
-    scope: 'openid email profile',
+    scope: 'openid email profile https://www.googleapis.com/auth/calendar.events',
     access_type: 'offline',
     prompt: 'consent',
     state,

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -38,9 +38,7 @@ export function startGoogleLogin(redirectUri?: string): void {
   sessionStorage.setItem('oauth_state', state);
 
   const uri = redirectUri || `${window.location.origin}/auth/callback`;
-  const url = buildGoogleOAuthUrl({ redirectUri: uri, state });
-
-  window.location.href = url;
+  window.location.href = buildGoogleOAuthUrl({ redirectUri: uri, state });
 }
 
 // OAuth state 검증

--- a/frontend/src/queries/auth.ts
+++ b/frontend/src/queries/auth.ts
@@ -12,6 +12,7 @@ interface LoginGoogleRequest {
 interface SignupRequest {
   socialProvider: string;
   socialAccessToken: string;
+  socialRefreshToken: string;
   nickname: string;
   email: string;
 }
@@ -25,6 +26,7 @@ interface AuthResponse {
     refreshToken?: string;
     socialProvider?: string;
     socialAccessToken?: string;
+    socialRefreshToken?: string;
     name?: string;
     email?: string;
   } | null;


### PR DESCRIPTION
## #️⃣연관된 이슈

#235 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- callback 페이지 빌드 에러 수정
- 회원가입 요청 바디에 google refreshToken 추가
- OAuth 동의 화면 scope에 calendar.events 추가
- 이메일 인증 로직을 별도 컴포넌트로 분리


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
