### PR TITLE
[Fix/263] AI Agent MCP 툴 호출 시 projectId 키/타입 불일치 수정

### DIFF
--- a/ai/agent/agent.py
+++ b/ai/agent/agent.py
@@ -91,7 +91,7 @@ class Agent:
 
                 all_args = {
                     **dict(fc.args),
-                    "project_id": self.project_id,
+                    "projectId": int(self.project_id),
                 }
 
                 print(f"[Agent] 툴 호출: {fc.name}({all_args})")

--- a/ai/agent/tools/tool_schema_v1.py
+++ b/ai/agent/tools/tool_schema_v1.py
@@ -11,7 +11,7 @@ tool_schema = [
                 "type": {"type": "string", "enum": ["MAIN", "SUB"], "description": "노드 유형. MAIN은 최상위 노드, SUB는 하위 노드"},
                 "parentId": {"type": "integer", "description": "상위 노드의 ID. 최상위 노드인 경우 생략"}
             },
-            "required": ["projectId", "title", "type"],
+            "required": ["title", "type"],
             "additionalProperties": False
         }
     },
@@ -24,7 +24,7 @@ tool_schema = [
                 "projectId": {"type": "integer", "description": "멤버를 초대할 프로젝트의 ID"},
                 "email": {"type": "string", "format": "email", "description": "초대할 사용자의 이메일 주소"}
             },
-            "required": ["projectId", "email"],
+            "required": ["email"],
             "additionalProperties": False
         }
     },
@@ -37,7 +37,7 @@ tool_schema = [
                 "projectId": {"type": "integer", "description": "멤버를 삭제할 프로젝트의 ID"},
                 "memberId": {"type": "integer", "description": "삭제할 멤버의 ID"}
             },
-            "required": ["projectId", "memberId"],
+            "required": ["memberId"],
             "additionalProperties": False
         }
     },
@@ -51,7 +51,7 @@ tool_schema = [
                 "nodeId": {"type": "integer", "description": "수정할 노드의 ID"},
                 "title": {"type": "string", "description": "변경할 노드 제목"},
             },
-            "required": ["projectId", "nodeId", "title"],
+            "required": ["nodeId", "title"],
             "additionalProperties": False
         }
     },
@@ -65,7 +65,7 @@ tool_schema = [
                 "nodeId": {"type": "integer", "description": "수정할 노드의 ID"},
                 "description": {"type": "string", "description": "변경할 노드 설명(마크다운 형식 지원)"},
             },
-            "required": ["projectId", "nodeId", "description"],
+            "required": ["nodeId", "description"],
             "additionalProperties": False
         }
     },
@@ -79,7 +79,7 @@ tool_schema = [
                 "nodeId": {"type": "integer", "description": "수정할 노드의 ID"},
                 "status": {"type": "string", "enum": ["WAITING", "IN_PROGRESS", "DONE"], "description": "변경할 노드 진행 상태"}
             },
-            "required": ["projectId", "nodeId", "status"],
+            "required": ["nodeId", "status"],
             "additionalProperties": False
         }
     },
@@ -93,7 +93,7 @@ tool_schema = [
                 "nodeId": {"type": "integer", "description": "담당자를 추가할 노드의 ID"},
                 "userId": {"type": "integer", "description": "담당자로 지정할 사용자의 ID"}
             },
-            "required": ["projectId", "nodeId", "userId"],
+            "required": ["nodeId", "userId"],
             "additionalProperties": False
         }
     },
@@ -106,7 +106,7 @@ tool_schema = [
                 "projectId": {"type": "integer", "description": "조회할 노드가 속한 프로젝트의 ID"},
                 "nodeId": {"type": "integer", "description": "조회할 노드의 ID"}
             },
-            "required": ["projectId", "nodeId"],
+            "required": ["nodeId"],
             "additionalProperties": False
         }
     },
@@ -122,7 +122,7 @@ tool_schema = [
                 "participantUserIds": {"type": "array", "items": {"type": "integer"}, "description": "참여자 사용자 ID 목록 (1명 이상 필수)", "minItems": 1},
                 "isPushEnabled": {"type": "boolean", "description": "회의 시작 전 푸시 알림 사용 여부"}
             },
-            "required": ["projectId", "nodeId", "startedAt", "participantUserIds", "isPushEnabled"],
+            "required": ["nodeId", "startedAt", "participantUserIds", "isPushEnabled"],
             "additionalProperties": False
         }
     },
@@ -137,7 +137,7 @@ tool_schema = [
                 "endNodeId": {"type": "integer", "description": "연결선의 종료 노드 ID"},
                 "comment": {"type": "string", "description": "연결선에 대한 설명 (예: 로그인 성공 시 대시보드로 이동)"}
             },
-            "required": ["projectId", "startNodeId", "endNodeId"],
+            "required": ["startNodeId", "endNodeId"],
             "additionalProperties": False
         }
     },
@@ -150,7 +150,7 @@ tool_schema = [
                 "projectId": {"type": "integer", "description": "연결선이 속한 프로젝트의 ID"},
                 "edgeId": {"type": "integer", "description": "삭제할 연결선의 ID"}
             },
-            "required": ["projectId", "edgeId"],
+            "required": ["edgeId"],
             "additionalProperties": False
         }
     }

--- a/ai/agent/tools/tool_schema_v2.py
+++ b/ai/agent/tools/tool_schema_v2.py
@@ -7,7 +7,7 @@ tool_schema = [
             "properties": {
                 "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
             },
-            "required": ["projectId"],
+            "required": [],
             "additionalProperties": False
         }
     },
@@ -19,7 +19,7 @@ tool_schema = [
             "properties": {
                 "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
             },
-            "required": ["projectId"],
+            "required": [],
             "additionalProperties": False
         }
     },
@@ -31,7 +31,7 @@ tool_schema = [
             "properties": {
                 "projectId": {"type": "integer", "description": "조회할 프로젝트의 ID"}
             },
-            "required": ["projectId"],
+            "required": [],
             "additionalProperties": False
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #263

## 📝작업 내용

### AI Agent MCP 툴 호출 projectId 불일치 수정

- `agent.py` MCP 툴 호출 시 `project_id`(snake_case, string) → `projectId`(camelCase, int)로 수정
- 기존 코드는 MCP 툴 스키마가 기대하는 `projectId`와 키 불일치로 모든 노드 조회/수정 툴이 실패하는 버그

## 변경 파일

| 파일 | 변경 |
|------|------|
| `ai/agent/agent.py` | 수정 |

## 💬리뷰 요구사항(선택)

MCP 툴 스키마에서 `projectId`가 `required`로 정의되어 있어 Gemini가 유저에게 프로젝트 ID를 묻는 현상이 남아있을 수 있습니다.
