### PR TITLE
[Feat/#241] get_edges MCP 툴 추가 및 연결선 목록 조회 API 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeApi.java
@@ -10,6 +10,7 @@ import kr.flowmeet.api.common.swagger.ApiErrorCode;
 import kr.flowmeet.api.common.swagger.ApiSuccessCode;
 import kr.flowmeet.api.node.dto.request.CreateEdgeRequest;
 import kr.flowmeet.api.node.dto.request.UpdateEdgeRequest;
+import kr.flowmeet.api.node.dto.response.GetEdgesResponse;
 import kr.flowmeet.api.node.success.EdgeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
 import kr.flowmeet.domain.node.exception.EdgeErrorCode;
@@ -17,6 +18,13 @@ import kr.flowmeet.domain.node.exception.NodeErrorCode;
 
 @Tag(name = "Edge", description = "연결선")
 public interface EdgeApi {
+
+    @Operation(summary = "연결선 목록 조회", description = "프로젝트 내 모든 연결선의 ID와 시작/종료 노드를 조회합니다.")
+    @ApiSuccessCode(code = EdgeSuccessCode.class, name = "GET_EDGES")
+    CommonResponse<GetEdgesResponse> getEdges(
+            @UserId Long userId,
+            @PathVariable Long projectId
+    );
 
     @Operation(summary = "연결선 생성", description = "노드 간 연결선을 추가합니다.")
     @ApiSuccessCode(code = EdgeSuccessCode.class, name = "CREATE_EDGE")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/controller/EdgeController.java
@@ -3,6 +3,7 @@ package kr.flowmeet.api.node.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import kr.flowmeet.api.common.dto.CommonResponse;
 import kr.flowmeet.api.node.dto.request.CreateEdgeRequest;
+import kr.flowmeet.api.node.dto.response.GetEdgesResponse;
 import kr.flowmeet.api.node.facade.EdgeFacade;
 import kr.flowmeet.api.node.success.EdgeSuccessCode;
 import kr.flowmeet.auth.annotation.UserId;
@@ -20,6 +22,15 @@ import kr.flowmeet.auth.annotation.UserId;
 public class EdgeController implements EdgeApi {
 
     private final EdgeFacade edgeFacade;
+
+    @Override
+    @GetMapping
+    public CommonResponse<GetEdgesResponse> getEdges(
+            @UserId Long userId,
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.ok(EdgeSuccessCode.GET_EDGES, edgeFacade.getEdges(userId, projectId));
+    }
 
     @Override
     @PostMapping

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetEdgesResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetEdgesResponse.java
@@ -1,0 +1,33 @@
+package kr.flowmeet.api.node.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import kr.flowmeet.domain.node.entity.Edge;
+
+@Schema(description = "엣지 목록 조회 응답")
+public record GetEdgesResponse(
+        @Schema(description = "연결선 목록")
+        List<EdgeItem> edges
+) {
+
+    public static GetEdgesResponse of(final List<Edge> edges) {
+        return new GetEdgesResponse(
+                edges.stream().map(EdgeItem::from).toList()
+        );
+    }
+
+    @Schema(description = "연결선 항목")
+    public record EdgeItem(
+            @Schema(description = "연결선 ID", example = "9001")
+            Long edgeId,
+            @Schema(description = "시작 노드 ID", example = "101")
+            Long startNodeId,
+            @Schema(description = "종료 노드 ID", example = "102")
+            Long endNodeId
+    ) {
+
+        public static EdgeItem from(final Edge edge) {
+            return new EdgeItem(edge.getId(), edge.getStartNodeId(), edge.getEndNodeId());
+        }
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/EdgeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/EdgeFacade.java
@@ -1,14 +1,16 @@
 package kr.flowmeet.api.node.facade;
 
-import kr.flowmeet.domain.node.service.NodeValidator;
-import kr.flowmeet.domain.project.entity.ProjectMemberRole;
-import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import kr.flowmeet.api.node.dto.request.CreateEdgeRequest;
+import kr.flowmeet.api.node.dto.response.GetEdgesResponse;
 import kr.flowmeet.domain.node.entity.Edge;
 import kr.flowmeet.domain.node.service.EdgeService;
+import kr.flowmeet.domain.node.service.NodeValidator;
+import kr.flowmeet.domain.project.entity.ProjectMemberRole;
+import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +20,12 @@ public class EdgeFacade {
     private final EdgeService edgeService;
     private final ProjectPermissionValidator projectPermissionValidator;
     private final NodeValidator nodeValidator;
+
+    public GetEdgesResponse getEdges(final Long userId, final Long projectId) {
+        projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
+        List<Edge> edges = edgeService.findAllByProjectId(projectId);
+        return GetEdgesResponse.of(edges);
+    }
 
     @Transactional
     public void createEdge(

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/EdgeSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/success/EdgeSuccessCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum EdgeSuccessCode implements SuccessCode {
+    GET_EDGES("연결선 목록을 조회했어요."),
     CREATE_EDGE("연결선을 생성했어요."),
     DELETE_EDGE("연결선을 삭제했어요.");
 

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/NodeTools.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/tool/NodeTools.java
@@ -33,10 +33,10 @@ public class NodeTools {
                 .body(String.class);
     }
 
-    @Tool(name = "get_flowchart", description = "프로젝트의 플로우차트를 조회합니다. 전체 노드 목록과 노드 간 연결선(엣지) 목록을 반환합니다. 엣지에는 edgeId, startNodeId, endNodeId가 포함되어 있어 연결선 삭제 시 edgeId를 찾는 데 사용하세요.")
-    public String getFlowchart(Long projectId) {
+    @Tool(name = "get_edges", description = "프로젝트 내 연결선 목록을 조회합니다. 각 연결선의 edgeId, startNodeId, endNodeId를 반환합니다. 연결선 삭제 시 edgeId를 찾는 데 사용하세요.")
+    public String getEdges(Long projectId) {
         return backendRestClient.get()
-                .uri("/v1/projects/{projectId}/nodes", projectId)
+                .uri("/v1/projects/{projectId}/edges", projectId)
                 .header("Authorization", ToolAuthExtractor.extractAuth())
                 .retrieve()
                 .body(String.class);


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #241

## 📝작업 내용

### 연결선 목록 조회 API 추가

- `GET /v1/projects/{projectId}/edges` 엔드포인트 신규 추가
- 응답은 `edgeId`, `startNodeId`, `endNodeId` 3개 필드만 반환하는 경량 DTO 사용
- 프로젝트 멤버 권한 검증 포함

### MCP `get_flowchart` → `get_edges` 툴 전환

- 기존 `get_flowchart`는 노드·태그·담당자 등 불필요한 데이터까지 반환해 토큰 소모가 과도했음
- `get_edges` 툴로 교체, 신규 `/edges` API 호출

## 변경 파일

| 파일 | 변경 |
|------|------|
| `flowmeet-api/.../dto/response/GetEdgesResponse.java` | 추가 |
| `flowmeet-api/.../success/EdgeSuccessCode.java` | 수정 - `GET_EDGES` 추가 |
| `flowmeet-api/.../facade/EdgeFacade.java` | 수정 - `getEdges()` 추가 |
| `flowmeet-api/.../controller/EdgeApi.java` | 수정 - `GET /edges` 인터페이스 추가 |
| `flowmeet-api/.../controller/EdgeController.java` | 수정 - `GET /edges` 구현 추가 |
| `mcp-server/.../tool/NodeTools.java` | 수정 - `get_flowchart` → `get_edges` 교체 |