### PR TITLE
[Feat/#275] 새 프로젝트 생성 시 메인 노드 미리 생성해놓도록 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/facade/ProjectFacade.java
@@ -1,6 +1,7 @@
 package kr.flowmeet.api.project.facade;
 
 import java.util.List;
+import kr.flowmeet.domain.node.service.NodeService;
 import kr.flowmeet.domain.project.service.ProjectPermissionValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,12 +47,15 @@ public class ProjectFacade {
     private final ImageUploader imageUploader;
     private final JwtProvider jwtProvider;
     private final FrontendProperties frontendProperties;
+    private final NodeService nodeService;
 
     @Transactional
     public CreateProjectResponse createProject(final Long userId, final CreateProjectRequest request) {
         Project project = projectService.create(request.name());
+        Long projectId = project.getId();
 
-        projectMemberService.create(userId, project.getId(), ProjectMemberRole.OWNER);
+        projectMemberService.create(userId, projectId, ProjectMemberRole.OWNER);
+        nodeService.createFirstMainNode(projectId);
 
         return CreateProjectResponse.from(project);
     }

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/service/NodeService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import kr.flowmeet.domain.node.entity.NodeStatus;
+import kr.flowmeet.domain.node.entity.NodeType;
 import kr.flowmeet.domain.node.service.vo.CreateNodeCommand;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeKanbanCommand;
 import kr.flowmeet.domain.node.service.vo.UpdateNodeStatusCommand;
@@ -32,6 +33,8 @@ public class NodeService {
     private final TagRepository tagRepository;
     private final NodeAssigneeRepository nodeAssigneeRepository;
     private final NodeTagRepository nodeTagRepository;
+
+    private static final int SORT_ORDER_GAP = 1024;
 
     public Node findById(final Long nodeId) {
         return nodeRepository.findById(nodeId)
@@ -87,13 +90,10 @@ public class NodeService {
         return parent.getNumber() + "." + parent.issueChildSeq();
     }
 
-    private static final int SORT_ORDER_GAP = 1024;
-
-    private int nextSortOrder(final Long projectId, final Long parentId, final NodeStatus status) {
-        int maxOrder = parentId != null
-                ? nodeRepository.findMaxSortOrderByParentId(parentId, status)
-                : nodeRepository.findMaxSortOrderByProjectIdAndRootNodes(projectId, status);
-        return maxOrder + SORT_ORDER_GAP;
+    @Transactional
+    public void createFirstMainNode(final Long projectId) {
+        CreateNodeCommand command = new CreateNodeCommand("새 메인 노드", null, NodeType.MAIN, null);
+        create(projectId, "1", command);
     }
 
     @Transactional
@@ -143,29 +143,6 @@ public class NodeService {
         nodeRepository.softDeleteAllByProjectId(projectId);
     }
 
-    private List<Node> findAllDescendants(Long projectId, Long nodeId) {
-        List<Node> allNodes = findAllByProjectId(projectId);
-
-        Map<Long, List<Node>> childMap = allNodes.stream()
-                .filter(n -> n.getParentId() != null)
-                .collect(Collectors.groupingBy(Node::getParentId));
-
-        List<Node> descendants = new ArrayList<>();
-        Deque<Long> queue = new ArrayDeque<>();
-
-        queue.add(nodeId);
-
-        while (!queue.isEmpty()) {
-            Long currentId = queue.poll();
-            List<Node> children = childMap.getOrDefault(currentId, List.of());
-
-            descendants.addAll(children);
-            children.forEach(child -> queue.add(child.getId()));
-        }
-
-        return descendants;
-    }
-
     @Transactional
     public void updateNodeTitle(final Long projectId, final Long nodeId, final String title) {
         Node node = findByIdAndProjectId(nodeId, projectId);
@@ -205,5 +182,35 @@ public class NodeService {
     public void saveSummary(final Long nodeId, final String summary) {
         Node node = findById(nodeId);
         node.saveSummary(summary);
+    }
+
+    private int nextSortOrder(final Long projectId, final Long parentId, final NodeStatus status) {
+        int maxOrder = parentId != null
+                ? nodeRepository.findMaxSortOrderByParentId(parentId, status)
+                : nodeRepository.findMaxSortOrderByProjectIdAndRootNodes(projectId, status);
+        return maxOrder + SORT_ORDER_GAP;
+    }
+
+    private List<Node> findAllDescendants(Long projectId, Long nodeId) {
+        List<Node> allNodes = findAllByProjectId(projectId);
+
+        Map<Long, List<Node>> childMap = allNodes.stream()
+                .filter(n -> n.getParentId() != null)
+                .collect(Collectors.groupingBy(Node::getParentId));
+
+        List<Node> descendants = new ArrayList<>();
+        Deque<Long> queue = new ArrayDeque<>();
+
+        queue.add(nodeId);
+
+        while (!queue.isEmpty()) {
+            Long currentId = queue.poll();
+            List<Node> children = childMap.getOrDefault(currentId, List.of());
+
+            descendants.addAll(children);
+            children.forEach(child -> queue.add(child.getId()));
+        }
+
+        return descendants;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #275

## 📝작업 내용

### 1. 새 프로젝트 생성 시 메인 노드 자동 생성

프로젝트를 처음 생성할 때 메인 노드가 없어 플로우차트 화면이 비어 있는 문제를 해결했습니다.

**변경 전**

프로젝트 생성 직후 노드가 0개인 상태여서, 사용자가 직접 첫 번째 노드를 추가해야 했습니다.

**변경 후**

`ProjectFacade.createProject()`에서 프로젝트·멤버 생성 직후 `NodeService.createFirstMainNode(projectId)`를 호출해 기본 메인 노드를 함께 생성합니다.

| 필드 | 값 |
|------|----|
| number | `"1"` |
| title | `"새 메인 노드"` |
| type | `MAIN` |
| status | `WAITING` |
| sortOrder | `1024` (gap-based 첫 번째 값) |

---

### 2. NodeService.createFirstMainNode() 추가

기존 `create()` 메서드를 재사용해 초기 메인 노드를 생성하는 `createFirstMainNode(Long projectId)` 메서드를 추가했습니다.

```java
public void createFirstMainNode(final Long projectId) {
    CreateNodeCommand command = new CreateNodeCommand("새 메인 노드", null, NodeType.MAIN, null);
    create(projectId, "1", command);
}
```

sortOrder는 기존 gap-based 방식(`SORT_ORDER_GAP = 1024`)을 그대로 따르므로, 이후 노드 추가·재정렬 로직과 호환됩니다.

## 💬리뷰 요구사항(선택)

- 초기 노드 title(`"새 메인 노드"`)을 하드코딩했습니다. 다국어 지원이 필요한 경우 별도 처리가 필요합니다.