### PR TITLE
[Feat/#245] 채팅 메시지 전송 시 노드/사용자 참조 기능 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatApi.java
@@ -11,6 +11,7 @@ import kr.flowmeet.api.chat.dto.response.ChatSessionSummaryResponse;
 import kr.flowmeet.api.chat.dto.response.CreateChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetReferenceNodesResponse;
+import kr.flowmeet.api.chat.dto.response.GetReferenceUsersResponse;
 import kr.flowmeet.api.chat.dto.response.SendMessageResponse;
 import kr.flowmeet.api.chat.dto.response.UpdateChatSessionResponse;
 import kr.flowmeet.api.chat.success.ChatSuccessCode;
@@ -83,6 +84,13 @@ public interface ChatApi {
     @ApiSuccessCode(code = ChatSuccessCode.class, name = "GET_REFERENCE_NODES")
     @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED"})
     CommonResponse<GetReferenceNodesResponse> getReferenceNodes(
+            @UserId Long userId,
+            Long projectId);
+
+    @Operation(summary = "참조 가능한 사용자 조회")
+    @ApiSuccessCode(code = ChatSuccessCode.class, name = "GET_REFERENCE_USERS")
+    @ApiErrorCode(code = ProjectErrorCode.class, names = {"PROJECT_ACCESS_DENIED"})
+    CommonResponse<GetReferenceUsersResponse> getReferenceUsers(
             @UserId Long userId,
             Long projectId);
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
@@ -10,6 +10,7 @@ import kr.flowmeet.api.chat.dto.response.ChatSessionSummaryResponse;
 import kr.flowmeet.api.chat.dto.response.CreateChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetReferenceNodesResponse;
+import kr.flowmeet.api.chat.dto.response.GetReferenceUsersResponse;
 import kr.flowmeet.api.chat.dto.response.SendMessageResponse;
 import kr.flowmeet.api.chat.dto.response.UpdateChatSessionResponse;
 import kr.flowmeet.api.chat.facade.ChatFacade;
@@ -126,6 +127,18 @@ public class ChatController implements ChatApi {
         return CommonResponse.ok(
                 ChatSuccessCode.GET_REFERENCE_NODES,
                 chatFacade.getReferenceNodes(userId, projectId)
+        );
+    }
+
+    @Override
+    @GetMapping("/users")
+    public CommonResponse<GetReferenceUsersResponse> getReferenceUsers(
+            @UserId Long userId,
+            @PathVariable Long projectId
+    ) {
+        return CommonResponse.ok(
+                ChatSuccessCode.GET_REFERENCE_USERS,
+                chatFacade.getReferenceUsers(userId, projectId)
         );
     }
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/controller/ChatController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -115,7 +116,7 @@ public class ChatController implements ChatApi {
     ) {
         return CommonResponse.ok(
                 ChatSuccessCode.SEND_MESSAGE,
-                chatFacade.sendMessage(userId, projectId, chatSessionId, request.content(), authorization)
+                chatFacade.sendMessage(userId, projectId, chatSessionId, request, authorization)
         );
     }
 

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/request/SendMessageRequest.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/request/SendMessageRequest.java
@@ -2,11 +2,18 @@ package kr.flowmeet.api.chat.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 @Schema(description = "메시지 전송 요청")
 public record SendMessageRequest(
         @Schema(description = "메시지 내용", example = "이 노드 내용을 기반으로 일정을 정리해줘")
         @NotBlank(message = "메시지 내용을 입력해 주세요.")
-        String content
+        String content,
+
+        @Schema(description = "참조 노드 ID 목록", example = "[1, 2]")
+        List<Long> referenceNodeIds,
+
+        @Schema(description = "참조 사용자 ID 목록", example = "[3, 4]")
+        List<Long> referenceUserIds
 ) {
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/GetReferenceUsersResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/GetReferenceUsersResponse.java
@@ -1,0 +1,17 @@
+package kr.flowmeet.api.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import kr.flowmeet.domain.project.entity.ProjectMember;
+
+@Schema(description = "참조 가능한 사용자 목록 응답")
+public record GetReferenceUsersResponse(
+        @Schema(description = "사용자 목록")
+        List<ReferencedUserResponse> users
+) {
+    public static GetReferenceUsersResponse from(final List<ProjectMember> members) {
+        return new GetReferenceUsersResponse(
+                members.stream().map(ReferencedUserResponse::from).toList()
+        );
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedNodeResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedNodeResponse.java
@@ -7,10 +7,12 @@ import kr.flowmeet.domain.node.entity.Node;
 public record ReferencedNodeResponse(
         @Schema(description = "노드 ID", example = "101")
         Long nodeId,
+        @Schema(description = "노드 번호", example = "1.1")
+        String number,
         @Schema(description = "노드 제목", example = "기획 문서 작성")
         String title
 ) {
     public static ReferencedNodeResponse from(final Node node) {
-        return new ReferencedNodeResponse(node.getId(), node.getTitle());
+        return new ReferencedNodeResponse(node.getId(), node.getNumber(), node.getTitle());
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedUserResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedUserResponse.java
@@ -1,0 +1,22 @@
+package kr.flowmeet.api.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.flowmeet.domain.project.entity.ProjectMember;
+
+@Schema(description = "참조 사용자 정보")
+public record ReferencedUserResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+        @Schema(description = "닉네임", example = "홍길동")
+        String nickname,
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
+        String profileImageUrl
+) {
+    public static ReferencedUserResponse from(final ProjectMember member) {
+        return new ReferencedUserResponse(
+                member.getUserId(),
+                member.getUser().getNickname(),
+                member.getUser().getProfileImageUrl()
+        );
+    }
+}

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
@@ -8,6 +8,7 @@ import kr.flowmeet.api.chat.dto.response.ChatSessionSummaryResponse;
 import kr.flowmeet.api.chat.dto.response.CreateChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetChatSessionResponse;
 import kr.flowmeet.api.chat.dto.response.GetReferenceNodesResponse;
+import kr.flowmeet.api.chat.dto.response.GetReferenceUsersResponse;
 import kr.flowmeet.api.chat.dto.response.SendMessageResponse;
 import kr.flowmeet.api.chat.dto.response.UpdateChatSessionResponse;
 import kr.flowmeet.api.common.dto.CursorSliceResponse;
@@ -18,6 +19,8 @@ import kr.flowmeet.domain.chat.service.ChatSessionNodeService;
 import kr.flowmeet.domain.chat.service.ChatSessionService;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.service.NodeService;
+import kr.flowmeet.domain.project.entity.ProjectMember;
+import kr.flowmeet.domain.project.service.ProjectMemberService;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,6 +35,7 @@ public class ChatFacade {
     private final ChatMessageService chatMessageService;
     private final ChatSessionNodeService chatSessionNodeService;
     private final NodeService nodeService;
+    private final ProjectMemberService projectMemberService;
     private final ProjectPermissionValidator projectPermissionValidator;
 
     public CursorSliceResponse<ChatSessionSummaryResponse> getAllChatSessions(
@@ -148,6 +152,14 @@ public class ChatFacade {
         List<Node> nodes = nodeService.findAllByProjectId(projectId);
 
         return GetReferenceNodesResponse.from(nodes);
+    }
+
+    public GetReferenceUsersResponse getReferenceUsers(final Long userId, final Long projectId) {
+        projectPermissionValidator.validate(projectId, userId);
+
+        List<ProjectMember> members = projectMemberService.findAllByProjectIdOrderByRole(projectId);
+
+        return GetReferenceUsersResponse.from(members);
     }
 
     @Transactional

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/facade/ChatFacade.java
@@ -1,7 +1,9 @@
 package kr.flowmeet.api.chat.facade;
 
+import java.util.ArrayList;
 import java.util.List;
 import kr.flowmeet.api.chat.dto.request.CreateChatSessionRequest;
+import kr.flowmeet.api.chat.dto.request.SendMessageRequest;
 import kr.flowmeet.api.chat.dto.response.AddChatNodeResponse;
 import kr.flowmeet.api.chat.dto.response.ChatMessageResponse;
 import kr.flowmeet.api.chat.dto.response.ChatSessionSummaryResponse;
@@ -17,6 +19,7 @@ import kr.flowmeet.domain.chat.entity.ChatSession;
 import kr.flowmeet.domain.chat.service.ChatMessageService;
 import kr.flowmeet.domain.chat.service.ChatSessionNodeService;
 import kr.flowmeet.domain.chat.service.ChatSessionService;
+import kr.flowmeet.domain.chat.service.ChatSessionUserService;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.service.NodeService;
 import kr.flowmeet.domain.project.entity.ProjectMember;
@@ -35,6 +38,7 @@ public class ChatFacade {
     private final ChatSessionService chatSessionService;
     private final ChatMessageService chatMessageService;
     private final ChatSessionNodeService chatSessionNodeService;
+    private final ChatSessionUserService chatSessionUserService;
     private final NodeService nodeService;
     private final ProjectMemberService projectMemberService;
     private final ProjectPermissionValidator projectPermissionValidator;
@@ -127,6 +131,7 @@ public class ChatFacade {
         ChatSession session = chatSessionService.findByIdAndProjectId(chatSessionId, projectId);
         chatSessionService.validateCreatedBy(session, userId);
         chatSessionNodeService.deleteAllByChatSessionId(chatSessionId);
+        chatSessionUserService.deleteAllByChatSessionId(chatSessionId);
         chatMessageService.softDeleteAllByChatSessionId(chatSessionId);
         chatSessionService.delete(session);
     }
@@ -136,7 +141,7 @@ public class ChatFacade {
             final Long userId,
             final Long projectId,
             final Long chatSessionId,
-            final String content,
+            final SendMessageRequest request,
             final String authorization
     ) {
         projectPermissionValidator.validate(projectId, userId);
@@ -144,12 +149,40 @@ public class ChatFacade {
         ChatSession session = chatSessionService.findByIdAndProjectId(chatSessionId, projectId);
         chatSessionService.validateCreatedBy(session, userId);
 
-        chatMessageService.create(chatSessionId, content);
+        registerReferenceNodes(chatSessionId, request.referenceNodeIds());
+        registerReferenceUsers(chatSessionId, request.referenceUserIds());
 
-        String aiResponse = aiAgentClient.chat(content, chatSessionId.toString(), projectId, authorization);
+        String messageWithHint = buildMessageWithHint(request);
+        chatMessageService.create(chatSessionId, request.content());
+
+        String aiResponse = aiAgentClient.chat(messageWithHint, chatSessionId.toString(), projectId, authorization);
         ChatMessage aiMessage = chatMessageService.createAiResponse(chatSessionId, aiResponse);
 
         return SendMessageResponse.from(aiMessage);
+    }
+
+    private void registerReferenceNodes(final Long chatSessionId, final List<Long> nodeIds) {
+        if (nodeIds == null) return;
+        nodeIds.forEach(nodeId -> chatSessionNodeService.register(chatSessionId, nodeId));
+    }
+
+    private void registerReferenceUsers(final Long chatSessionId, final List<Long> userIds) {
+        if (userIds == null) return;
+        userIds.forEach(userId -> chatSessionUserService.register(chatSessionId, userId));
+    }
+
+    private String buildMessageWithHint(final SendMessageRequest request) {
+        List<String> hints = new ArrayList<>();
+        if (request.referenceNodeIds() != null && !request.referenceNodeIds().isEmpty()) {
+            hints.add("[참조 노드 ID: " + request.referenceNodeIds() + "]");
+        }
+        if (request.referenceUserIds() != null && !request.referenceUserIds().isEmpty()) {
+            hints.add("[참조 유저 ID: " + request.referenceUserIds() + "]");
+        }
+        if (hints.isEmpty()) {
+            return request.content();
+        }
+        return String.join(" ", hints) + " " + request.content();
     }
 
     public GetReferenceNodesResponse getReferenceNodes(final Long userId, final Long projectId) {

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/success/ChatSuccessCode.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/success/ChatSuccessCode.java
@@ -14,6 +14,7 @@ public enum ChatSuccessCode implements SuccessCode {
     DELETE_CHAT_SESSION("채팅을 삭제했어요."),
     SEND_MESSAGE("메시지를 전송했어요."),
     GET_REFERENCE_NODES("참조 가능한 노드를 조회했어요."),
+    GET_REFERENCE_USERS("참조 가능한 사용자를 조회했어요."),
     ADD_CHAT_NODE("참조 노드를 추가했어요."),
     REMOVE_CHAT_NODE("참조 노드를 제거했어요.");
 

--- a/backend/flowmeet-api/src/main/resources/db/migration/V20__add_chat_session_users.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V20__add_chat_session_users.sql
@@ -1,0 +1,17 @@
+-- =========================================================
+-- V20__add_chat_session_users.sql
+-- 채팅 세션 참조 사용자 테이블
+-- =========================================================
+
+CREATE TABLE chat_session_users (
+    chat_session_user_id BIGSERIAL PRIMARY KEY,
+    chat_session_id      BIGINT    NOT NULL,
+    user_id              BIGINT    NOT NULL,
+    created_at           TIMESTAMP NOT NULL,
+    CONSTRAINT fk_chat_session_users_session FOREIGN KEY (chat_session_id) REFERENCES chat_sessions (chat_session_id),
+    CONSTRAINT fk_chat_session_users_user    FOREIGN KEY (user_id)         REFERENCES users (user_id),
+    CONSTRAINT uk_chat_session_users         UNIQUE (chat_session_id, user_id)
+);
+
+CREATE INDEX idx_chat_session_users_chat_session_id ON chat_session_users (chat_session_id);
+CREATE INDEX idx_chat_session_users_user_id          ON chat_session_users (user_id);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/entity/ChatSessionUser.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/entity/ChatSessionUser.java
@@ -1,0 +1,60 @@
+package kr.flowmeet.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import kr.flowmeet.domain.common.BaseCreatedTimeEntity;
+import kr.flowmeet.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "chat_session_users",
+        indexes = {
+                @Index(name = "idx_chat_session_users_chat_session_id", columnList = "chat_session_id"),
+                @Index(name = "idx_chat_session_users_user_id", columnList = "user_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_chat_session_users", columnNames = {"chat_session_id", "user_id"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSessionUser extends BaseCreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_session_user_id")
+    private Long id;
+
+    @Column(name = "chat_session_id", nullable = false)
+    private Long chatSessionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_session_id", insertable = false, updatable = false)
+    private ChatSession chatSession;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @Builder
+    public ChatSessionUser(Long chatSessionId, Long userId) {
+        this.chatSessionId = chatSessionId;
+        this.userId = userId;
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/repository/ChatSessionUserRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/repository/ChatSessionUserRepository.java
@@ -1,0 +1,16 @@
+package kr.flowmeet.domain.chat.repository;
+
+import kr.flowmeet.domain.chat.entity.ChatSessionUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatSessionUserRepository extends JpaRepository<ChatSessionUser, Long> {
+
+    boolean existsByChatSessionIdAndUserId(Long chatSessionId, Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ChatSessionUser u WHERE u.chatSessionId = :chatSessionId")
+    int deleteAllByChatSessionId(@Param("chatSessionId") Long chatSessionId);
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatSessionNodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatSessionNodeService.java
@@ -43,6 +43,19 @@ public class ChatSessionNodeService {
     }
 
     @Transactional
+    public void register(final Long chatSessionId, final Long nodeId) {
+        if (chatSessionNodeRepository.existsByChatSessionIdAndNodeId(chatSessionId, nodeId)) {
+            return;
+        }
+        chatSessionNodeRepository.save(
+                ChatSessionNode.builder()
+                        .chatSessionId(chatSessionId)
+                        .nodeId(nodeId)
+                        .build()
+        );
+    }
+
+    @Transactional
     public void remove(final Long chatSessionId, final Long nodeId) {
         ChatSessionNode chatSessionNode = chatSessionNodeRepository
                 .findByChatSessionIdAndNodeId(chatSessionId, nodeId)

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatSessionUserService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/chat/service/ChatSessionUserService.java
@@ -1,0 +1,33 @@
+package kr.flowmeet.domain.chat.service;
+
+import kr.flowmeet.domain.chat.entity.ChatSessionUser;
+import kr.flowmeet.domain.chat.repository.ChatSessionUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatSessionUserService {
+
+    private final ChatSessionUserRepository chatSessionUserRepository;
+
+    @Transactional
+    public void register(final Long chatSessionId, final Long userId) {
+        if (chatSessionUserRepository.existsByChatSessionIdAndUserId(chatSessionId, userId)) {
+            return;
+        }
+        chatSessionUserRepository.save(
+                ChatSessionUser.builder()
+                        .chatSessionId(chatSessionId)
+                        .userId(userId)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void deleteAllByChatSessionId(final Long chatSessionId) {
+        chatSessionUserRepository.deleteAllByChatSessionId(chatSessionId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #245

## 📝작업 내용

채팅 AI 참조 기능에서 노드 외에 프로젝트 멤버(사용자)도 참조할 수 있도록 사용자 참조 조회 API를 추가하고, 메시지 전송 시 노드/사용자를 @로 참조하여 AI에게 힌트로 전달하는 기능을 추가했습니다.

### 참조 가능한 사용자 조회

- `GET /v1/projects/{projectId}/chats/users` API 추가
- 프로젝트 멤버를 역할 순서(OWNER → MEMBER → VIEWER), 닉네임 순으로 정렬하여 반환
- 응답 필드: userId, nickname, profileImageUrl

### 노드 참조 응답 개선

- `GET /v1/projects/{projectId}/chats/nodes` 응답에 `number` 필드 추가 (예: `"1.1"`)

### 메시지 전송 시 노드/사용자 참조 처리

- `SendMessageRequest`에 `referenceNodeIds`, `referenceUserIds` 필드 추가
- 참조된 노드/사용자는 `chat_session_nodes` / `chat_session_users` 다대다 테이블에 저장 (중복 시 skip)
- AI 호출 시 참조 ID를 힌트 텍스트로 메시지에 포함하여 전달

## 변경 파일

| 파일 | 변경 |
|------|------|
| `V20__add_chat_session_users.sql` | 추가 — chat_session_users 테이블 |
| `chat/entity/ChatSessionUser.java` | 추가 |
| `chat/repository/ChatSessionUserRepository.java` | 추가 |
| `chat/service/ChatSessionUserService.java` | 추가 |
| `chat/service/ChatSessionNodeService.java` | 수정 — `register()` 추가 |
| `chat/dto/request/SendMessageRequest.java` | 수정 — 참조 ID 필드 추가 |
| `chat/dto/response/ReferencedNodeResponse.java` | 수정 — `number` 필드 추가 |
| `chat/dto/response/ReferencedUserResponse.java` | 추가 |
| `chat/dto/response/GetReferenceUsersResponse.java` | 추가 |
| `chat/success/ChatSuccessCode.java` | 수정 — `GET_REFERENCE_USERS` 추가 |
| `chat/controller/ChatApi.java` | 수정 — Swagger 문서화 |
| `chat/controller/ChatController.java` | 수정 — 엔드포인트 추가 |
| `chat/facade/ChatFacade.java` | 수정 — 참조 저장 및 AI 힌트 전달 로직 추가 |

## 💬리뷰 요구사항(선택)

## 💬논의 사항(선택)