### PR TITLE
[Feat/#259] 리다이렉팅용 초대 페이지 추가

### DIFF
--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -54,7 +54,13 @@ function CallbackContent() {
             // 가입된 유저
             if (data.data?.accessToken && data.data?.refreshToken) {
               login(data.data.accessToken, data.data.refreshToken);
-              router.replace('/projects');
+              const pendingRedirect = sessionStorage.getItem('pending_redirect');
+              if (pendingRedirect) {
+                sessionStorage.removeItem('pending_redirect');
+                router.replace(pendingRedirect);
+              } else {
+                router.replace('/projects');
+              }
             } else {
               showToast(data.message);
               router.replace('/auth/login');

--- a/frontend/src/app/invitations/[token]/page.tsx
+++ b/frontend/src/app/invitations/[token]/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Loading } from '@wanteddev/wds';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { authStorage } from '@/api/authStorage';
+import { toastStore } from '@/components/commons/custom-toast/toastStore';
+import { useErrorToast } from '@/hooks/useErrorToast';
+import { useAcceptInvitationMutation } from '@/queries/project';
+
+let toastCount = 0;
+
+function getProjectIdFromToken(token: string): number | null {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof payload.projectId === 'number' ? payload.projectId : null;
+  } catch {
+    return null;
+  }
+}
+
+export default function InvitationPage() {
+  const { token } = useParams<{ token: string }>();
+  const router = useRouter();
+  const hasProcessed = useRef(false);
+  const acceptMutation = useAcceptInvitationMutation();
+  const errorToast = useErrorToast();
+
+  useEffect(() => {
+    if (hasProcessed.current) return;
+    hasProcessed.current = true;
+
+    const isAuthenticated = !!authStorage.getAccess();
+
+    if (!isAuthenticated) {
+      sessionStorage.setItem('pending_redirect', `/invitations/${token}`);
+      router.replace('/auth/google');
+      return;
+    }
+
+    acceptMutation.mutate(token, {
+      onSuccess: (data) => {
+        const projectId = data.data?.projectId;
+        if (projectId) {
+          toastStore.add({
+            id: `invitation-${++toastCount}`,
+            content: '프로젝트에 합류했어요.',
+            variant: 'positive',
+            placement: 'top-center',
+          });
+          router.replace(`/projects/${projectId}`);
+        } else {
+          router.replace('/projects');
+        }
+      },
+      onError: (err) => {
+        const code = (err as { error?: { code?: string } }).error?.code;
+        if (code === 'MEMBER_ALREADY_EXISTS') {
+          const projectId = getProjectIdFromToken(token);
+          if (projectId) {
+            router.replace(`/projects/${projectId}`);
+            return;
+          }
+        }
+        errorToast(err, '초대 링크가 유효하지 않거나 만료됐어요.');
+        router.replace('/projects');
+      },
+    });
+  }, [token, router, acceptMutation, errorToast]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Loading />
+    </div>
+  );
+}

--- a/frontend/src/queries/meeting.ts
+++ b/frontend/src/queries/meeting.ts
@@ -13,8 +13,10 @@ export function useCreateMeetingMutation(projectId: number, nodeId: number) {
   return useMutation({
     mutationFn: (data: CreateMeetingRequest) =>
       privateApi.meeting.createMeeting(projectId, nodeId, data),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: meetingKeys.list(projectId, nodeId) }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: meetingKeys.list(projectId, nodeId) });
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 

--- a/frontend/src/queries/project.ts
+++ b/frontend/src/queries/project.ts
@@ -42,3 +42,10 @@ export function useLeaveProjectMutation(projectId: number) {
     mutationFn: () => privateApi.projectMember.leaveProject(projectId),
   });
 }
+
+export function useAcceptInvitationMutation() {
+  return useMutation({
+    mutationFn: (token: string) =>
+      privateApi.project.acceptInvitation({ token }).then((res) => res.data),
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #259 

## 📝작업 내용
프로젝트 초대 메일 링크 처리를 위한 /invitations/[token] 페이지를 구현했습니다.

### 동작 방식

로그인 유저: `/invitations/{token}` 접근 시 초대 수락 API 호출 → 해당 프로젝트 페이지로 이동
미로그인 유저: `sessionStorage`에 리다이렉트 URL 저장 → Google 로그인 → 로그인 완료 후 자동으로 초대 처리 → 프로젝트 이동
이미 합류한 멤버 (MEMBER_ALREADY_EXISTS 409): JWT 페이로드에서 projectId를 디코딩해 토스트 없이 해당 프로젝트로 바로 이동
그 외 에러: `useErrorToast`로 서버 메시지 표시 후 /projects로 이동

### 변경 파일

`src/app/invitations/[token]/page.tsx` (신규): 초대 링크 처리 페이지
`src/app/auth/callback/page.tsx:` 로그인 성공 후 pending_redirect 확인 로직 추가
`src/queries/project.ts`: useAcceptInvitationMutation 추가

