### PR TITLE
[Feat/#248] SSE 알림 페이로드에 unreadCount 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/NotificationSsePayload.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/dto/response/NotificationSsePayload.java
@@ -10,10 +10,11 @@ public record NotificationSsePayload(
         String content,
         Long projectId,
         Long targetId,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        long unreadCount
 ) {
 
-    public static NotificationSsePayload from(final Notification notification) {
+    public static NotificationSsePayload from(final Notification notification, final long unreadCount) {
         return new NotificationSsePayload(
                 notification.getId(),
                 notification.getType().name(),
@@ -21,7 +22,8 @@ public record NotificationSsePayload(
                 notification.getContent(),
                 notification.getProjectId(),
                 notification.getTargetId(),
-                notification.getCreatedAt()
+                notification.getCreatedAt(),
+                unreadCount
         );
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/event/DefaultNotificationSender.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/event/DefaultNotificationSender.java
@@ -9,6 +9,7 @@ import kr.flowmeet.api.notification.dto.response.NotificationSsePayload;
 import kr.flowmeet.api.notification.sse.SseEmitterStore;
 import kr.flowmeet.domain.notification.entity.Notification;
 import kr.flowmeet.domain.notification.service.NotificationSender;
+import kr.flowmeet.domain.notification.service.NotificationService;
 
 @Slf4j
 @Component
@@ -16,15 +17,17 @@ import kr.flowmeet.domain.notification.service.NotificationSender;
 public class DefaultNotificationSender implements NotificationSender {
 
     private final SseEmitterStore sseEmitterStore;
+    private final NotificationService notificationService;
 
     @Override
     public void send(final Notification notification) {
         sseEmitterStore.findByUserId(notification.getUserId())
                 .ifPresent(emitter -> {
                     try {
+                        long unreadCount = notificationService.countUnread(notification.getUserId());
                         emitter.send(SseEmitter.event()
                                 .name("notification")
-                                .data(NotificationSsePayload.from(notification)));
+                                .data(NotificationSsePayload.from(notification, unreadCount)));
                     } catch (IOException e) {
                         sseEmitterStore.remove(notification.getUserId());
                         log.debug("[SSE] 전송 실패, 연결 제거: userId={}", notification.getUserId());


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #248

## 📝작업 내용

### SSE 알림 페이로드에 unreadCount 추가

- SSE `notification` 이벤트 수신 시 프론트가 별도 API 호출 없이 배지 카운트를 즉시 업데이트할 수 있도록 `unreadCount` 필드 추가
- 알림 전송 시점에 `countUnread` 조회 후 페이로드에 포함

## 변경 파일

| 파일 | 변경 |
|------|------|
| `api/notification/dto/response/NotificationSsePayload.java` | 수정 |
| `api/notification/event/DefaultNotificationSender.java` | 수정 |

## 💬논의 사항

SSE 연결이 끊겼다 재연결될 때는 그 사이 이벤트가 유실될 수 있습니다. 
프론트(@pkm021118) 에서 재연결 시 `GET /notifications/unread-count` 호출로 초기값 보정이 필요합니다. 참고부탁드립니다.
