### PR TITLE
[Feat/#239] AI Agent + MCP Server 배포 및 백엔드 채팅 연동

### DIFF
--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -1,0 +1,144 @@
+name: AI CI/CD
+
+on:
+  push:
+    branches: [ai/develop]
+    paths:
+      - 'mcp-server/**'
+      - 'ai/agent/**'
+      - 'ai/docker-compose.yml'
+      - '.github/workflows/deploy-agent.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-agent-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-mcp:
+    name: Build & Push MCP Server
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: meta
+        run: echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mcp-server
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/flowmeet-mcp:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/flowmeet-mcp:${{ steps.meta.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-agent:
+    name: Build & Push AI Agent
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: meta
+        run: echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ai/agent
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/flowmeet-agent:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/flowmeet-agent:${{ steps.meta.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    needs: [build-mcp, build-agent]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy compose file to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.AI_EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "ai/docker-compose.yml"
+          target: "/home/ubuntu/ai"
+          strip_components: 1
+
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.AI_EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd /home/ubuntu/ai
+            export MCP_IMAGE_TAG=${{ needs.build-mcp.outputs.image_tag }}
+            export AGENT_IMAGE_TAG=${{ needs.build-agent.outputs.image_tag }}
+            sed -i "s/^MCP_IMAGE_TAG=.*/MCP_IMAGE_TAG=${MCP_IMAGE_TAG}/" .env
+            sed -i "s/^AGENT_IMAGE_TAG=.*/AGENT_IMAGE_TAG=${AGENT_IMAGE_TAG}/" .env
+
+            echo "::group::Pull & Up"
+            docker compose pull
+            docker compose up -d
+            echo "::endgroup::"
+
+            echo "::group::Wait for agent health"
+            for i in $(seq 1 24); do
+              status=$(curl -sf http://localhost:8000/health > /dev/null 2>&1 && echo "healthy" || echo "starting")
+              echo "[$i/24] agent health: $status"
+              if [ "$status" = "healthy" ]; then
+                echo "healthy"
+                break
+              fi
+              if [ "$i" -eq 24 ]; then
+                echo "::error::agent did not become healthy within 2 minutes"
+                docker compose logs --tail=200 ai-agent
+                exit 1
+              fi
+              sleep 5
+            done
+            echo "::endgroup::"
+
+            docker image prune -f

--- a/ai/.env.example
+++ b/ai/.env.example
@@ -1,0 +1,12 @@
+# ====== 실제 .env 는 EC2 /home/ubuntu/ai/.env 에 두고 커밋하지 않는다 ======
+
+# ---------- Registry ----------
+DOCKERHUB_USERNAME=
+MCP_IMAGE_TAG=latest
+AGENT_IMAGE_TAG=latest
+
+# ---------- Backend ----------
+BACKEND_URL=
+
+# ---------- Gemini ----------
+GEMINI_API_KEY=

--- a/ai/.gitignore
+++ b/ai/.gitignore
@@ -1,0 +1,3 @@
+*.env
+.env.*
+!.env.example

--- a/ai/agent/Dockerfile
+++ b/ai/agent/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -33,7 +33,7 @@ class Agent:
  
         return [types.Tool(function_declarations=function_declarations)]
  
-    async def run(self, user_message: str) -> str:
+    async def run(self, user_message: str, project_id: int | None = None) -> str:
 
         self.conversation_history = self.conversation_history[-MAX_HISTORY:]
         # tool_call/response 쌍 중간에서 잘리면 Gemini 오류 발생 — 텍스트 user 메시지부터 시작
@@ -59,6 +59,7 @@ class Agent:
                 contents=self.conversation_history,
                 config=types.GenerateContentConfig(
                     tools=self._tools,
+                    system_instruction=f"당신은 프로젝트 {project_id}의 AI 어시스턴트입니다." if project_id else None,
                     thinking_config=types.ThinkingConfig(
                         thinking_budget=512 # 응답 너무 느리면 0으로 변경 가능
                     ),

--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -34,7 +34,7 @@ class Agent:
  
         return [types.Tool(function_declarations=function_declarations)]
  
-    async def run(self, user_message: str, project_id: int | None = None) -> str:
+    async def run(self, user_message: str) -> str:
 
         self.conversation_history = self.conversation_history[-MAX_HISTORY:]
         # tool_call/response 쌍 중간에서 잘리면 Gemini 오류 발생 — 텍스트 user 메시지부터 시작
@@ -60,7 +60,7 @@ class Agent:
                 contents=self.conversation_history,
                 config=types.GenerateContentConfig(
                     tools=self._tools,
-                    system_instruction=f"당신은 프로젝트 {project_id}의 AI 어시스턴트입니다." if project_id else None,
+                    system_instruction=f"당신은 프로젝트 {self.project_id}의 AI 어시스턴트입니다.",
                     thinking_config=types.ThinkingConfig(
                         thinking_budget=512 # 응답 너무 느리면 0으로 변경 가능
                     ),

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -48,6 +48,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], all
 class ChatRequest(BaseModel):
     message: str
     session_id: str | None = None
+    project_id: int | None = None
 
 
 class ChatResponse(BaseModel):
@@ -72,6 +73,6 @@ async def chat(body: ChatRequest, authorization: str = Header(None)):
     session = await get_or_create_session(session_id, token)
 
     async with session["lock"]:
-        response = await session["agent"].run(body.message)
+        response = await session["agent"].run(body.message, body.project_id)
 
     return ChatResponse(response=response, session_id=session_id)

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -16,26 +16,33 @@ SESSION_TTL_MINUTES = 30
 sessions: dict[str, dict] = {}  # {session_id: {"agent", "mcp_client", "last_active", "lock"}}
 
 
-async def get_or_create_session(session_id: str, token: str) -> dict:
+async def get_or_create_session(session_id: str, token: str, project_id: str) -> dict:
     now = datetime.utcnow()
 
     # 만료 세션 정리
     expired = [sid for sid, s in sessions.items()
                if now - s["last_active"] > timedelta(minutes=SESSION_TTL_MINUTES)]
     for sid in expired:
-        await sessions[sid]["mcp_client"].close()
-        del sessions[sid]
+        try:
+            await sessions[sid]["mcp_client"].close()
+        except Exception as e:
+            print(f"[Session] {sid} 종료 중 오류: {e}")
+        finally:
+            sessions.pop(sid, None)
 
     if session_id not in sessions:
         mcp_client = MCPClient()
         await mcp_client.connect(MCP_SERVER_URL, token)
         sessions[session_id] = {
-            "agent": Agent(mcp_client=mcp_client),
+            "agent": Agent(mcp_client=mcp_client, project_id=project_id),
             "mcp_client": mcp_client,
             "last_active": now,
             "lock": asyncio.Lock(),
         }
     else:
+        if sessions[session_id]["agent"].project_id != project_id:
+            print(f"[Session] 경고: session {session_id}의 project_id 불일치 "
+                f"(기존: {sessions[session_id]['agent'].project_id}, 요청: {project_id})")
         sessions[session_id]["last_active"] = now
 
     return sessions[session_id]
@@ -48,7 +55,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], all
 class ChatRequest(BaseModel):
     message: str
     session_id: str | None = None
-    project_id: int | None = None
+    project_id: str
 
 
 class ChatResponse(BaseModel):
@@ -70,9 +77,9 @@ async def chat(body: ChatRequest, authorization: str = Header(None)):
 
     token = authorization.removeprefix("Bearer ")
     session_id = body.session_id or str(uuid.uuid4())
-    session = await get_or_create_session(session_id, token)
+    session = await get_or_create_session(session_id, token, body.project_id)
 
     async with session["lock"]:
-        response = await session["agent"].run(body.message, body.project_id)
+        response = await session["agent"].run(body.message)
 
     return ChatResponse(response=response, session_id=session_id)

--- a/ai/docker-compose.yml
+++ b/ai/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  mcp-server:
+    image: ${DOCKERHUB_USERNAME}/flowmeet-mcp:${MCP_IMAGE_TAG:-latest}
+    container_name: flowmeet-mcp
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      BACKEND_URL: ${BACKEND_URL}
+    networks:
+      - ai-net
+
+  ai-agent:
+    image: ${DOCKERHUB_USERNAME}/flowmeet-agent:${AGENT_IMAGE_TAG:-latest}
+    container_name: flowmeet-agent
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      MCP_SERVER_URL: http://flowmeet-mcp:8082/mcp
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mcp-server
+    networks:
+      - ai-net
+
+networks:
+  ai-net:
+    driver: bridge

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -66,3 +66,6 @@ SQS_REGION=ap-northeast-2
 
 # ---------- AI (API Gateway) ----------
 AI_NODE_ANALYSIS_ENDPOINT_URL=
+
+# ---------- AI Agent ----------
+AI_AGENT_URL=

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatApi.java
@@ -21,6 +21,7 @@ import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.chat.exception.ChatErrorCode;
 import kr.flowmeet.domain.project.exception.ProjectErrorCode;
+import kr.flowmeet.external.ai.AiAgentErrorCode;
 
 @Tag(name = "Chat", description = "채팅")
 public interface ChatApi {
@@ -73,11 +74,13 @@ public interface ChatApi {
     @Operation(summary = "메시지 전송")
     @ApiSuccessCode(code = ChatSuccessCode.class, name = "SEND_MESSAGE")
     @ApiErrorCode(code = ChatErrorCode.class, names = {"CHAT_SESSION_NOT_FOUND"})
+    @ApiErrorCode(code = AiAgentErrorCode.class, names = {"AI_AGENT_UNAVAILABLE"})
     CommonResponse<SendMessageResponse> sendMessage(
             @UserId Long userId,
             Long projectId,
             Long chatSessionId,
-            SendMessageRequest request);
+            SendMessageRequest request,
+            String authorization);
 
     @Operation(summary = "참조 가능한 노드 조회")
     @ApiSuccessCode(code = ChatSuccessCode.class, name = "GET_REFERENCE_NODES")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
@@ -109,11 +109,12 @@ public class ChatController implements ChatApi {
             @UserId Long userId,
             @PathVariable Long projectId,
             @PathVariable Long chatSessionId,
-            @RequestBody @Valid SendMessageRequest request
+            @RequestBody @Valid SendMessageRequest request,
+            @RequestHeader("Authorization") String authorization
     ) {
         return CommonResponse.ok(
                 ChatSuccessCode.SEND_MESSAGE,
-                chatFacade.sendMessage(userId, projectId, chatSessionId, request.content())
+                chatFacade.sendMessage(userId, projectId, chatSessionId, request.content(), authorization)
         );
     }
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
@@ -19,6 +19,7 @@ import kr.flowmeet.domain.chat.service.ChatSessionService;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.service.NodeService;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
+import kr.flowmeet.external.ai.AiAgentClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,7 @@ public class ChatFacade {
     private final ChatSessionNodeService chatSessionNodeService;
     private final NodeService nodeService;
     private final ProjectPermissionValidator projectPermissionValidator;
+    private final AiAgentClient aiAgentClient;
 
     public CursorSliceResponse<ChatSessionSummaryResponse> getAllChatSessions(
             final Long userId,
@@ -130,16 +132,20 @@ public class ChatFacade {
             final Long userId,
             final Long projectId,
             final Long chatSessionId,
-            final String content
+            final String content,
+            final String authorization
     ) {
         projectPermissionValidator.validate(projectId, userId);
 
         ChatSession session = chatSessionService.findByIdAndProjectId(chatSessionId, projectId);
         chatSessionService.validateCreatedBy(session, userId);
 
-        ChatMessage message = chatMessageService.create(chatSessionId, content);
+        chatMessageService.create(chatSessionId, content);
 
-        return SendMessageResponse.from(message);
+        String aiResponse = aiAgentClient.chat(content, chatSessionId.toString(), projectId, authorization);
+        ChatMessage aiMessage = chatMessageService.createAiResponse(chatSessionId, aiResponse);
+
+        return SendMessageResponse.from(aiMessage);
     }
 
     public GetReferenceNodesResponse getReferenceNodes(final Long userId, final Long projectId) {

--- a/backend/flowmeet-api/src/main/resources/config/external.yaml
+++ b/backend/flowmeet-api/src/main/resources/config/external.yaml
@@ -37,6 +37,10 @@ oauth:
     token-uri: ${OAUTH2_GOOGLE_TOKEN_URI:https://oauth2.googleapis.com/token}
     user-info-uri: ${OAUTH2_GOOGLE_USER_INFO_URI:https://www.googleapis.com/oauth2/v3/userinfo}
 
+ai:
+  agent:
+    url: ${AI_AGENT_URL:http://localhost:8000}
+
 discord:
   error-notifier:
     enabled: ${DISCORD_ERROR_NOTIFIER_ENABLED:false}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatMessageService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatMessageService.java
@@ -31,6 +31,17 @@ public class ChatMessageService {
     }
 
     @Transactional
+    public ChatMessage createAiResponse(final Long chatSessionId, final String content) {
+        return chatMessageRepository.save(
+                ChatMessage.builder()
+                        .chatSessionId(chatSessionId)
+                        .content(content)
+                        .messageType(ChatMessageType.AI_RESPONSE)
+                        .build()
+        );
+    }
+
+    @Transactional
     public void softDeleteAllByChatSessionId(final Long chatSessionId) {
         chatMessageRepository.softDeleteAllByChatSessionId(chatSessionId);
     }

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/AiAgentClient.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/AiAgentClient.java
@@ -1,0 +1,39 @@
+package kr.flowmeet.external.ai;
+
+import kr.flowmeet.external.ai.dto.AiChatRequest;
+import kr.flowmeet.external.ai.dto.AiChatResponse;
+import kr.flowmeet.external.exception.ExternalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiAgentClient {
+
+    private final RestClient aiAgentRestClient;
+
+    public String chat(final String message, final String sessionId, final Long projectId, final String authorization) {
+        AiChatRequest request = new AiChatRequest(message, sessionId, projectId);
+
+        log.info("AI Agent 호출 - sessionId: {}", sessionId);
+
+        try {
+            AiChatResponse response = aiAgentRestClient.post()
+                    .uri("/chat")
+                    .header("Authorization", authorization)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(AiChatResponse.class);
+
+            return response.response();
+        } catch (Exception e) {
+            log.error("AI Agent 호출 실패 - sessionId: {}", sessionId, e);
+            throw new ExternalException(AiAgentErrorCode.AI_AGENT_UNAVAILABLE);
+        }
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/AiAgentErrorCode.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/AiAgentErrorCode.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.external.ai;
+
+import kr.flowmeet.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AiAgentErrorCode implements ErrorCode {
+
+    AI_AGENT_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "AI Agent 호출에 실패했어요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/AiAgentConfig.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/AiAgentConfig.java
@@ -1,0 +1,18 @@
+package kr.flowmeet.external.ai.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(AiAgentProperties.class)
+public class AiAgentConfig {
+
+    @Bean
+    public RestClient aiAgentRestClient(final AiAgentProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.getUrl())
+                .build();
+    }
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/AiAgentProperties.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/config/AiAgentProperties.java
@@ -1,0 +1,13 @@
+package kr.flowmeet.external.ai.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "ai.agent")
+public class AiAgentProperties {
+
+    private final String url;
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/AiChatRequest.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/AiChatRequest.java
@@ -1,0 +1,10 @@
+package kr.flowmeet.external.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AiChatRequest(
+        String message,
+        @JsonProperty("session_id") String sessionId,
+        @JsonProperty("project_id") Long projectId
+) {
+}

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/AiChatResponse.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/AiChatResponse.java
@@ -1,0 +1,9 @@
+package kr.flowmeet.external.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AiChatResponse(
+        String response,
+        @JsonProperty("session_id") String sessionId
+) {
+}

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /workspace
+
+COPY gradlew ./
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+
+RUN chmod +x gradlew && ./gradlew --no-daemon dependencies
+
+COPY src ./src
+
+RUN ./gradlew --no-daemon bootJar -x test
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --system spring && useradd --system --gid spring spring
+USER spring
+
+COPY --from=builder /workspace/build/libs/mcp-server-0.0.1.jar /app/app.jar
+
+EXPOSE 8082
+
+ENTRYPOINT ["sh", "-c", "exec java -jar /app/app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #239

## 📝작업 내용

### projectId 처리

- `project_id`를 `Agent` 생성자에 저장, MCP Tool 호출 시 `all_args`에 자동 주입 (AI #244 병합)
- Gemini `system_instruction`에 `"당신은 프로젝트 {project_id}의 AI 어시스턴트입니다."` 추가 주입
  - tool arg 주입: tool 호출 신뢰성 보장
  - system_instruction: LLM이 프로젝트 컨텍스트를 이해해 유저에게 되묻는 상황 방지
- 세션 정리 `try/finally` 적용, project_id 불일치 경고 로그 추가 (AI팀 개선사항)
- 유저가 프로젝트 ID를 직접 명시하지 않아도 현재 프로젝트 컨텍스트 안에서 동작 (#236 논의 사항 해결)

### 배포 인프라 구성

- `mcp-server/Dockerfile`: eclipse-temurin:21 멀티스테이지 빌드
- `ai/agent/Dockerfile`: python:3.12-slim 기반 uvicorn 실행
- `ai/docker-compose.yml`: mcp-server + ai-agent 단일 브릿지 네트워크, ai-agent만 포트 8000 외부 노출
- `.github/workflows/deploy-agent.yml`: build-mcp / build-agent 병렬 빌드 후 AI EC2 SSH 배포 (`ai/develop` 트리거)

### 백엔드 AI Agent 연동

- `AiAgentClient`: `POST /chat` 호출, 실패 시 `AI_AGENT_UNAVAILABLE`(502) 예외
- `AiAgentProperties` / `AiAgentConfig`: `AI_AGENT_URL` 환경변수 기반 `RestClient` Bean 등록
- `ChatMessageService.createAiResponse()`: AI 응답 저장 메서드 추가
- `ChatFacade.sendMessage()`: 사용자 메시지 저장 → AI Agent 호출 → AI 응답 저장
- `ChatController` / `ChatApi`: `Authorization` 헤더 수신 후 Facade로 전달, Swagger 에러 코드 추가

## 변경 파일

| 파일 | 변경 |
|------|------|
| `ai/agent/agent.py` | 수정 - project_id 생성자 주입, system_instruction 추가, run() 시그니처 변경 |
| `ai/agent/main.py` | 수정 - AI팀 PR #244 병합, project_id 필수 필드, 세션 정리 개선 |
| `mcp-server/Dockerfile` | 추가 |
| `ai/agent/Dockerfile` | 추가 |
| `ai/docker-compose.yml` | 추가 |
| `ai/.env.example` | 추가 |
| `ai/.gitignore` | 추가 |
| `.github/workflows/deploy-agent.yml` | 추가 |
| `flowmeet-external/.../ai/AiAgentClient.java` | 추가 |
| `flowmeet-external/.../ai/AiAgentErrorCode.java` | 추가 |
| `flowmeet-external/.../ai/config/AiAgentConfig.java` | 추가 |
| `flowmeet-external/.../ai/config/AiAgentProperties.java` | 추가 |
| `flowmeet-external/.../ai/dto/AiChatRequest.java` | 추가 |
| `flowmeet-external/.../ai/dto/AiChatResponse.java` | 추가 |
| `flowmeet-domain/.../chat/service/ChatMessageService.java` | 수정 - createAiResponse() 추가 |
| `flowmeet-api/.../chat/facade/ChatFacade.java` | 수정 - AI Agent 호출 연동 |
| `flowmeet-api/.../chat/controller/ChatController.java` | 수정 - Authorization 헤더 추가 |
| `flowmeet-api/.../chat/controller/ChatApi.java` | 수정 - 시그니처 동기화, Swagger 에러 코드 추가 |
| `flowmeet-api/src/main/resources/config/external.yaml` | 수정 - ai.agent.url 추가 |
| `backend/.env.example` | 수정 - AI_AGENT_URL 추가 |

## 💬리뷰 요구사항

`ChatFacade.sendMessage()`는 `@Transactional` 안에서 외부 HTTP 호출(AI Agent)을 포함합니다.
AI Agent 장애 시 `ExternalException`이 발생해 트랜잭션이 롤백되므로 사용자 메시지도 저장되지 않습니다.
현재는 AI Agent가 정상일 때만 메시지가 저장되는 구조인데, 사용자 메시지를 먼저 커밋하고 AI 호출을 별도 처리하는 방식이 더 나은지 의견 부탁드립니다.

## 💬참고 사항

이 PR은 `ai/develop`에 먼저 머지하여 AI EC2 배포 및 정상 동작을 검증한 후, `backend/develop`에 별도로 머지할 예정입니다.
백엔드 배포 시점에 MCP Server + AI Agent가 이미 떠 있는 상태여야 `sendMessage` 호출 시 502 오류가 발생하지 않기 때문입니다. 참고부탁드립니다.