### PR TITLE
[Feat/#278] 노드 뷰 유저 보이게 구현

### DIFF
--- a/frontend/src/app/projects/[projectId]/(project)/layout.tsx
+++ b/frontend/src/app/projects/[projectId]/(project)/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import { useState, useEffect, useMemo } from 'react';
 import { ChatWidget } from '@/components/chat/ChatWidget';
 import { ProjectDetailHeader } from '@/components/projects/project-detail/ProjectDetailHeader';
@@ -10,7 +9,7 @@ import {
   VALID_VIEWS,
   ProjectViewTypes,
 } from '@/contexts/ProjectDetailLayoutContext';
-import { ProjectPresenceProvider, useAwarenessUsers } from '@/contexts/YjsContext';
+import { useAwarenessUsers } from '@/contexts/YjsContext';
 
 const STORAGE_KEY = 'project-active-view';
 
@@ -37,11 +36,6 @@ function HeaderWithPresence({
 }
 
 export default function ProjectDetailLayout({ children }: ProjectDetailLayoutProps) {
-  const params = useParams<{ projectId?: string }>();
-  const projectIdRaw = params?.projectId;
-  const projectId = projectIdRaw ? Number(projectIdRaw) : NaN;
-  const isProjectIdValid = !Number.isNaN(projectId);
-
   const [mounted, setMounted] = useState(false);
   const [activeView, setActiveView] = useState<ProjectViewTypes>(() => {
     if (typeof window === 'undefined') return 'node-flow';
@@ -80,9 +74,5 @@ export default function ProjectDetailLayout({ children }: ProjectDetailLayoutPro
     </ProjectDetailLayoutContext.Provider>
   );
 
-  if (!isProjectIdValid) {
-    return inner;
-  }
-
-  return <ProjectPresenceProvider projectId={projectId}>{inner}</ProjectPresenceProvider>;
+  return inner;
 }

--- a/frontend/src/app/projects/[projectId]/layout.tsx
+++ b/frontend/src/app/projects/[projectId]/layout.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { useParams } from 'next/navigation';
 import { ProjectAuthGuard } from '@/components/commons/project-guard/ProjectAuthGuard';
 import { ProjectSidebar } from '@/components/commons/project-sidebar/ProjectSidebar';
+import { ProjectPresenceProvider } from '@/contexts/YjsContext';
 
 interface ProjectDetailLayoutProps {
   children: React.ReactNode;
 }
 
 export default function ProjectDetailLayout({ children }: ProjectDetailLayoutProps) {
-  return (
+  const params = useParams<{ projectId?: string }>();
+  const projectIdRaw = params?.projectId;
+  const projectId = projectIdRaw ? Number(projectIdRaw) : NaN;
+  const isProjectIdValid = Number.isFinite(projectId);
+
+  const layout = (
     <ProjectAuthGuard>
       <div className="flex h-screen overflow-hidden">
         <ProjectSidebar />
@@ -18,4 +25,8 @@ export default function ProjectDetailLayout({ children }: ProjectDetailLayoutPro
       </div>
     </ProjectAuthGuard>
   );
+
+  if (!isProjectIdValid) return layout;
+
+  return <ProjectPresenceProvider projectId={projectId}>{layout}</ProjectPresenceProvider>;
 }

--- a/frontend/src/app/projects/[projectId]/nodes/[id]/layout.tsx
+++ b/frontend/src/app/projects/[projectId]/nodes/[id]/layout.tsx
@@ -6,7 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import NodeMeetingTab from '@/components/node-datail/meeting/NodeMeetingTab';
 import NodeNoteTab from '@/components/node-datail/note/NodeNoteTab';
-import { YjsProvider } from '@/contexts/YjsContext';
+import { YjsProvider, useSetActiveAwarenessNode } from '@/contexts/YjsContext';
 import { NodePageLayoutClient } from './_components/NodePageLayoutClient';
 
 export default function NodePageLayout() {
@@ -18,6 +18,8 @@ export default function NodePageLayout() {
   const projectSegment = segments[segments.length - 4];
   const nodeId = Number(nodeSegment);
   const projectId = Number(projectSegment);
+
+  useSetActiveAwarenessNode(Number.isFinite(nodeId) ? nodeId : null);
 
   return (
     <div className="flex h-full w-full flex-col bg-white">

--- a/frontend/src/components/node-datail/NodeSidebar.tsx
+++ b/frontend/src/components/node-datail/NodeSidebar.tsx
@@ -4,7 +4,7 @@ import { IconButton } from '@wanteddev/wds';
 import { IconFull } from '@wanteddev/wds-icon';
 import Link from 'next/link';
 import { useEffect, useState, useCallback, useSyncExternalStore } from 'react';
-import { YjsProvider } from '@/contexts/YjsContext';
+import { YjsProvider, useSetActiveAwarenessNode } from '@/contexts/YjsContext';
 import {
   getServerSnapshot,
   getSessionSnapshot,
@@ -41,6 +41,9 @@ export function NodeSidebar({ nodeId, projectId, onClose }: NodeSidebarProps) {
   const activeNodeId = nodeId ?? savedNodeId;
   const numericNodeId = Number(activeNodeId);
   const isOpen = !!activeNodeId;
+  const awarenessNodeId = isOpen && Number.isFinite(numericNodeId) ? numericNodeId : null;
+
+  useSetActiveAwarenessNode(awarenessNodeId);
 
   const handleClose = useCallback(() => {
     sessionStorage.removeItem(SESSION_KEY);

--- a/frontend/src/components/projects/node-flow/CustomNode.tsx
+++ b/frontend/src/components/projects/node-flow/CustomNode.tsx
@@ -4,6 +4,7 @@ import { NodeProps, Handle, Position } from 'reactflow';
 import type { NodeItem } from '@/api/Api';
 import { Users } from '@/components/commons/user/UserAvatarGroup';
 import { ColorType } from '@/constants/badgeColor';
+import { useActiveNodeUsers } from '@/contexts/YjsContext';
 import { useNodeMenuActions } from '@/hooks/useNodeMenuActions';
 import { getColorToken } from '@/utils/getBadgeColorInfo';
 import { formatDate, getVisibleTags } from '@/utils/nodeUtils';
@@ -18,6 +19,7 @@ interface CustomNodeData extends NodeItem {
 
 function CustomFlowNodeComponent({ data, selected }: NodeProps<CustomNodeData>) {
   const { visibleTags, remainingTagsCount } = getVisibleTags(data.tags ?? []);
+  const activeUsers = useActiveNodeUsers(data.nodeId);
   const isMain = data.isMainNode;
   const nodeNumber = data.number ?? data.nodeId;
 
@@ -195,9 +197,9 @@ function CustomFlowNodeComponent({ data, selected }: NodeProps<CustomNodeData>) 
           )}
         </div>
 
-        {data.assignees && data.assignees.length > 0 && (
+        {activeUsers.length > 0 && (
           <div className="shrink-0">
-            <Users users={data.assignees} maxVisible={2} compact />
+            <Users users={activeUsers} maxVisible={2} compact />
           </div>
         )}
       </div>

--- a/frontend/src/contexts/YjsContext.tsx
+++ b/frontend/src/contexts/YjsContext.tsx
@@ -14,6 +14,7 @@ export interface YjsAwarenessState {
     nickname: string;
     profileImageUrl: string | null;
     color: string;
+    activeNodeId?: number | null;
   };
 }
 
@@ -88,12 +89,16 @@ function YjsInstance({ room, children }: { room: string; children: React.ReactNo
     const existingColor =
       (value.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null)?.user
         ?.color ?? AWARENESS_COLORS[0];
+    const activeNodeId =
+      (value.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null)?.user
+        ?.activeNodeId ?? null;
     value.provider.awareness.setLocalStateField('user', {
       userId: value.provider.awareness.clientID,
       email: currentUser.email ?? '',
       nickname: currentUser.nickname ?? '',
       profileImageUrl: currentUser.profileImageUrl ?? null,
       color: existingColor,
+      activeNodeId,
     });
   }, [value, currentUser]);
 
@@ -130,6 +135,48 @@ export function useAwarenessUsers(): YjsAwarenessState['user'][] {
   }, [yjsCtx]);
 
   return users;
+}
+
+export function useActiveNodeUsers(nodeId?: number | null): YjsAwarenessState['user'][] {
+  const users = useAwarenessUsers();
+
+  if (!nodeId) return [];
+
+  return users.filter((user) => user.activeNodeId === nodeId);
+}
+
+export const useNodeAwarenessUsers = useActiveNodeUsers;
+
+export function useSetActiveAwarenessNode(nodeId?: number | null) {
+  const yjsCtx = useYjsContext();
+
+  useEffect(() => {
+    if (!yjsCtx) return;
+    const { provider } = yjsCtx;
+
+    const setActiveNodeId = (activeNodeId: number | null) => {
+      const localState = provider.awareness.getLocalState() as
+        | Partial<YjsAwarenessState>
+        | null;
+      const user = localState?.user;
+      if (!user) return;
+
+      provider.awareness.setLocalStateField('user', {
+        ...user,
+        activeNodeId,
+      });
+    };
+
+    setActiveNodeId(nodeId ?? null);
+    return () => {
+      const localState = provider.awareness.getLocalState() as
+        | Partial<YjsAwarenessState>
+        | null;
+      if (localState?.user?.activeNodeId === nodeId) {
+        setActiveNodeId(null);
+      }
+    };
+  }, [yjsCtx, nodeId]);
 }
 
 /**


### PR DESCRIPTION
## #️⃣연관된 이슈
#278 

## 📝작업 내용
- 노드에 보고있는 유저 프로필 뜨게 구현했습니다

### 스크린샷 (선택)
<img width="1710" height="891" alt="스크린샷 2026-05-21 오후 8 01 40" src="https://github.com/user-attachments/assets/6d7ca117-ea0d-4ca7-be1e-70e62c7cd634" />

## 💬리뷰 요구사항(선택)
ㅎㅎ
