### PR TITLE
[Fix/#272] SSE 알림 구독 프로젝트 단위 변경 및 연결 안정화

### DIFF
--- a/backend/docker/nginx/conf.d/app.conf.template
+++ b/backend/docker/nginx/conf.d/app.conf.template
@@ -31,6 +31,19 @@ server {
         return 404;
     }
 
+    location /v1/notifications/subscribe {
+        proxy_pass              http://app:8080;
+        proxy_http_version      1.1;
+        proxy_set_header        Host              $host;
+        proxy_set_header        X-Real-IP         $remote_addr;
+        proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Forwarded-Host  $host;
+        proxy_read_timeout      1800s;
+        proxy_buffering         off;
+        proxy_cache             off;
+    }
+
     location / {
         proxy_pass         http://app:8080;
         proxy_http_version 1.1;

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/LlmResponseHandler.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/handler/LlmResponseHandler.java
@@ -74,7 +74,7 @@ public class LlmResponseHandler {
             return;
         }
 
-        AiTask mainTask = aiTaskService.create(task.getUserId(), node.getParentId(), AiTaskType.MAIN_SUMMARY);
+        AiTask mainTask = aiTaskService.create(task.getUserId(), node.getProjectId(), node.getParentId(), AiTaskType.MAIN_SUMMARY);
         eventPublisher.publishEvent(new NodeSummaryRequestEvent(mainTask.getId(), mergedText));
         log.info("sub-summary 완료 → main-summary 자동 트리거 - parentNodeId: {}, jobId: {}",
                 node.getParentId(), mainTask.getId());

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/ai/listener/LlmResponseListener.java
@@ -50,15 +50,15 @@ public class LlmResponseListener {
     }
 
     private void notifyUser(final AiTask task) {
-        sseEmitterStore.findByUserId(task.getUserId())
+        sseEmitterStore.findByUserAndProject(task.getUserId(), task.getProjectId())
                 .ifPresent(emitter -> {
                     try {
                         emitter.send(SseEmitter.event()
                                 .name("ai-task-done")
                                 .data(Map.of("jobId", task.getId())));
                     } catch (IOException e) {
-                        sseEmitterStore.remove(task.getUserId());
-                        log.debug("[SSE] AI 결과 알림 전송 실패, 연결 제거: userId={}", task.getUserId());
+                        sseEmitterStore.remove(task.getUserId(), task.getProjectId());
+                        log.debug("[SSE] AI 결과 알림 전송 실패, 연결 제거: userId={}, projectId={}", task.getUserId(), task.getProjectId());
                     }
                 });
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/facade/MeetingFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/meeting/facade/MeetingFacade.java
@@ -146,7 +146,7 @@ public class MeetingFacade {
             throw new BusinessException(MeetingErrorCode.MEETING_NO_TRANSCRIPT);
         }
 
-        AiTask aiTask = aiTaskService.create(userId, meetingId, AiTaskType.SUB_SUMMARY);
+        AiTask aiTask = aiTaskService.create(userId, projectId, meetingId, AiTaskType.SUB_SUMMARY);
         eventPublisher.publishEvent(new MeetingEndedEvent(aiTask.getId(), mergedText));
 
         return EndMeetingResponse.from(aiTask.getId());

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -275,7 +275,7 @@ public class NodeFacade {
             throw new BusinessException(NodeErrorCode.NO_CHILD_SUMMARY);
         }
 
-        AiTask aiTask = aiTaskService.create(userId, nodeId, AiTaskType.MAIN_SUMMARY);
+        AiTask aiTask = aiTaskService.create(userId, projectId, nodeId, AiTaskType.MAIN_SUMMARY);
         eventPublisher.publishEvent(new NodeSummaryRequestEvent(aiTask.getId(), mergedText));
 
         return RequestNodeSummaryResponse.from(aiTask.getId());

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationApi.java
@@ -21,7 +21,7 @@ public interface NotificationApi {
 
     @Operation(summary = "알림 실시간 구독 (SSE)",
             description = "SSE 연결 후 알림이 발생하면 `notification` 이벤트로 실시간 전달됩니다. 연결 타임아웃은 30분이며 클라이언트가 자동 재연결해야 합니다.")
-    SseEmitter subscribe(@UserId Long userId, HttpServletResponse response);
+    SseEmitter subscribe(@UserId Long userId, @RequestParam Long projectId, HttpServletResponse response);
 
     @Operation(summary = "알림 목록 조회",
             description = "isRead 필터와 커서 기반 슬라이싱을 지원합니다. 첫 요청은 cursorId 생략, 이후 응답의 nextCursorId를 그대로 전달합니다.")

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationController.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/controller/NotificationController.java
@@ -31,9 +31,9 @@ public class NotificationController implements NotificationApi {
 
     @Override
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@UserId Long userId, HttpServletResponse response) {
+    public SseEmitter subscribe(@UserId Long userId, @RequestParam Long projectId, HttpServletResponse response) {
         response.setHeader("X-Accel-Buffering", "no");
-        return sseEmitterService.subscribe(userId);
+        return sseEmitterService.subscribe(userId, projectId);
     }
 
     @Override

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/event/DefaultNotificationSender.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/event/DefaultNotificationSender.java
@@ -21,7 +21,7 @@ public class DefaultNotificationSender implements NotificationSender {
 
     @Override
     public void send(final Notification notification) {
-        sseEmitterStore.findByUserId(notification.getUserId())
+        sseEmitterStore.findByUserAndProject(notification.getUserId(), notification.getProjectId())
                 .ifPresent(emitter -> {
                     try {
                         long unreadCount = notificationService.countUnread(notification.getUserId());
@@ -29,8 +29,8 @@ public class DefaultNotificationSender implements NotificationSender {
                                 .name("notification")
                                 .data(NotificationSsePayload.from(notification, unreadCount)));
                     } catch (IOException e) {
-                        sseEmitterStore.remove(notification.getUserId());
-                        log.debug("[SSE] 전송 실패, 연결 제거: userId={}", notification.getUserId());
+                        sseEmitterStore.remove(notification.getUserId(), notification.getProjectId());
+                        log.debug("[SSE] 전송 실패, 연결 제거: userId={}, projectId={}", notification.getUserId(), notification.getProjectId());
                     }
                 });
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/sse/SseEmitterService.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/sse/SseEmitterService.java
@@ -16,18 +16,18 @@ public class SseEmitterService {
 
     private final SseEmitterStore sseEmitterStore;
 
-    public SseEmitter subscribe(final Long userId) {
+    public SseEmitter subscribe(final Long userId, final Long projectId) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
-        sseEmitterStore.save(userId, emitter);
+        sseEmitterStore.save(userId, projectId, emitter);
 
-        emitter.onTimeout(() -> sseEmitterStore.remove(userId));
-        emitter.onError(e -> sseEmitterStore.remove(userId));
-        emitter.onCompletion(() -> sseEmitterStore.remove(userId));
+        emitter.onTimeout(() -> sseEmitterStore.remove(userId, projectId));
+        emitter.onError(e -> sseEmitterStore.remove(userId, projectId));
+        emitter.onCompletion(() -> sseEmitterStore.remove(userId, projectId));
 
         try {
             emitter.send(SseEmitter.event().name("connect").data("connected"));
         } catch (IOException e) {
-            sseEmitterStore.remove(userId);
+            sseEmitterStore.remove(userId, projectId);
         }
 
         return emitter;
@@ -35,12 +35,12 @@ public class SseEmitterService {
 
     @Scheduled(fixedRate = 30_000)
     public void sendHeartbeat() {
-        sseEmitterStore.findAll().forEach((userId, emitter) -> {
+        sseEmitterStore.findAll().forEach((key, emitter) -> {
             try {
                 emitter.send(SseEmitter.event().name("heartbeat").data(""));
             } catch (IOException e) {
-                sseEmitterStore.remove(userId);
-                log.debug("[SSE] heartbeat 실패, 연결 제거: userId={}", userId);
+                sseEmitterStore.removeByKey(key);
+                log.debug("[SSE] heartbeat 실패, 연결 제거: key={}", key);
             }
         });
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/sse/SseEmitterStore.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/notification/sse/SseEmitterStore.java
@@ -10,24 +10,33 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Component
 public class SseEmitterStore {
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
-    public void save(final Long userId, final SseEmitter emitter) {
-        SseEmitter existing = emitters.put(userId, emitter);
+    private String key(Long userId, Long projectId) {
+        return userId + ":" + projectId;
+    }
+
+    public void save(final Long userId, final Long projectId, final SseEmitter emitter) {
+        String key = key(userId, projectId);
+        SseEmitter existing = emitters.put(key, emitter);
         if (existing != null) {
             existing.complete();
         }
     }
 
-    public Optional<SseEmitter> findByUserId(final Long userId) {
-        return Optional.ofNullable(emitters.get(userId));
+    public Optional<SseEmitter> findByUserAndProject(final Long userId, final Long projectId) {
+        return Optional.ofNullable(emitters.get(key(userId, projectId)));
     }
 
-    public void remove(final Long userId) {
-        emitters.remove(userId);
+    public void remove(final Long userId, final Long projectId) {
+        emitters.remove(key(userId, projectId));
     }
 
-    public Map<Long, SseEmitter> findAll() {
+    public void removeByKey(final String key) {
+        emitters.remove(key);
+    }
+
+    public Map<String, SseEmitter> findAll() {
         return Collections.unmodifiableMap(emitters);
     }
 }

--- a/backend/flowmeet-api/src/main/resources/application.yaml
+++ b/backend/flowmeet-api/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ spring:
       - classpath:config/domain.yaml
       - classpath:config/auth.yaml
       - classpath:config/external.yaml
+  mvc:
+    async:
+      request-timeout: 1800000
   servlet:
     multipart:
       max-file-size: 5MB

--- a/backend/flowmeet-api/src/main/resources/db/migration/V21__add_project_id_to_ai_tasks.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V21__add_project_id_to_ai_tasks.sql
@@ -1,0 +1,15 @@
+-- =========================================================
+-- V21__add_project_id_to_ai_tasks.sql
+-- ai_tasks에 project_id 컬럼 추가
+-- =========================================================
+
+ALTER TABLE ai_tasks
+    ADD COLUMN project_id BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE ai_tasks
+    ALTER COLUMN project_id DROP DEFAULT;
+
+ALTER TABLE ai_tasks
+    ADD CONSTRAINT fk_ai_tasks_project FOREIGN KEY (project_id) REFERENCES projects (project_id) NOT VALID;
+
+CREATE INDEX idx_ai_tasks_project_id ON ai_tasks (project_id);

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/entity/AiTask.java
@@ -47,10 +47,14 @@ public class AiTask extends BaseTimeEntity {
     @Column(name = "error_message")
     private String errorMessage;
 
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
     @Builder
-    public AiTask(String id, Long userId, Long referenceId, AiTaskType taskType) {
+    public AiTask(String id, Long userId, Long projectId, Long referenceId, AiTaskType taskType) {
         this.id = id;
         this.userId = userId;
+        this.projectId = projectId;
         this.referenceId = referenceId;
         this.taskType = taskType;
         this.status = AiTaskStatus.PENDING;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/ai/service/AiTaskService.java
@@ -23,11 +23,12 @@ public class AiTaskService {
     }
 
     @Transactional
-    public AiTask create(final Long userId, final Long referenceId, final AiTaskType taskType) {
+    public AiTask create(final Long userId, final Long projectId, final Long referenceId, final AiTaskType taskType) {
         return aiTaskRepository.save(
                 AiTask.builder()
                         .id(UUID.randomUUID().toString())
                         .userId(userId)
+                        .projectId(projectId)
                         .referenceId(referenceId)
                         .taskType(taskType)
                         .build()


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #272

## 📝작업 내용

### SSE 알림 구독을 프로젝트 단위로 변경

- SSE 연결 key를 `userId` → `userId:projectId` 조합으로 변경하여 프로젝트별 독립 채널 구성
- `/subscribe` 엔드포인트에 `projectId` 쿼리 파라미터 추가

### AiTask에 projectId 추가

- `AiTask` 엔티티에 `projectId` 필드 추가
- `ai-task-done` SSE 이벤트도 해당 프로젝트 채널로 정확히 전달되도록 수정
- Flyway V21: `ai_tasks.project_id` 컬럼 추가 (`NOT VALID` FK)

### SSE 연결 타임아웃 설정

- Nginx `/v1/notifications/subscribe` 경로 `proxy_read_timeout` 1800s로 별도 설정
- Spring MVC async request-timeout 1800000ms로 설정

## 변경 파일

| 파일 | 변경 |
|------|------|
| `api/notification/sse/SseEmitterStore.java` | 수정 |
| `api/notification/sse/SseEmitterService.java` | 수정 |
| `api/notification/controller/NotificationApi.java` | 수정 |
| `api/notification/controller/NotificationController.java` | 수정 |
| `api/notification/event/DefaultNotificationSender.java` | 수정 |
| `api/ai/listener/LlmResponseListener.java` | 수정 |
| `api/ai/handler/LlmResponseHandler.java` | 수정 |
| `api/meeting/facade/MeetingFacade.java` | 수정 |
| `api/node/facade/NodeFacade.java` | 수정 |
| `domain/ai/entity/AiTask.java` | 수정 |
| `domain/ai/service/AiTaskService.java` | 수정 |
| `db/migration/V21__add_project_id_to_ai_tasks.sql` | 추가 |
| `docker/nginx/conf.d/app.conf.template` | 수정 |
| `resources/application.yaml` | 수정 |