### PR TITLE
[Feat/#243] mcp client에서 project_id 처리

### DIFF
--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -8,8 +8,9 @@ MAX_TOOL_ROUNDS = 10
 MAX_HISTORY = 30
  
 class Agent:
-    def __init__(self, mcp_client: MCPClient):
+    def __init__(self, mcp_client: MCPClient, project_id: str):
         self.mcp_client = mcp_client
+        self.project_id = project_id
         self.client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
         self.model = "gemini-2.5-flash"
         self.conversation_history = []
@@ -86,12 +87,18 @@ class Agent:
             tool_results = []
             for part in tool_calls:
                 fc = part.function_call
-                print(f"[Agent] 툴 호출: {fc.name}({dict(fc.args)})")
 
+                all_args = {
+                    **dict(fc.args),
+                    "project_id": self.project_id,
+                }
+
+                print(f"[Agent] 툴 호출: {fc.name}({all_args})")
+                
                 try:
                     result = await self.mcp_client.call_tool(
                         tool_name=fc.name,
-                        arguments=dict(fc.args),
+                        arguments=all_args,
                     )
                 except Exception as e:
                     result = f"Tool execution failed: {str(e)}"

--- a/ai/agent/main.py
+++ b/ai/agent/main.py
@@ -16,26 +16,33 @@ SESSION_TTL_MINUTES = 30
 sessions: dict[str, dict] = {}  # {session_id: {"agent", "mcp_client", "last_active", "lock"}}
 
 
-async def get_or_create_session(session_id: str, token: str) -> dict:
+async def get_or_create_session(session_id: str, token: str, project_id: str) -> dict:
     now = datetime.utcnow()
 
     # 만료 세션 정리
     expired = [sid for sid, s in sessions.items()
                if now - s["last_active"] > timedelta(minutes=SESSION_TTL_MINUTES)]
     for sid in expired:
-        await sessions[sid]["mcp_client"].close()
-        del sessions[sid]
+        try:
+            await sessions[sid]["mcp_client"].close()
+        except Exception as e:
+            print(f"[Session] {sid} 종료 중 오류: {e}")
+        finally:
+            sessions.pop(sid, None)
 
     if session_id not in sessions:
         mcp_client = MCPClient()
         await mcp_client.connect(MCP_SERVER_URL, token)
         sessions[session_id] = {
-            "agent": Agent(mcp_client=mcp_client),
+            "agent": Agent(mcp_client=mcp_client, project_id=project_id),
             "mcp_client": mcp_client,
             "last_active": now,
             "lock": asyncio.Lock(),
         }
     else:
+        if sessions[session_id]["agent"].project_id != project_id:
+            print(f"[Session] 경고: session {session_id}의 project_id 불일치 "
+                f"(기존: {sessions[session_id]['agent'].project_id}, 요청: {project_id})")
         sessions[session_id]["last_active"] = now
 
     return sessions[session_id]
@@ -48,6 +55,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], all
 class ChatRequest(BaseModel):
     message: str
     session_id: str | None = None
+    project_id: str
 
 
 class ChatResponse(BaseModel):
@@ -69,7 +77,7 @@ async def chat(body: ChatRequest, authorization: str = Header(None)):
 
     token = authorization.removeprefix("Bearer ")
     session_id = body.session_id or str(uuid.uuid4())
-    session = await get_or_create_session(session_id, token)
+    session = await get_or_create_session(session_id, token, body.project_id)
 
     async with session["lock"]:
         response = await session["agent"].run(body.message)


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #243 

## 📝작업 내용

> Agent 단위로 project_id를 관리하도록 구조를 개선하기 위해 MCP Tool 호출 시 project_id를 서버에서 자동 주입하도록 수정하였습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 기존 논의사항대로 System instruction에서 project_id를 모든 사용자가 동일한 project_id를 공유하는 문제가 발생합니다 (system instruction은 LLM API 하나 당 한 개 설정, 그런데 LLM API 하나로 여러 Agent가 병렬 동작하므로 사용자별/세션별 프로젝트 context를 분리할 수 없음).

이러한 문제 우회하기 위해 project_id를 System instruction이 아닌 Agent state(all_args)에서 관리하도록 변경하였으며, MCP Tool 호출 직전에 프론트엔드에서 전달받은 project_id를 포함한 all_args를 구성하여 MCP Server로 전달하는 방식으로 구조를 개선하였습니다.

위처럼 mcp client 결과를 반환할 때 코드 상으로 project_id를 직접 포함하므로 tool schema에서 project_id를 제거해야할 것 같습니다.