### PR TITLE
[Feat/#270] 점선 삭제 알러트 및 플로우차트 참조 점선 인터랙션 개선, 알림 UX 개선

### DIFF
--- a/frontend/src/app/projects/[projectId]/(project)/layout.tsx
+++ b/frontend/src/app/projects/[projectId]/(project)/layout.tsx
@@ -1,15 +1,16 @@
 'use client';
 
+import { useParams } from 'next/navigation';
 import { useState, useEffect, useMemo } from 'react';
 import { ChatWidget } from '@/components/chat/ChatWidget';
 import { ProjectDetailHeader } from '@/components/projects/project-detail/ProjectDetailHeader';
 import { ProjectDetailLinks } from '@/components/projects/project-detail/ProjectDetailLinks';
-import { EXAMPLE_USERS } from '@/constants/exampleConstant';
 import {
   ProjectDetailLayoutContext,
   VALID_VIEWS,
   ProjectViewTypes,
 } from '@/contexts/ProjectDetailLayoutContext';
+import { ProjectPresenceProvider, useAwarenessUsers } from '@/contexts/YjsContext';
 
 const STORAGE_KEY = 'project-active-view';
 
@@ -17,7 +18,30 @@ interface ProjectDetailLayoutProps {
   children: React.ReactNode;
 }
 
+// ProjectPresenceProvider 내부에서 awareness 유저를 읽어 헤더에 전달
+function HeaderWithPresence({
+  activeView,
+  onViewChange,
+}: {
+  activeView: ProjectViewTypes;
+  onViewChange: (view: ProjectViewTypes) => void;
+}) {
+  const onlineUsers = useAwarenessUsers();
+  return (
+    <ProjectDetailHeader
+      activeView={activeView}
+      onlineUsers={onlineUsers}
+      onViewChange={onViewChange}
+    />
+  );
+}
+
 export default function ProjectDetailLayout({ children }: ProjectDetailLayoutProps) {
+  const params = useParams<{ projectId?: string }>();
+  const projectIdRaw = params?.projectId;
+  const projectId = projectIdRaw ? Number(projectIdRaw) : NaN;
+  const isProjectIdValid = !Number.isNaN(projectId);
+
   const [mounted, setMounted] = useState(false);
   const [activeView, setActiveView] = useState<ProjectViewTypes>(() => {
     if (typeof window === 'undefined') return 'node-flow';
@@ -45,18 +69,20 @@ export default function ProjectDetailLayout({ children }: ProjectDetailLayoutPro
     return null;
   }
 
-  return (
+  const inner = (
     <ProjectDetailLayoutContext.Provider value={contextValue}>
       <div className="flex h-full w-full flex-1 flex-col overflow-hidden" suppressHydrationWarning>
-        <ProjectDetailHeader
-          activeView={activeView}
-          onlineUsers={EXAMPLE_USERS}
-          onViewChange={setActiveView}
-        />
+        <HeaderWithPresence activeView={activeView} onViewChange={setActiveView} />
         <ProjectDetailLinks />
         {children}
         <ChatWidget />
       </div>
     </ProjectDetailLayoutContext.Provider>
   );
+
+  if (!isProjectIdValid) {
+    return inner;
+  }
+
+  return <ProjectPresenceProvider projectId={projectId}>{inner}</ProjectPresenceProvider>;
 }

--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import {
   IconBell,
   IconChevronDoubleLeft,
@@ -8,7 +9,6 @@ import {
   IconSearch,
   IconSetting,
 } from '@wanteddev/wds-icon';
-import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -88,15 +88,19 @@ export const ProjectSidebar = ({
   const [hasNewSseNotification, setHasNewSseNotification] = useState(false);
 
   useEffect(() => {
+    if (!isProjectIdValid || projectId === undefined) return;
+
     const token = authStorage.getAccess();
     if (!token) return;
 
-    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+    const baseUrl = (process.env.NEXT_PUBLIC_API_BASE_URL ?? '').replace(/\/$/, '');
     const controller = new AbortController();
+    const subscribeUrl = new URL(`${baseUrl}/v1/notifications/subscribe`, window.location.origin);
+    subscribeUrl.searchParams.set('projectId', String(projectId));
 
     const connect = async () => {
       try {
-        const response = await fetch(`${baseUrl}/v1/notifications/subscribe`, {
+        const response = await fetch(subscribeUrl, {
           headers: { Authorization: `Bearer ${token}` },
           signal: controller.signal,
         });
@@ -136,7 +140,7 @@ export const ProjectSidebar = ({
 
     void connect();
     return () => { controller.abort(); };
-  }, []);
+  }, [isProjectIdValid, projectId]);
 
   // prop > query > storage > 빈 문자열 우선순위로 합성
   const projectName = projectNameProp ?? projectData?.name ?? '';
@@ -361,8 +365,9 @@ export const ProjectSidebar = ({
         </div>
       </motion.aside>
       <AnimatePresence>
-        {isAlarmModalOpen && !isCollapsed && (
+        {isAlarmModalOpen && !isCollapsed && isProjectIdValid && projectId !== undefined && (
           <SidebarAlarmModal
+            projectId={projectId}
             onClose={() => setIsAlarmModalOpen(false)}
             onNotificationClick={handleNotificationClick}
             onListLoaded={(unreadInList) => {

--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -8,6 +8,7 @@ import {
   IconSearch,
   IconSetting,
 } from '@wanteddev/wds-icon';
+import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -15,6 +16,7 @@ import { useEffect, useRef, useState } from 'react';
 import { authStorage } from '@/api/authStorage';
 import { userStorage } from '@/api/userStorage';
 import { useModal } from '@/components/commons/modal/ModalContext';
+import { notificationKeys } from '@/queries/keys/notificationKeys';
 import { useUnreadCountQuery } from '@/queries/notification';
 import { useProjectQuery } from '@/queries/project';
 import { useCurrentUserQuery } from '@/queries/user';
@@ -64,6 +66,7 @@ export const ProjectSidebar = ({
   const projectId = projectIdRaw ? Number(projectIdRaw) : undefined;
   const isProjectIdValid = projectId !== undefined && !Number.isNaN(projectId);
   const { openModal, closeModal } = useModal();
+  const queryClient = useQueryClient();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isCollapsedInternal, setIsCollapsedInternal] = useState(false);
   const [isAlarmModalOpen, setIsAlarmModalOpen] = useState(false);
@@ -103,7 +106,7 @@ export const ProjectSidebar = ({
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = '';
-        let isFirstDataEvent = true;
+        let currentEventType: string | null = null;
 
         while (true) {
           const { done, value } = await reader.read();
@@ -112,14 +115,17 @@ export const ProjectSidebar = ({
           const lines = buffer.split('\n');
           buffer = lines.pop() ?? '';
           for (const line of lines) {
-            if (line.startsWith('data:')) {
-              // 첫 번째 data 이벤트는 연결 확인(connected) 메시지이므로 무시
-              if (isFirstDataEvent) {
-                isFirstDataEvent = false;
-                continue;
+            if (line.startsWith('event:')) {
+              currentEventType = line.slice('event:'.length).trim();
+            } else if (line.startsWith('data:')) {
+              // 'notification' 이벤트만 카운트 (connected, heartbeat 등은 무시)
+              if (currentEventType === 'notification') {
+                setSseExtra((prev) => prev + 1);
+                setHasNewSseNotification(true);
               }
-              setSseExtra((prev) => prev + 1);
-              setHasNewSseNotification(true);
+            } else if (line === '') {
+              // 빈 줄은 메시지 구분자 — event 타입 초기화
+              currentEventType = null;
             }
           }
         }
@@ -359,6 +365,11 @@ export const ProjectSidebar = ({
           <SidebarAlarmModal
             onClose={() => setIsAlarmModalOpen(false)}
             onNotificationClick={handleNotificationClick}
+            onListLoaded={(unreadInList) => {
+              // 알림 리스트 기반 실제 unread 개수로 캐시 동기화 + SSE 누적값 초기화
+              queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
+              setSseExtra(0);
+            }}
           />
         )}
       </AnimatePresence>

--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -9,7 +9,7 @@ import {
   IconSetting,
 } from '@wanteddev/wds-icon';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useParams, usePathname } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 import { authStorage } from '@/api/authStorage';
@@ -58,6 +58,7 @@ export const ProjectSidebar = ({
   onProfileClick,
 }: ProjectSidebarProps) => {
   const pathname = usePathname();
+  const router = useRouter();
   const params = useParams<{ projectId?: string }>();
   const projectIdRaw = params?.projectId;
   const projectId = projectIdRaw ? Number(projectIdRaw) : undefined;
@@ -80,6 +81,8 @@ export const ProjectSidebar = ({
   const { data: initialUnreadCount = 0 } = useUnreadCountQuery();
   const [sseExtra, setSseExtra] = useState(0);
   const unreadCount = initialUnreadCount + sseExtra;
+  // SSE로 새로 수신한 알림 여부 (알림창 열면 초기화)
+  const [hasNewSseNotification, setHasNewSseNotification] = useState(false);
 
   useEffect(() => {
     const token = authStorage.getAccess();
@@ -100,6 +103,7 @@ export const ProjectSidebar = ({
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = '';
+        let isFirstDataEvent = true;
 
         while (true) {
           const { done, value } = await reader.read();
@@ -109,7 +113,13 @@ export const ProjectSidebar = ({
           buffer = lines.pop() ?? '';
           for (const line of lines) {
             if (line.startsWith('data:')) {
+              // 첫 번째 data 이벤트는 연결 확인(connected) 메시지이므로 무시
+              if (isFirstDataEvent) {
+                isFirstDataEvent = false;
+                continue;
+              }
               setSseExtra((prev) => prev + 1);
+              setHasNewSseNotification(true);
             }
           }
         }
@@ -165,7 +175,11 @@ export const ProjectSidebar = ({
   };
 
   const handleAlarmModalToggle = () => {
-    setIsAlarmModalOpen((prev) => !prev);
+    setIsAlarmModalOpen((prev) => {
+      const nextOpen = !prev;
+      if (nextOpen) setHasNewSseNotification(false);
+      return nextOpen;
+    });
     onInboxClick?.();
   };
 
@@ -191,6 +205,15 @@ export const ProjectSidebar = ({
       closeOnEsc: true,
       content: <SettingsModalContent projectId={projectId} onClose={closeModal} />,
     });
+  };
+
+  const handleNotificationClick = (notification: import('@/api/Api').NotificationSummaryResponse) => {
+    // 알림창 닫기
+    setIsAlarmModalOpen(false);
+    const targetId = notification.targetId;
+    const notifProjectId = notification.projectId;
+    if (!targetId || !notifProjectId) return;
+    router.push(`/projects/${notifProjectId}?openNode=${targetId}`);
   };
 
   const handleProfileClick = () => {
@@ -304,6 +327,7 @@ export const ProjectSidebar = ({
                   label="수신함"
                   labelWidth={64}
                   badgeText={badgeText}
+                  showDot={hasNewSseNotification}
                   labelTransitionDuration={SIDEBAR_LABEL_TRANSITION_DURATION}
                   onClick={handleAlarmModalToggle}
                 />
@@ -332,7 +356,10 @@ export const ProjectSidebar = ({
       </motion.aside>
       <AnimatePresence>
         {isAlarmModalOpen && !isCollapsed && (
-          <SidebarAlarmModal onClose={() => setIsAlarmModalOpen(false)} />
+          <SidebarAlarmModal
+            onClose={() => setIsAlarmModalOpen(false)}
+            onNotificationClick={handleNotificationClick}
+          />
         )}
       </AnimatePresence>
     </div>

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -11,6 +11,7 @@ import { useErrorToast } from '@/hooks/useErrorToast';
 import { SidebarAlarmModalItem } from './SidebarAlarmModalItem';
 
 interface SidebarAlarmModalProps {
+  projectId: number;
   onClose: () => void;
   onNotificationClick?: (notification: NotificationSummaryResponse) => void;
   /** 리스트 로드 완료 시 실제 unread 개수 동기화용 콜백 */
@@ -78,6 +79,7 @@ const formatNotificationTime = (createdAt?: string) => {
 };
 
 export const SidebarAlarmModal = ({
+  projectId,
   onClose,
   onNotificationClick,
   onListLoaded,
@@ -92,7 +94,9 @@ export const SidebarAlarmModal = ({
       try {
         const response = await privateApi.notification.getAllNotifications();
         if (cancelled) return;
-        const items = response.data.data?.content ?? [];
+        const items = (response.data.data?.content ?? []).filter(
+          (notification) => notification.projectId === projectId,
+        );
         setNotifications(items);
         // 실제 리스트 기준 unread 개수를 부모로 전달해 뱃지 동기화
         const unreadInList = items.filter((n) => n.isRead === false).length;
@@ -106,7 +110,7 @@ export const SidebarAlarmModal = ({
     return () => {
       cancelled = true;
     };
-  }, [showErrorToast, onListLoaded]);
+  }, [projectId, showErrorToast, onListLoaded]);
 
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     setHasScrolled(event.currentTarget.scrollTop > 0);

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -12,6 +12,7 @@ import { SidebarAlarmModalItem } from './SidebarAlarmModalItem';
 
 interface SidebarAlarmModalProps {
   onClose: () => void;
+  onNotificationClick?: (notification: NotificationSummaryResponse) => void;
 }
 
 const sidebarVariants = {
@@ -74,7 +75,7 @@ const formatNotificationTime = (createdAt?: string) => {
   return createdAt.slice(0, 10);
 };
 
-export const SidebarAlarmModal = ({ onClose }: SidebarAlarmModalProps) => {
+export const SidebarAlarmModal = ({ onClose, onNotificationClick }: SidebarAlarmModalProps) => {
   const showErrorToast = useErrorToast();
   const [hasScrolled, setHasScrolled] = useState(false);
   const [notifications, setNotifications] = useState<NotificationSummaryResponse[]>([]);
@@ -157,6 +158,7 @@ export const SidebarAlarmModal = ({ onClose }: SidebarAlarmModalProps) => {
                         description={description}
                         timeText={formatNotificationTime(item.createdAt)}
                         isUnread={item.isRead === false}
+                        onClick={() => onNotificationClick?.(item)}
                       />
                     );
                   })}

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -13,6 +13,8 @@ import { SidebarAlarmModalItem } from './SidebarAlarmModalItem';
 interface SidebarAlarmModalProps {
   onClose: () => void;
   onNotificationClick?: (notification: NotificationSummaryResponse) => void;
+  /** 리스트 로드 완료 시 실제 unread 개수 동기화용 콜백 */
+  onListLoaded?: (unreadCount: number) => void;
 }
 
 const sidebarVariants = {
@@ -75,7 +77,11 @@ const formatNotificationTime = (createdAt?: string) => {
   return createdAt.slice(0, 10);
 };
 
-export const SidebarAlarmModal = ({ onClose, onNotificationClick }: SidebarAlarmModalProps) => {
+export const SidebarAlarmModal = ({
+  onClose,
+  onNotificationClick,
+  onListLoaded,
+}: SidebarAlarmModalProps) => {
   const showErrorToast = useErrorToast();
   const [hasScrolled, setHasScrolled] = useState(false);
   const [notifications, setNotifications] = useState<NotificationSummaryResponse[]>([]);
@@ -86,7 +92,11 @@ export const SidebarAlarmModal = ({ onClose, onNotificationClick }: SidebarAlarm
       try {
         const response = await privateApi.notification.getAllNotifications();
         if (cancelled) return;
-        setNotifications(response.data.data?.content ?? []);
+        const items = response.data.data?.content ?? [];
+        setNotifications(items);
+        // 실제 리스트 기준 unread 개수를 부모로 전달해 뱃지 동기화
+        const unreadInList = items.filter((n) => n.isRead === false).length;
+        onListLoaded?.(unreadInList);
       } catch (caught) {
         if (cancelled) return;
         showErrorToast(caught, '알림 목록을 불러오지 못했어요.');
@@ -96,7 +106,7 @@ export const SidebarAlarmModal = ({ onClose, onNotificationClick }: SidebarAlarm
     return () => {
       cancelled = true;
     };
-  }, [showErrorToast]);
+  }, [showErrorToast, onListLoaded]);
 
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     setHasScrolled(event.currentTarget.scrollTop > 0);
@@ -158,7 +168,27 @@ export const SidebarAlarmModal = ({ onClose, onNotificationClick }: SidebarAlarm
                         description={description}
                         timeText={formatNotificationTime(item.createdAt)}
                         isUnread={item.isRead === false}
-                        onClick={() => onNotificationClick?.(item)}
+                        onClick={() => {
+                          // 클릭한 알림을 로컬에서 즉시 읽음 처리 (dot 즉시 사라짐)
+                          if (item.notificationId !== undefined && item.isRead === false) {
+                            setNotifications((prev) => {
+                              const next = prev.map((n) =>
+                                n.notificationId === item.notificationId
+                                  ? { ...n, isRead: true }
+                                  : n,
+                              );
+                              // 뱃지 카운트 즉시 동기화
+                              const unreadInList = next.filter((n) => n.isRead === false).length;
+                              onListLoaded?.(unreadInList);
+                              return next;
+                            });
+                            // 백엔드 동기화 (실패해도 UI는 그대로 유지)
+                            void privateApi.notification
+                              .markAsRead(item.notificationId)
+                              .catch(() => undefined);
+                          }
+                          onNotificationClick?.(item);
+                        }}
                       />
                     );
                   })}

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModalItem.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModalItem.tsx
@@ -5,6 +5,7 @@ interface SidebarAlarmModalItemProps {
   description: string;
   timeText: string;
   isUnread?: boolean;
+  onClick?: () => void;
 }
 
 export const SidebarAlarmModalItem = ({
@@ -12,10 +13,12 @@ export const SidebarAlarmModalItem = ({
   description,
   timeText,
   isUnread = false,
+  onClick,
 }: SidebarAlarmModalItemProps) => {
   return (
     <button
       type="button"
+      onClick={onClick}
       className="bg-static-white hover:bg-background-normal-alternative flex w-full flex-col gap-2 rounded-md px-2 py-3 text-left"
     >
       <div className="flex items-start justify-between gap-2">

--- a/frontend/src/components/commons/project-sidebar/SidebarMenuButton.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarMenuButton.tsx
@@ -10,6 +10,7 @@ interface SidebarMenuButtonProps {
   labelWidth: number;
   labelTransitionDuration: number;
   badgeText?: string;
+  showDot?: boolean;
   onClick?: () => void;
 }
 
@@ -20,6 +21,7 @@ export const SidebarMenuButton = ({
   labelWidth,
   labelTransitionDuration,
   badgeText,
+  showDot,
   onClick,
 }: SidebarMenuButtonProps) => {
   return (
@@ -32,7 +34,7 @@ export const SidebarMenuButton = ({
       )}
     >
       <span className={cn('flex items-center gap-1.5 text-label-alternative', isCollapsed && 'gap-0')}>
-        <Icon className="h-4 w-4" aria-hidden="true" />
+        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
         <motion.span
           initial={false}
           animate={{ maxWidth: isCollapsed ? 0 : labelWidth, opacity: isCollapsed ? 0 : 1 }}
@@ -42,10 +44,23 @@ export const SidebarMenuButton = ({
           {label}
         </motion.span>
       </span>
-      {!isCollapsed && badgeText && (
-        <span className="ml-auto rounded-sm bg-fill-normal px-1 py-0.5 text-caption-1 font-normal text-label-alternative">
-          {badgeText}
-        </span>
+      {!isCollapsed && (badgeText || showDot) && (
+        <div className="relative ml-auto flex shrink-0 items-center">
+          {badgeText && (
+            <span className="rounded-sm bg-fill-normal px-1 py-0.5 text-caption-1 font-normal text-label-alternative">
+              {badgeText}
+            </span>
+          )}
+          {showDot && (
+            <span
+              className={cn(
+                'bg-primary-40 h-2 w-2 rounded-full',
+                badgeText ? 'absolute -top-1 -right-1' : 'block',
+              )}
+              aria-hidden="true"
+            />
+          )}
+        </div>
       )}
     </button>
   );

--- a/frontend/src/components/commons/project-sidebar/setting-modal/MemberDeleteConfirmContent.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MemberDeleteConfirmContent.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface MemberDeleteConfirmContentProps {
+  /** 삭제 대상 멤버의 닉네임 또는 이메일. 다이얼로그 본문에 표시된다. */
+  memberName: string;
+  /** 삭제 확인 버튼을 눌렀을 때 호출. */
+  onConfirm: () => void;
+  /** 닫기·취소 시 호출. */
+  onClose: () => void;
+}
+
+/**
+ * 구성원 삭제 컨펌 다이얼로그 콘텐츠.
+ *
+ * - 실제 `deleteMe` 호출은 부모(`MembersSettingsPanel`)에서 onConfirm으로 처리.
+ */
+export const MemberDeleteConfirmContent = ({
+  memberName,
+  onConfirm,
+  onClose,
+}: MemberDeleteConfirmContentProps) => (
+  <div className="flex w-90 flex-col gap-4 pb-2">
+    <h3 className="text-headline-1 text-label-normal font-semibold">구성원을 삭제하시겠어요?</h3>
+    <p className="text-body-2 text-label-alternative whitespace-pre-line">
+      <span className="text-label-normal font-medium">{memberName}</span>
+      {' '}님을 프로젝트에서 내보내면 다시 초대하기 전까지 접근할 수 없어요.
+    </p>
+    <div className="flex items-center justify-end gap-6 pt-2">
+      <button
+        type="button"
+        onClick={onClose}
+        className="text-body-1 text-label-alternative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
+      >
+        취소
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        className={cn(
+          'text-body-1 rounded-md px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
+          'focus-visible:ring-primary-40',
+          'text-status-negative hover:bg-fill-normal active:bg-fill-strong bg-transparent',
+        )}
+      >
+        삭제
+      </button>
+    </div>
+  </div>
+);
+
+MemberDeleteConfirmContent.displayName = 'MemberDeleteConfirmContent';

--- a/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
@@ -17,6 +17,7 @@ import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
 import { CustomMenuItem } from '@/components/commons/custom-menu/CustomMemuItem';
 import { usePositionedToast } from '@/components/commons/custom-toast/usePositionedToast';
 import { useErrorToast } from '@/hooks/useErrorToast';
+import { normalizeImageUrl } from '@/utils/normalizeImageUrl';
 import {
   useDeleteMemberMutation,
   useInviteMemberMutation,
@@ -244,7 +245,7 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
                   <Avatar
                     variant="person"
                     size="small"
-                    src={member.profileImageUrl}
+                    src={normalizeImageUrl(member.profileImageUrl)}
                     alt={member.nickname || member.email}
                   />
                   <div className="flex min-w-0 flex-col">

--- a/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/queries/member';
 import { cn } from '@/utils/cn';
 
-import { ProjectDeleteConfirmContent } from './ProjectDeleteConfirmContent';
+import { MemberDeleteConfirmContent } from './MemberDeleteConfirmContent';
 import type { ProjectMemberRole } from './SettingsModalContent';
 import { useMemberInviteForm } from './useMemberInviteForm';
 
@@ -139,8 +139,8 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
       closeOnBackdrop: true,
       closeOnEsc: true,
       content: (
-        <ProjectDeleteConfirmContent
-          projectName={member.nickname || member.email}
+        <MemberDeleteConfirmContent
+          memberName={member.nickname || member.email}
           onConfirm={async () => {
             try {
               await deleteMemberMutation.mutateAsync(member.memberId);

--- a/frontend/src/components/commons/user/UserAvatarGroup.tsx
+++ b/frontend/src/components/commons/user/UserAvatarGroup.tsx
@@ -1,12 +1,20 @@
 import {
   Avatar,
   AvatarGroup,
+  type Theme,
   Tooltip,
   TooltipContent,
   TooltipGroup,
   TooltipTrigger,
   Typography,
 } from '@wanteddev/wds';
+
+import { normalizeImageUrl } from '@/utils/normalizeImageUrl';
+
+const IMAGE_AVATAR_SX = (theme: Theme) => ({
+  backgroundColor: theme.semantic.background.normal.normal,
+  padding: '1px',
+});
 
 export interface UserInfo {
   userId?: number;
@@ -26,11 +34,13 @@ interface UsersProps {
 interface UserAvatarWithTooltipProps {
   user: UserInfo;
   position: 'bottom-center' | 'bottom-end';
+  size: 'xsmall' | 'small';
 }
 
-const UserAvatarWithTooltip = ({ user, position }: UserAvatarWithTooltipProps) => {
+const UserAvatarWithTooltip = ({ user, position, size }: UserAvatarWithTooltipProps) => {
+  const profileImageUrl = normalizeImageUrl(user.profileImageUrl ?? undefined);
   const borderStyle =
-    !user.profileImageUrl && user.color
+    !profileImageUrl && user.color
       ? { outline: `2.5px solid ${user.color}`, borderRadius: '50%' }
       : undefined;
 
@@ -38,13 +48,23 @@ const UserAvatarWithTooltip = ({ user, position }: UserAvatarWithTooltipProps) =
     <Tooltip>
       <TooltipTrigger>
         <div style={borderStyle}>
-          <Avatar variant="person" size="xsmall" src={user.profileImageUrl ?? undefined} />
+          <Avatar
+            variant="person"
+            size={size}
+            src={profileImageUrl}
+            sx={profileImageUrl ? IMAGE_AVATAR_SX : undefined}
+          />
         </div>
       </TooltipTrigger>
 
       <TooltipContent size="small" position={position}>
         <div className="flex min-w-35 items-center gap-2 px-1 py-1.5">
-          <Avatar variant="person" size="xsmall" />
+          <Avatar
+            variant="person"
+            size="xsmall"
+            src={profileImageUrl}
+            sx={profileImageUrl ? IMAGE_AVATAR_SX : undefined}
+          />
           <div className="flex flex-col">
             <span className="text-caption-1 font-medium text-neutral-100">
               {user.nickname ?? ''}
@@ -87,19 +107,28 @@ const AllUsersTooltip = ({ users, maxVisible = 5, compact = false }: AllUsersToo
 
       <TooltipContent size="small" position="bottom-end">
         <div className="flex min-w-40 flex-col gap-2 px-1 py-1.5">
-          {users.map((user, idx) => (
-            <div key={user.email ?? idx} className="flex items-center gap-2">
-              <Avatar variant="person" size="xsmall" />
-              <div className="flex flex-col">
-                <span className="text-caption-1 font-medium text-neutral-100">
-                  {user.nickname ?? ''}
-                </span>
-                <span className="text-caption-2 font-normal text-neutral-100">
-                  {user.email ?? ''}
-                </span>
+          {users.map((user, idx) => {
+            const profileImageUrl = normalizeImageUrl(user.profileImageUrl ?? undefined);
+
+            return (
+              <div key={user.email ?? idx} className="flex items-center gap-2">
+                <Avatar
+                  variant="person"
+                  size="xsmall"
+                  src={profileImageUrl}
+                  sx={profileImageUrl ? IMAGE_AVATAR_SX : undefined}
+                />
+                <div className="flex flex-col">
+                  <span className="text-caption-1 font-medium text-neutral-100">
+                    {user.nickname ?? ''}
+                  </span>
+                  <span className="text-caption-2 font-normal text-neutral-100">
+                    {user.email ?? ''}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </TooltipContent>
     </Tooltip>
@@ -123,6 +152,7 @@ export const Users = ({ users, maxVisible = 5, compact = false, size = 'small' }
           <div key={`${user.userId}-${index}`} className={index === 0 ? '' : '-ml-1'}>
             <UserAvatarWithTooltip
               user={user}
+              size={size}
               position={index === visibleUsers.length - 1 ? 'bottom-end' : 'bottom-center'}
             />
           </div>

--- a/frontend/src/components/projects/node-flow/DashedComment.tsx
+++ b/frontend/src/components/projects/node-flow/DashedComment.tsx
@@ -1,12 +1,13 @@
 import { Avatar } from '@wanteddev/wds';
+import { IconTrash } from '@wanteddev/wds-icon';
 import { useState, useRef, useEffect } from 'react';
 
 import { EXAMPLE_PROJECT_SIDEBAR_PROFILE } from '@/constants/exampleConstant';
 import type { Edge } from '@/types/FlowChartTypes';
 
 type DashedCommentProps =
-  | { isCreateMode: true; edge?: never; onCommentCreate?: (comment: string) => void }
-  | { isCreateMode?: false; edge: Edge; onCommentCreate?: never };
+  | { isCreateMode: true; edge?: never; onCommentCreate?: (comment: string) => void; onDeleteEdge?: never }
+  | { isCreateMode?: false; edge: Edge; onCommentCreate?: never; onDeleteEdge?: () => void };
 
 interface CommentDisplayProps {
   avatarSrc?: string;
@@ -35,6 +36,7 @@ function CommentDisplay({ avatarSrc, nickname, timeText, comment }: CommentDispl
 
 export function DashedComment(props: DashedCommentProps) {
   const { isCreateMode, onCommentCreate } = props;
+  const onDeleteEdge = 'onDeleteEdge' in props ? props.onDeleteEdge : undefined;
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [savedComment, setSavedComment] = useState<string | null>(null);
@@ -119,15 +121,30 @@ export function DashedComment(props: DashedCommentProps) {
     );
   }
 
-  // Default 상태 (코멘트가 있는 경우)
+  // Default 상태 (저장된 엣지 코멘트)
   const { edge } = props;
 
   return (
-    <CommentDisplay
-      avatarSrc={edge.createdBy.profileImageUrl}
-      nickname={edge.createdBy.nickname}
-      timeText="2일 전"
-      comment={edge.comment}
-    />
+    <div className="group relative">
+      <CommentDisplay
+        avatarSrc={edge.createdBy.profileImageUrl}
+        nickname={edge.createdBy.nickname}
+        timeText="2일 전"
+        comment={edge.comment}
+      />
+      {onDeleteEdge && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteEdge();
+          }}
+          aria-label="참조 연결 삭제"
+          className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:bg-status-negative/10"
+        >
+          <IconTrash className="text-status-negative h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/projects/node-flow/DashedComment.tsx
+++ b/frontend/src/components/projects/node-flow/DashedComment.tsx
@@ -1,13 +1,14 @@
+'use client';
+
 import { Avatar } from '@wanteddev/wds';
-import { IconTrash } from '@wanteddev/wds-icon';
 import { useState, useRef, useEffect } from 'react';
 
 import { EXAMPLE_PROJECT_SIDEBAR_PROFILE } from '@/constants/exampleConstant';
 import type { Edge } from '@/types/FlowChartTypes';
 
 type DashedCommentProps =
-  | { isCreateMode: true; edge?: never; onCommentCreate?: (comment: string) => void; onDeleteEdge?: never }
-  | { isCreateMode?: false; edge: Edge; onCommentCreate?: never; onDeleteEdge?: () => void };
+  | { isCreateMode: true; edge?: never; onCommentCreate?: (comment: string) => void }
+  | { isCreateMode?: false; edge: Edge; onCommentCreate?: never };
 
 interface CommentDisplayProps {
   avatarSrc?: string;
@@ -16,7 +17,6 @@ interface CommentDisplayProps {
   comment: string | null;
 }
 
-// 공통 코멘트 컴포넌트 (default 상태)
 function CommentDisplay({ avatarSrc, nickname, timeText, comment }: CommentDisplayProps) {
   return (
     <div className="flex items-start justify-start gap-2 rounded-lg bg-white p-3">
@@ -36,7 +36,8 @@ function CommentDisplay({ avatarSrc, nickname, timeText, comment }: CommentDispl
 
 export function DashedComment(props: DashedCommentProps) {
   const { isCreateMode, onCommentCreate } = props;
-  const onDeleteEdge = 'onDeleteEdge' in props ? props.onDeleteEdge : undefined;
+
+  // 모든 훅은 early return 이전에 선언
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [savedComment, setSavedComment] = useState<string | null>(null);
@@ -48,14 +49,11 @@ export function DashedComment(props: DashedCommentProps) {
     }
   }, [isEditing]);
 
-  const handleCreateClick = () => {
-    setIsEditing(true);
-  };
+  const handleCreateClick = () => setIsEditing(true);
 
   const handleSave = () => {
     const trimmedValue = inputValue.trim();
     if (!trimmedValue) return;
-
     setSavedComment(trimmedValue);
     onCommentCreate?.(trimmedValue);
     setIsEditing(false);
@@ -88,22 +86,21 @@ export function DashedComment(props: DashedCommentProps) {
     );
   }
 
-  // Create 상태
   if (isCreateMode === true) {
     if (isEditing) {
       return (
         <div className="flex items-center justify-center rounded bg-white px-3 py-1 outline outline-1 outline-offset-[-1px] outline-primary-40">
-            <input
-              ref={inputRef}
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onBlur={handleBlur}
-              maxLength={50}
-              placeholder="코멘트를 입력해주세요"
-              className="w-full border-none bg-transparent text-caption-1 font-medium text-label-neutral outline-none placeholder:text-label-neutral/60"
-            />
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            maxLength={50}
+            placeholder="코멘트를 입력해주세요"
+            className="w-full border-none bg-transparent text-caption-1 font-medium text-label-neutral outline-none placeholder:text-label-neutral/60"
+          />
         </div>
       );
     }
@@ -121,30 +118,14 @@ export function DashedComment(props: DashedCommentProps) {
     );
   }
 
-  // Default 상태 (저장된 엣지 코멘트)
   const { edge } = props;
 
   return (
-    <div className="group relative">
-      <CommentDisplay
-        avatarSrc={edge.createdBy.profileImageUrl}
-        nickname={edge.createdBy.nickname}
-        timeText="2일 전"
-        comment={edge.comment}
-      />
-      {onDeleteEdge && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDeleteEdge();
-          }}
-          aria-label="참조 연결 삭제"
-          className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:bg-status-negative/10"
-        >
-          <IconTrash className="text-status-negative h-3 w-3" aria-hidden="true" />
-        </button>
-      )}
-    </div>
+    <CommentDisplay
+      avatarSrc={edge.createdBy.profileImageUrl}
+      nickname={edge.createdBy.nickname}
+      timeText="2일 전"
+      comment={edge.comment}
+    />
   );
 }

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -26,8 +26,11 @@ import { NodeSidebar } from '@/components/node-datail/NodeSidebar';
 import { MultiNodeSummaryModalContent } from '@/components/projects/project-detail/multi-node-summary/MultiNodeSummaryModalContent';
 import type { MultiNodeSummaryNode, MultiNodeSummaryResult } from '@/components/projects/project-detail/multi-node-summary/types';
 import { useMultiNodeSummaryRequest } from '@/components/projects/project-detail/multi-node-summary/useMultiNodeSummaryRequest';
+import { EdgeDeleteConfirmContent } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 import { nodeKeys } from '@/queries/keys/nodeKeys';
+import { useDeleteEdgeMutation } from '@/queries/edge';
 import { useFlowchartQuery } from '@/queries/node';
+import { useErrorToast } from '@/hooks/useErrorToast';
 import { convertToReactFlow } from '@/utils/flowchartToReactFlow';
 import { CustomNode } from './CustomNode';
 import { NodeButton } from './NodeButton';
@@ -81,6 +84,8 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const { setViewport, getViewport } = useReactFlow();
   const queryClient = useQueryClient();
   const { openModal, closeModal } = useModal();
+  const showErrorToast = useErrorToast();
+  const { mutate: deleteEdge } = useDeleteEdgeMutation(projectId);
   const { data: flowChart, isLoading: loading } = useFlowchartQuery(projectId);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [sidebarNodeId, setSidebarNodeId] = useState<number | null>(null);
@@ -254,6 +259,40 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     }
   }, [flowChart, updateFlowAndMoveToNode, projectId, isCreating, queryClient]);
 
+  // 점선(참조 엣지) 삭제 핸들러
+  const handleDeleteEdge = useCallback(
+    (edgeId: number) => {
+      openModal({
+        variant: 'small',
+        closeOnBackdrop: true,
+        content: (
+          <EdgeDeleteConfirmContent
+            onConfirm={() => {
+              deleteEdge(edgeId, {
+                onSuccess: () => {
+                  closeModal();
+                  void queryClient.invalidateQueries({ queryKey: nodeKeys.flowchart(projectId) });
+                },
+                onError: (err) => showErrorToast(err, '참조 연결 삭제에 실패했어요.'),
+              });
+            }}
+            onClose={closeModal}
+          />
+        ),
+      });
+    },
+    [openModal, closeModal, deleteEdge, projectId, queryClient, showErrorToast],
+  );
+
+  const edgesWithHandlers = useMemo(
+    () =>
+      edges.map((edge) => ({
+        ...edge,
+        data: { ...edge.data, onDeleteEdge: handleDeleteEdge },
+      })),
+    [edges, handleDeleteEdge],
+  );
+
   const nodesWithHandlers = useMemo(() => {
     return nodes.map((node) => ({
       ...node,
@@ -268,10 +307,10 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
 
   const visibleEdges = useMemo(() => {
     if (showDashedLines) {
-      return edges;
+      return edgesWithHandlers;
     }
-    return edges.filter((edge) => edge.type !== 'reference');
-  }, [edges, showDashedLines]);
+    return edgesWithHandlers.filter((edge) => edge.type !== 'reference');
+  }, [edgesWithHandlers, showDashedLines]);
 
   if (loading) {
     return <Loading />;

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -2,6 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import ReactFlow, {
   Node,
   Controls,
@@ -22,6 +23,8 @@ import { privateApi } from '@/api';
 import { GetFlowchartResponse } from '@/api/Api';
 import { Loading } from '@/components/commons/loading/Loading';
 import { useModal } from '@/components/commons/modal/ModalContext';
+import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
+import type { EdgeNodeInfo } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 import { NodeSidebar } from '@/components/node-datail/NodeSidebar';
 import { MultiNodeSummaryModalContent } from '@/components/projects/project-detail/multi-node-summary/MultiNodeSummaryModalContent';
 import type { MultiNodeSummaryNode, MultiNodeSummaryResult } from '@/components/projects/project-detail/multi-node-summary/types';
@@ -83,7 +86,10 @@ function ConnectedMultiNodeSummary({
 function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const { setViewport, getViewport } = useReactFlow();
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { openModal, closeModal } = useModal();
+  const { openDialog, closeDialog } = useDialog();
   const showErrorToast = useErrorToast();
   const { mutate: deleteEdge } = useDeleteEdgeMutation(projectId);
   const { data: flowChart, isLoading: loading } = useFlowchartQuery(projectId);
@@ -110,6 +116,18 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   useEffect(() => {
     localStorage.setItem('showDashedLines', JSON.stringify(showDashedLines));
   }, [showDashedLines]);
+
+  // 알림 클릭으로 넘어온 openNode param 처리
+  useEffect(() => {
+    const openNodeParam = searchParams.get('openNode');
+    if (!openNodeParam) return;
+    const nodeId = parseInt(openNodeParam, 10);
+    if (!Number.isNaN(nodeId)) {
+      setSidebarNodeId(nodeId);
+      // 파라미터 제거 (히스토리 오염 없이)
+      router.replace(`/projects/${projectId}`);
+    }
+  }, [searchParams, projectId, router]);
 
   // 쿼리 데이터가 바뀌면 ReactFlow 상태 동기화
   useEffect(() => {
@@ -259,38 +277,57 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     }
   }, [flowChart, updateFlowAndMoveToNode, projectId, isCreating, queryClient]);
 
+  // 노드 정보 조회 헬퍼
+  const findNodeInfo = useCallback(
+    (nodeId: number): EdgeNodeInfo | undefined => {
+      const flowNode = nodes.find((n) => n.id === String(nodeId));
+      if (!flowNode) return undefined;
+      return {
+        number: String(flowNode.data?.number ?? nodeId),
+        title: String(flowNode.data?.title ?? ''),
+      };
+    },
+    [nodes],
+  );
+
   // 점선(참조 엣지) 삭제 핸들러
   const handleDeleteEdge = useCallback(
-    (edgeId: number) => {
-      openModal({
-        variant: 'small',
+    (edgeId: number, fromNode?: EdgeNodeInfo, toNode?: EdgeNodeInfo) => {
+      openDialog({
         closeOnBackdrop: true,
+        closeOnEsc: true,
         content: (
           <EdgeDeleteConfirmContent
+            fromNode={fromNode}
+            toNode={toNode}
             onConfirm={() => {
               deleteEdge(edgeId, {
                 onSuccess: () => {
-                  closeModal();
+                  closeDialog();
                   void queryClient.invalidateQueries({ queryKey: nodeKeys.flowchart(projectId) });
                 },
                 onError: (err) => showErrorToast(err, '참조 연결 삭제에 실패했어요.'),
               });
             }}
-            onClose={closeModal}
+            onClose={closeDialog}
           />
         ),
       });
     },
-    [openModal, closeModal, deleteEdge, projectId, queryClient, showErrorToast],
+    [openDialog, closeDialog, deleteEdge, projectId, queryClient, showErrorToast],
   );
 
   const edgesWithHandlers = useMemo(
     () =>
       edges.map((edge) => ({
         ...edge,
-        data: { ...edge.data, onDeleteEdge: handleDeleteEdge },
+        data: {
+          ...edge.data,
+          onDeleteEdge: (edgeId: number, startNodeId: number, endNodeId: number) =>
+            handleDeleteEdge(edgeId, findNodeInfo(startNodeId), findNodeInfo(endNodeId)),
+        },
       })),
-    [edges, handleDeleteEdge],
+    [edges, handleDeleteEdge, findNodeInfo],
   );
 
   const nodesWithHandlers = useMemo(() => {

--- a/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
+++ b/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
@@ -17,6 +17,7 @@ export function ReferenceEdge({
   data,
 }: EdgeProps) {
   const edgeData = data?.edgeData as FlowChartEdge | undefined;
+  const onDeleteEdge = data?.onDeleteEdge as ((edgeId: number) => void) | undefined;
   const nodes = useNodes();
 
   const midX = (sourceX + targetX) / 2;
@@ -127,7 +128,10 @@ export function ReferenceEdge({
             }}
             className="nodrag nopan"
           >
-            <DashedComment edge={edgeData} />
+            <DashedComment
+              edge={edgeData}
+              onDeleteEdge={onDeleteEdge && edgeData ? () => onDeleteEdge(edgeData.edgeId) : undefined}
+            />
           </div>
         </EdgeLabelRenderer>
       )}

--- a/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
+++ b/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
@@ -1,4 +1,5 @@
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge, useNodes, Position } from 'reactflow';
+import { useState, useCallback } from 'react';
+import { EdgeProps, getBezierPath, EdgeLabelRenderer, useNodes, useReactFlow, Position } from 'reactflow';
 import type { Edge as FlowChartEdge } from '@/types/FlowChartTypes';
 import { DashedComment } from './DashedComment';
 
@@ -17,8 +18,27 @@ export function ReferenceEdge({
   data,
 }: EdgeProps) {
   const edgeData = data?.edgeData as FlowChartEdge | undefined;
-  const onDeleteEdge = data?.onDeleteEdge as ((edgeId: number) => void) | undefined;
+  const onDeleteEdgeFn = data?.onDeleteEdge as
+    | ((edgeId: number, startNodeId: number, endNodeId: number) => void)
+    | undefined;
   const nodes = useNodes();
+  const { screenToFlowPosition } = useReactFlow();
+  const [hovered, setHovered] = useState(false);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+
+  const handleEdgeClick = () => {
+    if (onDeleteEdgeFn && edgeData) {
+      onDeleteEdgeFn(edgeData.edgeId, edgeData.startNodeId, edgeData.endNodeId);
+    }
+  };
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+      setMousePos(pos);
+    },
+    [screenToFlowPosition],
+  );
 
   const midX = (sourceX + targetX) / 2;
   const midY = (sourceY + targetY) / 2;
@@ -93,45 +113,68 @@ export function ReferenceEdge({
     curvature: 0.25,
   });
 
+  const commentX = mousePos?.x ?? referenceNodeX;
+  const commentY = mousePos?.y ?? referenceNodeY;
+
+  const sharedHoverProps = {
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => { setHovered(false); setMousePos(null); },
+    onMouseMove: handleMouseMove,
+  };
+
   return (
     <>
-      {/* 첫 번째 점선: 시작 노드 → 참조노드 */}
-      <BaseEdge
-        id={`${id}-1`}
-        path={path1}
+      {/* 첫 번째 점선: 시작 노드 → 참조노드 (시각) */}
+      <path
+        d={path1}
+        fill="none"
         style={{
-          stroke: 'var(--color-primary-50)',
+          stroke: hovered ? 'var(--color-primary-40)' : 'var(--color-primary-50)',
           strokeWidth: 1,
           strokeDasharray: '5,5',
+          transition: 'stroke 0.15s',
         }}
       />
-
-      {/* 두 번째 점선: 참조노드 → 끝 노드 */}
-      <BaseEdge
-        id={`${id}-2`}
-        path={path2}
+      {/* 두 번째 점선: 참조노드 → 끝 노드 (시각) */}
+      <path
+        d={path2}
+        fill="none"
         style={{
-          stroke: 'var(--color-primary-50)',
+          stroke: hovered ? 'var(--color-primary-40)' : 'var(--color-primary-50)',
           strokeWidth: 1,
           strokeDasharray: '5,5',
+          transition: 'stroke 0.15s',
         }}
       />
+      {/* 투명 히트영역: path1 클릭/호버/마우스 감지 */}
+      <path
+        d={path1}
+        fill="none"
+        style={{ stroke: 'transparent', strokeWidth: 14, cursor: 'pointer' }}
+        onClick={handleEdgeClick}
+        {...sharedHoverProps}
+      />
+      {/* 투명 히트영역: path2 클릭/호버/마우스 감지 */}
+      <path
+        d={path2}
+        fill="none"
+        style={{ stroke: 'transparent', strokeWidth: 14, cursor: 'pointer' }}
+        onClick={handleEdgeClick}
+        {...sharedHoverProps}
+      />
 
-      {edgeData && (
+      {edgeData && hovered && mousePos && (
         <EdgeLabelRenderer>
           <div
             style={{
               position: 'absolute',
-              transform: `translate(-50%, -50%) translate(${referenceNodeX}px,${referenceNodeY}px)`,
-              pointerEvents: 'all',
+              transform: `translate(-50%, -120%) translate(${commentX}px,${commentY}px)`,
+              pointerEvents: 'none',
               zIndex: 10001,
             }}
             className="nodrag nopan"
           >
-            <DashedComment
-              edge={edgeData}
-              onDeleteEdge={onDeleteEdge && edgeData ? () => onDeleteEdge(edgeData.edgeId) : undefined}
-            />
+            <DashedComment edge={edgeData} />
           </div>
         </EdgeLabelRenderer>
       )}

--- a/frontend/src/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent.tsx
+++ b/frontend/src/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface EdgeDeleteConfirmContentProps {
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * 참조 연결(점선) 삭제 컨펌 모달 콘텐츠.
+ *
+ * - 삭제 API 호출은 부모에게 위임한다.
+ */
+export const EdgeDeleteConfirmContent = ({
+  onConfirm,
+  onClose,
+}: EdgeDeleteConfirmContentProps) => (
+  <div className="flex w-full flex-col gap-4 pb-2">
+    <h3 className="text-heading-2 text-label-normal font-medium">참조 연결을 삭제하시겠어요?</h3>
+    <p className="text-body-2 text-label-alternative">
+      참조 연결을 삭제하면 복구할 수 없어요.
+    </p>
+    <div className="flex items-center justify-end gap-6 pt-2">
+      <button
+        type="button"
+        onClick={onClose}
+        className="text-body-1 text-label-alternative hover:bg-fill-normal active:bg-fill-strong focus-visible:ring-primary-40 rounded-md bg-transparent px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
+      >
+        취소
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        className={cn(
+          'text-body-1 rounded-md px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
+          'focus-visible:ring-primary-40',
+          'text-status-negative hover:bg-fill-normal active:bg-fill-strong bg-transparent',
+        )}
+      >
+        삭제
+      </button>
+    </div>
+  </div>
+);
+
+EdgeDeleteConfirmContent.displayName = 'EdgeDeleteConfirmContent';

--- a/frontend/src/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent.tsx
+++ b/frontend/src/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent.tsx
@@ -1,26 +1,51 @@
 'use client';
 
+import { ContentBadge } from '@wanteddev/wds';
+
 import { cn } from '@/utils/cn';
 
+export interface EdgeNodeInfo {
+  number: string;
+  title: string;
+}
+
 interface EdgeDeleteConfirmContentProps {
+  fromNode?: EdgeNodeInfo;
+  toNode?: EdgeNodeInfo;
   onConfirm: () => void;
   onClose: () => void;
 }
 
-/**
- * 참조 연결(점선) 삭제 컨펌 모달 콘텐츠.
- *
- * - 삭제 API 호출은 부모에게 위임한다.
- */
 export const EdgeDeleteConfirmContent = ({
+  fromNode,
+  toNode,
   onConfirm,
   onClose,
 }: EdgeDeleteConfirmContentProps) => (
-  <div className="flex w-full flex-col gap-4 pb-2">
-    <h3 className="text-heading-2 text-label-normal font-medium">참조 연결을 삭제하시겠어요?</h3>
-    <p className="text-body-2 text-label-alternative">
-      참조 연결을 삭제하면 복구할 수 없어요.
-    </p>
+  <div className="flex w-90 flex-col gap-4 pb-2">
+    <h3 className="text-headline-1 text-label-normal font-semibold">참조 연결을 삭제하시겠어요?</h3>
+
+    {fromNode && toNode && (
+      <div className="bg-fill-alternative flex flex-col gap-2 rounded-lg px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-caption-1 text-label-assistive w-14 shrink-0 font-medium">시작 노드</span>
+          <ContentBadge size="xsmall" variant="solid" color="accent" className="!bg-primary-40/10 !text-primary-40 shrink-0">
+            #{fromNode.number}
+          </ContentBadge>
+          <span className="text-body-2 text-label-normal min-w-0 truncate font-medium">{fromNode.title}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-caption-1 text-label-assistive w-14 shrink-0 font-medium">도착 노드</span>
+          <ContentBadge size="xsmall" variant="solid" color="accent" className="!bg-primary-40/10 !text-primary-40 shrink-0">
+            #{toNode.number}
+          </ContentBadge>
+          <span className="text-body-2 text-label-normal min-w-0 truncate font-medium">{toNode.title}</span>
+        </div>
+      </div>
+    )}
+
+    <p className="text-body-2 text-label-alternative">참조 연결을 삭제하면 복구할 수 없어요.</p>
+
     <div className="flex items-center justify-end gap-6 pt-2">
       <button
         type="button"
@@ -33,8 +58,7 @@ export const EdgeDeleteConfirmContent = ({
         type="button"
         onClick={onConfirm}
         className={cn(
-          'text-body-1 rounded-md px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
-          'focus-visible:ring-primary-40',
+          'text-body-1 rounded-md px-2 py-1 font-semibold outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-40',
           'text-status-negative hover:bg-fill-normal active:bg-fill-strong bg-transparent',
         )}
       >

--- a/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
@@ -18,6 +18,7 @@ interface ReferenceNodeModalContentProps {
   nodeOptions: readonly ReferenceNodeOption[];
   onClose: () => void;
   onCreate?: (payload: ReferenceNodeCreatePayload) => void;
+  onDeleteEdge?: (edgeId: number) => void;
 }
 
 export const ReferenceNodeModalContent = ({
@@ -26,6 +27,7 @@ export const ReferenceNodeModalContent = ({
   nodeOptions,
   onClose,
   onCreate,
+  onDeleteEdge,
 }: ReferenceNodeModalContentProps) => {
   const form = useReferenceNodeForm({ startNodeId, nodeOptions });
   const { handleSubmit, canCreate, buildPayload, viewMode, openAddView, closeAddView } = form;
@@ -51,7 +53,7 @@ export const ReferenceNodeModalContent = ({
       </header>
 
       <div className="flex w-full flex-col gap-6">
-        <ReferencedNodesList items={referencedNodes} variant={viewMode} />
+        <ReferencedNodesList items={referencedNodes} variant={viewMode} onDeleteEdge={onDeleteEdge} />
 
         {viewMode === 'list' ? (
           <div className="flex w-full justify-end">

--- a/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
@@ -11,11 +11,13 @@ import {
   type ReferenceNodeOption,
   useReferenceNodeForm,
 } from './useReferenceNodeForm';
+import type { EdgeNodeInfo } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 
 interface ReferenceNodeModalContentProps {
   startNodeId: number;
   referencedNodes: readonly ReferencedNodeItem[];
   nodeOptions: readonly ReferenceNodeOption[];
+  currentNode?: EdgeNodeInfo;
   onClose: () => void;
   onCreate?: (payload: ReferenceNodeCreatePayload) => void;
   onDeleteEdge?: (edgeId: number) => void;
@@ -25,6 +27,7 @@ export const ReferenceNodeModalContent = ({
   startNodeId,
   referencedNodes,
   nodeOptions,
+  currentNode,
   onClose,
   onCreate,
   onDeleteEdge,
@@ -53,7 +56,7 @@ export const ReferenceNodeModalContent = ({
       </header>
 
       <div className="flex w-full flex-col gap-6">
-        <ReferencedNodesList items={referencedNodes} variant={viewMode} onDeleteEdge={onDeleteEdge} />
+        <ReferencedNodesList items={referencedNodes} variant={viewMode} currentNode={currentNode} onDeleteEdge={onDeleteEdge} />
 
         {viewMode === 'list' ? (
           <div className="flex w-full justify-end">

--- a/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { ContentBadge } from '@wanteddev/wds';
+import { IconTrash } from '@wanteddev/wds-icon';
 
+import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
+import { EdgeDeleteConfirmContent } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 import { cn } from '@/utils/cn';
 
 import type { ReferencedNodeItem } from './useReferenceNodeForm';
@@ -10,47 +13,90 @@ interface ReferencedNodesListProps {
   items: readonly ReferencedNodeItem[];
   /** 추가 모드일 때는 외곽 폼 패널과 함께 노출되므로 최대 높이를 좁혀 노출한다. */
   variant?: 'list' | 'add';
+  /** 참조 연결 삭제 핸들러. 전달되면 각 아이템에 삭제 버튼이 표시된다. */
+  onDeleteEdge?: (edgeId: number) => void;
 }
 
-export const ReferencedNodesList = ({ items, variant = 'list' }: ReferencedNodesListProps) => (
-  <section className="flex w-full flex-col gap-2">
-    <h3 className="text-label-1 text-label-neutral font-semibold">참조 중인 노드 목록</h3>
-    <ul
-      className={cn(
-        'custom-scrollbar flex w-full flex-col gap-1 overflow-y-auto pr-2',
-        variant === 'list' ? 'max-h-95' : 'max-h-72',
-      )}
-    >
-      {items.map((item) => (
-        <li
-          key={item.edgeId}
-          className="bg-fill-alternative/50 flex items-start gap-2 rounded-lg px-4 py-2"
+export const ReferencedNodesList = ({
+  items,
+  variant = 'list',
+  onDeleteEdge,
+}: ReferencedNodesListProps) => {
+  const { openDialog, closeDialog } = useDialog();
+
+  const handleDeleteClick = (edgeId: number) => {
+    openDialog({
+      closeOnBackdrop: true,
+      closeOnEsc: true,
+      content: (
+        <EdgeDeleteConfirmContent
+          onConfirm={() => {
+            closeDialog();
+            onDeleteEdge?.(edgeId);
+          }}
+          onClose={closeDialog}
+        />
+      ),
+    });
+  };
+
+  return (
+    <section className="flex w-full flex-col gap-2">
+      <h3 className="text-label-1 text-label-neutral font-semibold">참조 중인 노드 목록</h3>
+
+      {items.length === 0 ? (
+        <div className="flex items-center justify-center py-8">
+          <p className="text-body-2 text-label-assistive">참조 중인 노드가 없어요.</p>
+        </div>
+      ) : (
+        <ul
+          className={cn(
+            'custom-scrollbar flex w-full flex-col gap-1 overflow-y-auto pr-2',
+            variant === 'list' ? 'max-h-95' : 'max-h-72',
+          )}
         >
-          <ContentBadge
-            size="medium"
-            variant="solid"
-            color="accent"
-            className="!bg-primary-40/10 !text-primary-40 shrink-0"
-          >
-            #{item.number}
-          </ContentBadge>
-          <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-body-2 text-label-normal truncate font-medium">
-                {item.title}
-              </span>
-              <span className="text-caption-1 text-label-assistive shrink-0 font-normal">
-                연결한 사람: {item.createdBy?.nickname}
-              </span>
-            </div>
-            <p className="text-caption-1 text-label-alternative w-full truncate font-normal">
-              {item.comment}
-            </p>
-          </div>
-        </li>
-      ))}
-    </ul>
-  </section>
-);
+          {items.map((item) => (
+            <li
+              key={item.edgeId}
+              className="bg-fill-alternative/50 flex items-start gap-2 rounded-lg px-4 py-2"
+            >
+              <ContentBadge
+                size="medium"
+                variant="solid"
+                color="accent"
+                className="!bg-primary-40/10 !text-primary-40 shrink-0"
+              >
+                #{item.number}
+              </ContentBadge>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-body-2 text-label-normal truncate font-medium">
+                    {item.title}
+                  </span>
+                  <span className="text-caption-1 text-label-assistive shrink-0 font-normal">
+                    연결한 사람: {item.createdBy?.nickname}
+                  </span>
+                </div>
+                <p className="text-caption-1 text-label-alternative w-full truncate font-normal">
+                  {item.comment}
+                </p>
+              </div>
+              {onDeleteEdge && item.edgeId !== undefined && (
+                <button
+                  type="button"
+                  onClick={() => handleDeleteClick(item.edgeId!)}
+                  aria-label="참조 연결 삭제"
+                  className="text-label-assistive hover:text-status-negative focus-visible:ring-primary-40 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent outline-none transition-colors focus-visible:ring-2"
+                >
+                  <IconTrash className="h-4 w-4" aria-hidden="true" />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
 
 ReferencedNodesList.displayName = 'ReferencedNodesList';

--- a/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
@@ -4,7 +4,7 @@ import { ContentBadge } from '@wanteddev/wds';
 import { IconTrash } from '@wanteddev/wds-icon';
 
 import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
-import { EdgeDeleteConfirmContent } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
+import { EdgeDeleteConfirmContent, type EdgeNodeInfo } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 import { cn } from '@/utils/cn';
 
 import type { ReferencedNodeItem } from './useReferenceNodeForm';
@@ -13,6 +13,8 @@ interface ReferencedNodesListProps {
   items: readonly ReferencedNodeItem[];
   /** 추가 모드일 때는 외곽 폼 패널과 함께 노출되므로 최대 높이를 좁혀 노출한다. */
   variant?: 'list' | 'add';
+  /** 현재 모달을 열고 있는 노드 정보. from/to 방향 계산에 사용한다. */
+  currentNode?: EdgeNodeInfo;
   /** 참조 연결 삭제 핸들러. 전달되면 각 아이템에 삭제 버튼이 표시된다. */
   onDeleteEdge?: (edgeId: number) => void;
 }
@@ -20,16 +22,30 @@ interface ReferencedNodesListProps {
 export const ReferencedNodesList = ({
   items,
   variant = 'list',
+  currentNode,
   onDeleteEdge,
 }: ReferencedNodesListProps) => {
   const { openDialog, closeDialog } = useDialog();
 
-  const handleDeleteClick = (edgeId: number) => {
+  const handleDeleteClick = (item: ReferencedNodeItem) => {
+    const edgeId = item.edgeId!;
+    const linkedNode: EdgeNodeInfo | undefined =
+      item.number !== undefined
+        ? { number: item.number, title: item.title ?? '' }
+        : undefined;
+
+    // linkType === 'START': 현재 노드가 시작, 상대 노드가 도착
+    // linkType === 'END': 상대 노드가 시작, 현재 노드가 도착
+    const fromNode = item.linkType === 'START' ? currentNode : linkedNode;
+    const toNode = item.linkType === 'START' ? linkedNode : currentNode;
+
     openDialog({
       closeOnBackdrop: true,
       closeOnEsc: true,
       content: (
         <EdgeDeleteConfirmContent
+          fromNode={fromNode}
+          toNode={toNode}
           onConfirm={() => {
             closeDialog();
             onDeleteEdge?.(edgeId);
@@ -84,7 +100,7 @@ export const ReferencedNodesList = ({
               {onDeleteEdge && item.edgeId !== undefined && (
                 <button
                   type="button"
-                  onClick={() => handleDeleteClick(item.edgeId!)}
+                  onClick={() => handleDeleteClick(item)}
                   aria-label="참조 연결 삭제"
                   className="text-label-assistive hover:text-status-negative focus-visible:ring-primary-40 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent outline-none transition-colors focus-visible:ring-2"
                 >

--- a/frontend/src/contexts/YjsContext.tsx
+++ b/frontend/src/contexts/YjsContext.tsx
@@ -49,7 +49,7 @@ const YjsContext = createContext<YjsContextValue | null>(null);
  * 브라우저 환경에서만 Y.Doc과 WebsocketProvider를 생성한다.
  * SSR(typeof window === 'undefined') 시에는 null을 반환한다.
  */
-function createYjsState(nodeId: number): YjsContextValue | null {
+function createYjsState(room: string): YjsContextValue | null {
   if (typeof window === 'undefined') return null;
 
   const serverUrl = process.env.NEXT_PUBLIC_YJS_WS_URL ?? 'ws://localhost:1234';
@@ -57,8 +57,8 @@ function createYjsState(nodeId: number): YjsContextValue | null {
 
   // 서버용 인증 토큰 로컬 서버에서 임시로 제거
   // const token = authStorage.getAccess();
-  // const provider = new WebsocketProvider(serverUrl, `node-${nodeId}`, ydoc, {token && {params: {token}}});
-  const provider = new WebsocketProvider(serverUrl, `node-${nodeId}`, ydoc);
+  // const provider = new WebsocketProvider(serverUrl, room, ydoc, {token && {params: {token}}});
+  const provider = new WebsocketProvider(serverUrl, room, ydoc);
 
   // 세션 랜덤 색 설정
   const color = AWARENESS_COLORS[Math.floor(Math.random() * AWARENESS_COLORS.length)];
@@ -67,21 +67,21 @@ function createYjsState(nodeId: number): YjsContextValue | null {
   return { ydoc, provider };
 }
 
-// YjsProvider의 key prop으로 nodeId 변경 시 리마운트된다.
-function YjsInstance({ nodeId, children }: { nodeId: number; children: React.ReactNode }) {
+// 상위 Provider의 key prop으로 room 변경 시 리마운트된다.
+function YjsInstance({ room, children }: { room: string; children: React.ReactNode }) {
   const [value, setValue] = useState<YjsContextValue | null>(null);
   const { data: currentUser } = useCurrentUserQuery();
 
   useEffect(() => {
-    const yjsValue = createYjsState(nodeId);
-    // nodeId가 바뀌지 않는 한 effect가 재실행되지 않으므로 cascading render 없으므로 lint 무시 가능...?
+    const yjsValue = createYjsState(room);
+    // room이 바뀌지 않는 한 effect가 재실행되지 않으므로 cascading render 없으므로 lint 무시 가능...?
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setValue(yjsValue);
     return () => {
       yjsValue?.provider.destroy();
       yjsValue?.ydoc.destroy();
     };
-  }, [nodeId]);
+  }, [room]);
 
   useEffect(() => {
     if (!value || !currentUser) return;
@@ -133,12 +133,33 @@ export function useAwarenessUsers(): YjsAwarenessState['user'][] {
 }
 
 /**
- * nodeId별로 Yjs 연결 관리용 프로바이더
+ * nodeId별로 Yjs 연결 관리용 프로바이더 (노드 상세용)
  * nodeId가 바뀌면 key 교체로 YjsInstance를 리마운트해 WebSocket 연결 재설정
  */
 export function YjsProvider({ nodeId, children }: { nodeId: number; children: React.ReactNode }) {
+  const room = `node-${nodeId}`;
   return (
-    <YjsInstance key={nodeId} nodeId={nodeId}>
+    <YjsInstance key={room} room={room}>
+      {children}
+    </YjsInstance>
+  );
+}
+
+/**
+ * 프로젝트 단위 presence 전용 프로바이더.
+ * 같은 프로젝트를 보고 있는 유저들이 `project-${projectId}` 룸에서 awareness만 공유한다.
+ * (ydoc 공유 필드는 사용하지 않음 — 단순 presence 용도)
+ */
+export function ProjectPresenceProvider({
+  projectId,
+  children,
+}: {
+  projectId: number;
+  children: React.ReactNode;
+}) {
+  const room = `project-${projectId}`;
+  return (
+    <YjsInstance key={room} room={room}>
       {children}
     </YjsInstance>
   );

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -9,7 +9,7 @@ import { MeetingEditModalContent } from '@/components/projects/node-flow/Meeting
 import { MeetingDeleteConfirmContent } from '@/components/projects/project-detail/meeting-delete/MeetingDeleteConfirmContent';
 import { NodeDeleteConfirmContent } from '@/components/projects/project-detail/node-delete/NodeDeleteConfirmContent';
 import { ReferenceNodeModalContent } from '@/components/projects/project-detail/reference-node/ReferenceNodeModalContent';
-import { useCreateEdgeMutation, useLinkedNodesQuery, useNodeListQuery } from '@/queries/edge';
+import { useCreateEdgeMutation, useDeleteEdgeMutation, useLinkedNodesQuery, useNodeListQuery } from '@/queries/edge';
 import { useCreateMeetingMutation, useUpdateMeetingMutation } from '@/queries/meeting';
 import { useDeleteMeetingMutation } from '@/queries/meetingDelete';
 import { useProjectMembersQuery } from '@/queries/member';
@@ -159,6 +159,7 @@ function ConnectedReferenceNodeModal({
   const { data: linkedNodes = [] } = useLinkedNodesQuery(projectId, nodeId);
   const { data: nodeList = [] } = useNodeListQuery(projectId);
   const { mutate: createEdge } = useCreateEdgeMutation(projectId);
+  const { mutate: deleteEdge } = useDeleteEdgeMutation(projectId);
   const showErrorToast = useErrorToast();
 
   const nodeOptions = nodeList
@@ -175,6 +176,11 @@ function ConnectedReferenceNodeModal({
         createEdge(payload, {
           onSuccess: onClose,
           onError: (err) => showErrorToast(err, '참조 노드 연결에 실패했어요.'),
+        });
+      }}
+      onDeleteEdge={(edgeId) => {
+        deleteEdge(edgeId, {
+          onError: (err) => showErrorToast(err, '참조 연결 삭제에 실패했어요.'),
         });
       }}
     />

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -150,10 +150,14 @@ function ConnectedMeetingEditModal({
 function ConnectedReferenceNodeModal({
   projectId,
   nodeId,
+  nodeTitle,
+  nodeNumber,
   onClose,
 }: {
   projectId: number;
   nodeId: number;
+  nodeTitle: string;
+  nodeNumber: string;
   onClose: () => void;
 }) {
   const { data: linkedNodes = [] } = useLinkedNodesQuery(projectId, nodeId);
@@ -171,6 +175,7 @@ function ConnectedReferenceNodeModal({
       startNodeId={nodeId}
       referencedNodes={linkedNodes}
       nodeOptions={nodeOptions}
+      currentNode={{ number: nodeNumber, title: nodeTitle }}
       onClose={onClose}
       onCreate={(payload) => {
         createEdge(payload, {
@@ -255,7 +260,13 @@ export function useNodeMenuActions({
       openModal({
         closeOnBackdrop: true,
         content: (
-          <ConnectedReferenceNodeModal projectId={projectId} nodeId={nodeId} onClose={closeModal} />
+          <ConnectedReferenceNodeModal
+            projectId={projectId}
+            nodeId={nodeId}
+            nodeTitle={nodeTitle}
+            nodeNumber={String(nodeNumber ?? nodeId)}
+            onClose={closeModal}
+          />
         ),
       });
     },

--- a/frontend/src/queries/edge.ts
+++ b/frontend/src/queries/edge.ts
@@ -31,3 +31,9 @@ export function useCreateEdgeMutation(projectId: number) {
     mutationFn: (data: CreateEdgeRequest) => privateApi.edge.createEdge(projectId, data),
   });
 }
+
+export function useDeleteEdgeMutation(projectId: number) {
+  return useMutation({
+    mutationFn: (edgeId: number) => privateApi.edge.deleteEdge(projectId, edgeId),
+  });
+}

--- a/frontend/src/utils/normalizeImageUrl.ts
+++ b/frontend/src/utils/normalizeImageUrl.ts
@@ -1,0 +1,12 @@
+/**
+ * 백엔드가 반환하는 이미지 URL을 브라우저에서 로드 가능한 형태로 정규화한다.
+ *
+ * - `undefined` / 빈 문자열 → `undefined`
+ * - `https://...` / `http://...` / `//...` → 그대로 반환
+ * - 그 외 (프로토콜 없는 경우) → `https://` 를 앞에 붙여 반환
+ */
+export const normalizeImageUrl = (raw?: string): string | undefined => {
+  if (!raw) return undefined;
+  if (/^(https?:)?\/\//i.test(raw)) return raw;
+  return `https://${raw}`;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
> #270 

## 📝작업 내용

### 참조 점선 인터랙션 개선
- 점선 클릭 시 삭제 확인 알럿 표시. 알럿에 시작 노드 / 도착 노드 정보를 2줄로 표기해 방향을 명확히 전달
- 점선 위에 마우스를 올릴 때만 코멘트 말풍선이 나타나며, 마우스 커서 위치를 따라 표시
- 투명 히트영역 path(strokeWidth 14)를 추가해 얇은 점선도 쉽게 클릭/호버 가능

### 참조 노드 모달 개선
- 참조 중인 노드가 없을 때 빈 상태 UI 표시
- 참조 노드 목록 각 아이템에 삭제 버튼 추가, 클릭 시 from/to 노드 정보가 포함된 삭제 알럿 노출
- `linkType`(START/END) 기반으로 시작·도착 방향을 정확히 판별

### 사이드바 알림 UX 개선
- SSE로 새 알림 수신 시 벨 아이콘 우측 숫자 뱃지 영역에 primary color dot 표시
- 알림창을 열면 dot 즉시 제거
- 새로고침 시 dot 재생성 방지: SSE 연결 직후 서버가 보내는 `connected` 이벤트(첫 번째 data 이벤트)를 무시
- 알림 클릭 시 `?openNode={targetId}` 쿼리 파라미터로 이동, `NodeFlowView`에서 감지해 해당 노드 사이드바 자동 오픈

### 스크린샷 (선택)
<img width="321" height="272" alt="스크린샷 2026-05-21 오후 12 12 35" src="https://github.com/user-attachments/assets/676e0e03-e211-4ace-b33e-838a5959d615" />
<img width="415" height="269" alt="스크린샷 2026-05-21 오후 12 12 40" src="https://github.com/user-attachments/assets/2a4a11b3-571d-4152-9b52-93a0841e93a2" />

## 💬리뷰 요구사항(선택)