### PR TITLE
[Feat/#277] 노드 변경 시 프로젝트 lastActivityAt 갱신 구현

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -10,6 +10,9 @@ import kr.flowmeet.api.ai.handler.NodeSummaryTextMerger;
 import kr.flowmeet.api.node.dto.response.AnalyzeDraggedNodesResponse;
 import kr.flowmeet.api.node.dto.response.RequestNodeSummaryResponse;
 import kr.flowmeet.api.node.event.NodeSummaryRequestEvent;
+import kr.flowmeet.domain.node.event.NodeCreatedEvent;
+import kr.flowmeet.domain.node.event.NodeDeletedEvent;
+import kr.flowmeet.domain.node.event.NodeUpdatedEvent;
 import kr.flowmeet.domain.ai.entity.AiTask;
 import kr.flowmeet.domain.ai.entity.AiTaskType;
 import kr.flowmeet.domain.ai.service.AiTaskService;
@@ -128,6 +131,7 @@ public class NodeFacade {
         }
 
         nodeService.create(projectId, number, request.toCommand());
+        eventPublisher.publishEvent(NodeCreatedEvent.of(projectId));
     }
 
     @Transactional
@@ -140,6 +144,7 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeTitle(projectId, nodeId, title);
+        eventPublisher.publishEvent(NodeUpdatedEvent.of(projectId));
     }
 
     @Transactional
@@ -152,6 +157,7 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeDescription(projectId, nodeId, description);
+        eventPublisher.publishEvent(NodeUpdatedEvent.of(projectId));
     }
 
     @Transactional
@@ -164,6 +170,7 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeNote(projectId, nodeId, noteContent);
+        eventPublisher.publishEvent(NodeUpdatedEvent.of(projectId));
     }
 
     @Transactional
@@ -180,6 +187,7 @@ public class NodeFacade {
 
         edgeService.deleteAllByNodeIds(allNodeIds);
         nodeService.deleteWithAllDescendants(node);
+        eventPublisher.publishEvent(NodeDeletedEvent.of(projectId));
     }
 
     public GetNodeListResponse getNodeList(
@@ -225,6 +233,7 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeKanban(projectId, nodeId, request.toCommand());
+        eventPublisher.publishEvent(NodeUpdatedEvent.of(projectId));
     }
 
     @Transactional
@@ -237,6 +246,7 @@ public class NodeFacade {
         projectPermissionValidator.validate(projectId, userId, ProjectMemberRole.MEMBER);
 
         nodeService.updateNodeStatus(projectId, nodeId, request.toCommand());
+        eventPublisher.publishEvent(NodeUpdatedEvent.of(projectId));
     }
 
     public GetLinkedNodesResponse getLinkedNodes(

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectSummaryResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/dto/response/ProjectSummaryResponse.java
@@ -15,8 +15,8 @@ public record ProjectSummaryResponse(
         String name,
         @Schema(description = "프로젝트 멤버 수", example = "8")
         int memberCount,
-        @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
-        LocalDateTime updatedAt
+        @Schema(description = "마지막 활동 시각", example = "2026-04-19T10:15:30")
+        LocalDateTime lastActivityAt
 ) {
     public static ProjectSummaryResponse from(final ProjectWithMemberCountProjection projection) {
         Project project = projection.project();
@@ -25,7 +25,7 @@ public record ProjectSummaryResponse(
                 project.getProfileImageUrl(),
                 project.getName(),
                 projection.memberCount().intValue(),
-                project.getUpdatedAt()
+                project.getLastActivityAt()
         );
     }
 }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectActivityEventListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectActivityEventListener.java
@@ -1,0 +1,36 @@
+package kr.flowmeet.api.project.event;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import kr.flowmeet.domain.node.event.NodeCreatedEvent;
+import kr.flowmeet.domain.node.event.NodeDeletedEvent;
+import kr.flowmeet.domain.node.event.NodeUpdatedEvent;
+import kr.flowmeet.domain.project.repository.ProjectRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectActivityEventListener {
+
+    private final ProjectRepository projectRepository;
+
+    @TransactionalEventListener
+    public void handleNodeCreated(final NodeCreatedEvent event) {
+        touch(event.projectId());
+    }
+
+    @TransactionalEventListener
+    public void handleNodeUpdated(final NodeUpdatedEvent event) {
+        touch(event.projectId());
+    }
+
+    @TransactionalEventListener
+    public void handleNodeDeleted(final NodeDeletedEvent event) {
+        touch(event.projectId());
+    }
+
+    private void touch(final Long projectId) {
+        projectRepository.touchLastActivityAt(projectId, LocalDateTime.now());
+    }
+}

--- a/backend/flowmeet-api/src/main/resources/db/migration/V10__add_last_activity_at_to_projects.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V10__add_last_activity_at_to_projects.sql
@@ -1,0 +1,7 @@
+-- =========================================================
+-- V10__add_last_activity_at_to_projects.sql
+-- 프로젝트 하위 항목 변경 시 반영되는 마지막 활동 시각 컬럼 추가
+-- =========================================================
+
+ALTER TABLE projects
+    ADD COLUMN last_activity_at TIMESTAMP;

--- a/backend/flowmeet-api/src/main/resources/db/migration/V22__add_last_activity_at_to_projects.sql
+++ b/backend/flowmeet-api/src/main/resources/db/migration/V22__add_last_activity_at_to_projects.sql
@@ -1,7 +1,10 @@
 -- =========================================================
--- V10__add_last_activity_at_to_projects.sql
+-- V22__add_last_activity_at_to_projects.sql
 -- 프로젝트 하위 항목 변경 시 반영되는 마지막 활동 시각 컬럼 추가
 -- =========================================================
 
 ALTER TABLE projects
     ADD COLUMN last_activity_at TIMESTAMP;
+
+UPDATE projects
+SET last_activity_at = updated_at;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeCreatedEvent.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeCreatedEvent.java
@@ -1,0 +1,8 @@
+package kr.flowmeet.domain.node.event;
+
+public record NodeCreatedEvent(Long projectId) {
+
+    public static NodeCreatedEvent of(final Long projectId) {
+        return new NodeCreatedEvent(projectId);
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeDeletedEvent.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeDeletedEvent.java
@@ -1,0 +1,8 @@
+package kr.flowmeet.domain.node.event;
+
+public record NodeDeletedEvent(Long projectId) {
+
+    public static NodeDeletedEvent of(final Long projectId) {
+        return new NodeDeletedEvent(projectId);
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeUpdatedEvent.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/node/event/NodeUpdatedEvent.java
@@ -1,0 +1,8 @@
+package kr.flowmeet.domain.node.event;
+
+public record NodeUpdatedEvent(Long projectId) {
+
+    public static NodeUpdatedEvent of(final Long projectId) {
+        return new NodeUpdatedEvent(projectId);
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/Project.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/entity/Project.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +36,9 @@ public class Project extends BaseSoftDeleteEntity {
 
     @Column(name = "root_node_seq", nullable = false)
     private int rootNodeSeq;
+
+    @Column(name = "last_activity_at")
+    private LocalDateTime lastActivityAt;
 
     @Builder
     public Project(String name, String profileImageUrl) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectRepository.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/project/repository/ProjectRepository.java
@@ -1,11 +1,14 @@
 package kr.flowmeet.domain.project.repository;
 
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import kr.flowmeet.domain.project.entity.Project;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
@@ -13,4 +16,14 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Project p WHERE p.id = :id")
     Optional<Project> findByIdWithLock(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query("""
+            UPDATE Project p
+            SET p.lastActivityAt = :time
+            WHERE p.id = :id
+              AND (p.lastActivityAt IS NULL OR p.lastActivityAt < :time)
+            """)
+    void touchLastActivityAt(@Param("id") Long id, @Param("time") LocalDateTime time);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #277

## 📝작업 내용

### 1. projects 테이블에 last_activity_at 컬럼 추가

기존 `updated_at`은 Project 엔티티 자체가 수정될 때만 갱신되어, 하위 노드 변경은 반영되지 않는 문제가 있었습니다.

별도 컬럼 `last_activity_at`을 추가해 노드 변경 시에도 프로젝트의 마지막 활동 시각을 추적합니다.

- `updated_at`: Project 엔티티 직접 수정 시각 (JPA Auditing 유지)
- `last_activity_at`: 노드 생성·수정·삭제 등 하위 항목 변경까지 포함한 마지막 활동 시각

### 2. 액션별 노드 도메인 이벤트 추가

`NodeFacade`가 project 도메인에 직접 의존하지 않도록 node 도메인 이벤트를 새로 만들었습니다.

| 이벤트 | 발행 시점 |
|--------|-----------|
| `NodeCreatedEvent` | 노드 생성 |
| `NodeUpdatedEvent` | 제목·설명·노트·칸반·상태 수정 |
| `NodeDeletedEvent` | 노드 삭제 |

### 3. ProjectActivityEventListener로 lastActivityAt 갱신

`@TransactionalEventListener` (AFTER_COMMIT)로 노드 쓰기 트랜잭션 커밋 이후 별도 트랜잭션에서 갱신합니다.

- `lastActivityAt`은 표시·정렬용 비중요 정보이므로 실패해도 노드 쓰기에 영향 없음
- 동시성 안전: `UPDATE ... WHERE last_activity_at IS NULL OR last_activity_at < :time` 조건부 UPDATE로 더 오래된 값이 덮어쓰는 역전 현상 방지

```java
@Transactional
@Modifying
@Query("""
        UPDATE Project p
        SET p.lastActivityAt = :time
        WHERE p.id = :id
          AND (p.lastActivityAt IS NULL OR p.lastActivityAt < :time)
        """)
void touchLastActivityAt(@Param("id") Long id, @Param("time") LocalDateTime time);
```

### 4. ProjectSummaryResponse 필드 교체

프로젝트 목록 응답의 `updatedAt`을 `lastActivityAt`으로 교체했습니다.

## 💬리뷰 요구사항(선택)

- 현재 Meeting 등 노드 외 연관 엔티티 변경은 `lastActivityAt`에 반영되지 않습니다. 범위 확장이 필요하면 해당 Facade에도 동일한 이벤트 발행을 추가하면 됩니다.
