### PR TITLE
[Feat/#284]프로젝트 목록/칸반/노드 사이드바 UX 개선

### DIFF
--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -447,85 +447,6 @@ export interface CreateEdgeRequest {
   comment?: string;
 }
 
-/** 채팅 세션 생성 요청 */
-export interface CreateChatSessionRequest {
-  /**
-   * 채팅 제목 (미입력 시 자동 생성)
-   * @example "기획 방향성 질문"
-   */
-  title?: string;
-  /**
-   * 참조할 노드 ID 목록
-   * @example [101,102]
-   */
-  nodeIds?: number[];
-}
-
-/** 공통 응답 형식 */
-export interface CommonResponseCreateChatSessionResponse {
-  /**
-   * HTTP 상태 코드
-   * @format int32
-   * @example 200
-   */
-  status?: number;
-  /**
-   * 응답 코드
-   * @example "OK"
-   */
-  code?: string;
-  /**
-   * 응답 메시지
-   * @example "요청에 성공했습니다."
-   */
-  message?: string;
-  /** 응답 데이터 */
-  data?: CreateChatSessionResponse;
-}
-
-/** 채팅 세션 생성 응답 */
-export interface CreateChatSessionResponse {
-  /**
-   * 채팅 세션 ID
-   * @format int64
-   * @example 301
-   */
-  chatSessionId?: number;
-  /**
-   * 채팅 제목
-   * @example "기획 방향성 질문"
-   */
-  title?: string;
-  /** 참조 노드 목록 */
-  referencedNodes?: ReferencedNodeResponse[];
-  /**
-   * 생성 시각
-   * @format date-time
-   * @example "2026-04-19T10:00:00"
-   */
-  createdAt?: string;
-}
-
-/** 참조 노드 정보 */
-export interface ReferencedNodeResponse {
-  /**
-   * 노드 ID
-   * @format int64
-   * @example 101
-   */
-  nodeId?: number;
-  /**
-   * 노드 번호
-   * @example "1.1"
-   */
-  number?: string;
-  /**
-   * 노드 제목
-   * @example "기획 문서 작성"
-   */
-  title?: string;
-}
-
 /** 참조 노드 추가 요청 */
 export interface AddChatNodeRequest {
   /**
@@ -568,6 +489,26 @@ export interface CommonResponseAddChatNodeResponse {
   message?: string;
   /** 응답 데이터 */
   data?: AddChatNodeResponse;
+}
+
+/** 참조 노드 정보 */
+export interface ReferencedNodeResponse {
+  /**
+   * 노드 ID
+   * @format int64
+   * @example 101
+   */
+  nodeId?: number;
+  /**
+   * 노드 번호
+   * @example "1.1"
+   */
+  number?: string;
+  /**
+   * 노드 제목
+   * @example "기획 문서 작성"
+   */
+  title?: string;
 }
 
 /** 메시지 전송 요청 */
@@ -631,6 +572,71 @@ export interface SendMessageResponse {
    * 생성 시각
    * @format date-time
    * @example "2026-04-19T10:05:00"
+   */
+  createdAt?: string;
+}
+
+/** 새 채팅 시작 요청 */
+export interface StartChatRequest {
+  /**
+   * 첫 메시지 내용
+   * @minLength 1
+   * @example "이 프로젝트 노드들을 정리해줘"
+   */
+  content: string;
+  /**
+   * 참조할 노드 ID 목록
+   * @example [101,102]
+   */
+  nodeIds?: number[];
+  /**
+   * 참조 사용자 ID 목록
+   * @example [3,4]
+   */
+  referenceUserIds?: number[];
+}
+
+/** 공통 응답 형식 */
+export interface CommonResponseStartChatResponse {
+  /**
+   * HTTP 상태 코드
+   * @format int32
+   * @example 200
+   */
+  status?: number;
+  /**
+   * 응답 코드
+   * @example "OK"
+   */
+  code?: string;
+  /**
+   * 응답 메시지
+   * @example "요청에 성공했습니다."
+   */
+  message?: string;
+  /** 응답 데이터 */
+  data?: StartChatResponse;
+}
+
+/** 새 채팅 시작 응답 */
+export interface StartChatResponse {
+  /**
+   * 채팅 세션 ID
+   * @format int64
+   * @example 301
+   */
+  chatSessionId?: number;
+  /**
+   * AI가 생성한 채팅 제목
+   * @example "프로젝트 노드 정리 요청"
+   */
+  title?: string;
+  /** AI 응답 메시지 */
+  aiResponse?: string;
+  /**
+   * 생성 시각
+   * @format date-time
+   * @example "2026-04-19T10:00:00"
    */
   createdAt?: string;
 }
@@ -1406,11 +1412,11 @@ export interface ProjectSummaryResponse {
    */
   memberCount?: number;
   /**
-   * 마지막 수정 시각
+   * 마지막 활동 시각
    * @format date-time
    * @example "2026-04-19T10:15:30"
    */
-  updatedAt?: string;
+  lastActivityAt?: string;
 }
 
 /** 공통 응답 형식 */
@@ -5309,116 +5315,6 @@ export class Api<
      * No description
      *
      * @tags Chat
-     * @name GetAllChatSessions
-     * @summary 채팅 세션 목록 조회
-     * @request GET:/v1/projects/{projectId}/chats
-     * @secure
-     */
-    getAllChatSessions: (
-      projectId: number,
-      query?: {
-        search?: string;
-        /** @format int64 */
-        cursorId?: number;
-        /**
-         * @format int32
-         * @default 20
-         */
-        size?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /**
-           * HTTP 상태 코드
-           * @format int32
-           * @example 200
-           */
-          status?: object;
-          /**
-           * 응답 코드
-           * @example "GET_ALL_CHAT_SESSIONS"
-           */
-          code?: object;
-          /**
-           * 응답 메시지
-           * @example "채팅 목록을 조회했어요."
-           */
-          message?: object;
-          /** 커서 기반 페이지 응답 */
-          data?: CursorSliceResponseChatSessionSummaryResponse;
-        },
-        {
-          /** @format int32 */
-          status?: number;
-          code?: string;
-          message?: string;
-          data?: object;
-        }
-      >({
-        path: `/v1/projects/${projectId}/chats`,
-        method: "GET",
-        query: query,
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Chat
-     * @name CreateChatSession
-     * @summary 새 채팅 세션 생성
-     * @request POST:/v1/projects/{projectId}/chats
-     * @secure
-     */
-    createChatSession: (
-      projectId: number,
-      data: CreateChatSessionRequest,
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /**
-           * HTTP 상태 코드
-           * @format int32
-           * @example 200
-           */
-          status?: object;
-          /**
-           * 응답 코드
-           * @example "CREATE_CHAT_SESSION"
-           */
-          code?: object;
-          /**
-           * 응답 메시지
-           * @example "새 채팅을 생성했어요."
-           */
-          message?: object;
-          /** 채팅 세션 생성 응답 */
-          data?: CreateChatSessionResponse;
-        },
-        {
-          /** @format int32 */
-          status?: number;
-          code?: string;
-          message?: string;
-          data?: object;
-        }
-      >({
-        path: `/v1/projects/${projectId}/chats`,
-        method: "POST",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Chat
      * @name AddChatNode
      * @summary 참조 노드 추가
      * @request POST:/v1/projects/{projectId}/chats/{chatSessionId}/nodes
@@ -5512,6 +5408,57 @@ export class Api<
         }
       >({
         path: `/v1/projects/${projectId}/chats/${chatSessionId}/messages`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Chat
+     * @name StartChat
+     * @summary 새 채팅 시작 (세션 생성 + 첫 메시지 전송)
+     * @request POST:/v1/projects/{projectId}/chats/new
+     * @secure
+     */
+    startChat: (
+      projectId: number,
+      data: StartChatRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /**
+           * HTTP 상태 코드
+           * @format int32
+           * @example 200
+           */
+          status?: object;
+          /**
+           * 응답 코드
+           * @example "START_CHAT"
+           */
+          code?: object;
+          /**
+           * 응답 메시지
+           * @example "새 채팅을 시작했어요."
+           */
+          message?: object;
+          /** 새 채팅 시작 응답 */
+          data?: StartChatResponse;
+        },
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/chats/new`,
         method: "POST",
         body: data,
         secure: true,
@@ -5676,6 +5623,65 @@ export class Api<
         body: data,
         secure: true,
         type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Chat
+     * @name GetAllChatSessions
+     * @summary 채팅 세션 목록 조회
+     * @request GET:/v1/projects/{projectId}/chats
+     * @secure
+     */
+    getAllChatSessions: (
+      projectId: number,
+      query?: {
+        search?: string;
+        /** @format int64 */
+        cursorId?: number;
+        /**
+         * @format int32
+         * @default 20
+         */
+        size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /**
+           * HTTP 상태 코드
+           * @format int32
+           * @example 200
+           */
+          status?: object;
+          /**
+           * 응답 코드
+           * @example "GET_ALL_CHAT_SESSIONS"
+           */
+          code?: object;
+          /**
+           * 응답 메시지
+           * @example "채팅 목록을 조회했어요."
+           */
+          message?: object;
+          /** 커서 기반 페이지 응답 */
+          data?: CursorSliceResponseChatSessionSummaryResponse;
+        },
+        {
+          /** @format int32 */
+          status?: number;
+          code?: string;
+          message?: string;
+          data?: object;
+        }
+      >({
+        path: `/v1/projects/${projectId}/chats`,
+        method: "GET",
+        query: query,
+        secure: true,
         ...params,
       }),
 
@@ -6721,10 +6727,17 @@ export class Api<
      * @request GET:/v1/notifications/subscribe
      * @secure
      */
-    subscribe: (params: RequestParams = {}) =>
+    subscribe: (
+      query: {
+        /** @format int64 */
+        projectId: number;
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<SseEmitter, any>({
         path: `/v1/notifications/subscribe`,
         method: "GET",
+        query: query,
         secure: true,
         ...params,
       }),

--- a/frontend/src/components/commons/user/UserAvatarGroup.tsx
+++ b/frontend/src/components/commons/user/UserAvatarGroup.tsx
@@ -11,9 +11,8 @@ import {
 
 import { normalizeImageUrl } from '@/utils/normalizeImageUrl';
 
-const IMAGE_AVATAR_SX = (theme: Theme) => ({
-  backgroundColor: theme.semantic.background.normal.normal,
-  padding: '1px',
+const IMAGE_AVATAR_SX = (_theme: Theme) => ({
+  padding: '0',
 });
 
 export interface UserInfo {

--- a/frontend/src/components/node-datail/NodeSidebar.tsx
+++ b/frontend/src/components/node-datail/NodeSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { IconButton } from '@wanteddev/wds';
-import { IconFull } from '@wanteddev/wds-icon';
+import { IconChevronDoubleRight, IconFull } from '@wanteddev/wds-icon';
 import Link from 'next/link';
 import { useEffect, useState, useCallback, useSyncExternalStore } from 'react';
 import { YjsProvider, useSetActiveAwarenessNode } from '@/contexts/YjsContext';
@@ -30,9 +30,11 @@ export function NodeSidebar({ nodeId, projectId, onClose }: NodeSidebarProps) {
   );
 
   const [value, setValue] = useState('note');
+  const [isClosing, setIsClosing] = useState(false);
 
   useEffect(() => {
     if (nodeId) {
+      setIsClosing(false);
       sessionStorage.setItem(SESSION_KEY, nodeId.toString());
       setSidebarState(true);
     }
@@ -46,10 +48,16 @@ export function NodeSidebar({ nodeId, projectId, onClose }: NodeSidebarProps) {
   useSetActiveAwarenessNode(awarenessNodeId);
 
   const handleClose = useCallback(() => {
-    sessionStorage.removeItem(SESSION_KEY);
-    setSidebarState(false);
-    onClose();
-  }, [onClose]);
+    setIsClosing(true);
+  }, []);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (isClosing) {
+      sessionStorage.removeItem(SESSION_KEY);
+      setSidebarState(false);
+      onClose();
+    }
+  }, [isClosing, onClose]);
 
   if (!isOpen || !activeNodeId || !Number.isFinite(numericNodeId)) return null;
 
@@ -60,20 +68,28 @@ export function NodeSidebar({ nodeId, projectId, onClose }: NodeSidebarProps) {
       <div className="fixed inset-0 z-30" onClick={handleClose} aria-hidden="true" />
 
       {/* 사이드바 */}
-      {/* TODO : 지금 열릴 때만 애니메이션 적용됨 - 추후 닫힐 때 애니메이션 구현 */}
       {/* TODO : z-index 한 번에 관리할 수 있도록 정리 */}
       <aside
-        className="animate-slide-in fixed top-0 right-0 z-90 flex h-full w-2/5 flex-col border-l border-white bg-white"
+        className={`fixed top-0 right-0 z-90 flex h-full w-2/5 flex-col border-l border-white bg-white ${isClosing ? 'animate-slide-out' : 'animate-slide-in'}`}
         onClick={(e) => e.stopPropagation()}
+        onAnimationEnd={handleAnimationEnd}
       >
         {/* TODO : 전체 페이지의 경우 페이지 닫는 아이콘으로 변경 필요 */}
         {/* TODO : 사이드바 닫는 아이콘 필요 */}
-        <div className="absolute -scale-x-100 p-3">
+        <div className="absolute left-3 top-3 flex items-center gap-3">
+          <IconButton
+            color="semantic.label.alternative"
+            onClick={handleClose}
+            size={20}
+            aria-label="사이드바 접기"
+          >
+            <IconChevronDoubleRight />
+          </IconButton>
           <IconButton
             color="semantic.label.alternative"
             href={`/projects/${projectId}/nodes/${activeNodeId}/${value}`}
             onClick={handleClose}
-            size={16}
+            size={20}
             aria-label="전체화면 보기"
             as={Link}
           >

--- a/frontend/src/components/projects/kanban/KanbanColumn.tsx
+++ b/frontend/src/components/projects/kanban/KanbanColumn.tsx
@@ -24,10 +24,10 @@ export function KanbanColumn({ status, nodes, onNodeDoubleClick }: KanbanColumnP
   const nodeIds = validNodes.map((node) => node.nodeId);
 
   return (
-    <div className="flex flex-col flex-1 min-w-0 h-full">
+    <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
       <div
         className={clsx(
-          'flex-1 min-h-0 bg-line-normal-alternative rounded-xl flex flex-col',
+          'bg-line-normal-alternative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl',
           status === 'WAITING' && 'border-t-4 border-t-neutral-400',
           status === 'IN_PROGRESS' && 'border-t-4 border-t-orange-500',
           status === 'DONE' && 'border-t-4 border-t-green-500'
@@ -48,7 +48,7 @@ export function KanbanColumn({ status, nodes, onNodeDoubleClick }: KanbanColumnP
         <SortableContext id={status} items={nodeIds} strategy={verticalListSortingStrategy}>
           <div
             ref={setNodeRef}
-            className="flex-1 min-h-0 overflow-y-auto pr-6 pb-3 pl-3 flex flex-col gap-2.5 mt-2.5"
+            className="custom-scrollbar mt-2.5 flex min-h-0 flex-1 flex-col gap-2.5 overflow-x-hidden overflow-y-auto pr-6 pb-3 pl-3"
           >
             {validNodes.map((node) => (
               <NodeCard

--- a/frontend/src/components/projects/kanban/KanbanView.tsx
+++ b/frontend/src/components/projects/kanban/KanbanView.tsx
@@ -84,9 +84,14 @@ export function KanbanView({ projectId }: KanbanViewProps) {
   }
 
   return (
-    <DndContext sensors={sensors} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
-      <div className="flex-1 h-full w-full p-10 bg-surface-canvas">
-        <div className="flex gap-2.5 h-full">
+    <DndContext
+      sensors={sensors}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      autoScroll={{ threshold: { x: 0, y: 0.2 } }}
+    >
+      <div className="bg-surface-canvas h-full w-full flex-1 overflow-hidden p-10">
+        <div className="flex h-full gap-2.5 overflow-hidden">
           {KANBAN_STATUSES.map((status) => (
             <KanbanColumn
               key={status}

--- a/frontend/src/components/projects/kanban/NodeCard.tsx
+++ b/frontend/src/components/projects/kanban/NodeCard.tsx
@@ -40,7 +40,7 @@ export function NodeCard({
   });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
@@ -49,12 +49,12 @@ export function NodeCard({
     <div
       ref={setNodeRef}
       style={style}
-      className="self-stretch p-4 bg-white rounded-lg border border-neutral-200 flex flex-col cursor-pointer hover:shadow-sm transition-shadow select-none"
+      className="flex min-w-0 cursor-pointer select-none flex-col self-stretch rounded-lg border border-neutral-200 bg-white p-4 transition-shadow hover:shadow-sm"
       onClick={onClick}
       onDoubleClick={onDoubleClick}
     >
-      <div className="self-stretch flex justify-between items-center">
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between self-stretch">
+        <div className="flex min-w-0 items-center gap-2">
           {isMainNode ? (
             <ContentBadge
               className="!bg-primary-40/10 !text-primary-40"
@@ -90,7 +90,7 @@ export function NodeCard({
               </span>
             </ContentBadge>
           )}
-          <div className="text-caption-2 text-label-alternative font-normal">
+          <div className="text-caption-2 text-label-alternative shrink-0 font-normal">
             {date}
           </div>
         </div>
@@ -104,12 +104,12 @@ export function NodeCard({
         </div>
       </div>
 
-      <div className="self-stretch mt-1">
-        <div className="text-body-1 font-medium">{title}</div>
+      <div className="mt-1 min-w-0 self-stretch">
+        <div className="text-body-1 truncate font-medium">{title}</div>
       </div>
 
       {tags.length > 0 && (
-        <div className="self-stretch flex flex-wrap gap-1 mt-3">
+        <div className="mt-3 flex min-w-0 flex-wrap gap-1 self-stretch overflow-hidden">
           {visibleTags.map((tag) => (
             <ContentBadge
               key={tag.tagId}

--- a/frontend/src/components/projects/project-list/ProjectListPage.tsx
+++ b/frontend/src/components/projects/project-list/ProjectListPage.tsx
@@ -2,7 +2,6 @@
 
 import {
   Avatar,
-  AvatarGroup,
   Button,
   Menu,
   MenuContent,
@@ -11,16 +10,29 @@ import {
   MenuTrigger,
   TextField,
   TextFieldContent,
-  Typography,
 } from '@wanteddev/wds';
 import { IconChevronDownThickSmall, IconSearchThick } from '@wanteddev/wds-icon';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { ProjectSidebar } from '@/components/commons/project-sidebar/ProjectSidebar';
+import { Users } from '@/components/commons/user/UserAvatarGroup';
+import { useProjectMembersQuery } from '@/queries/member';
 import { useCreateProjectMutation, useProjectListQuery } from '@/queries/project';
 
 type SortType = 'LATEST' | 'NAME';
+
+function ProjectMemberAvatars({ projectId }: { projectId: number }) {
+  const { data: members = [] } = useProjectMembersQuery(projectId);
+  const users = members.map((m) => ({
+    userId: m.userId,
+    nickname: m.nickname,
+    email: m.email,
+    profileImageUrl: m.profileImageUrl,
+  }));
+  if (users.length === 0) return null;
+  return <Users users={users} maxVisible={3} compact={false} size="xsmall" />;
+}
 
 const SORT_OPTIONS: { label: string; value: SortType }[] = [
   { label: '최신순', value: 'LATEST' },
@@ -130,7 +142,7 @@ export const ProjectListPage = () => {
         </div>
 
         {/* Project list */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="bg-surface-canvas flex-1 overflow-y-auto">
           {isLoading && (
             <p className="text-body-2 text-label-assistive py-12 text-center">불러오는 중...</p>
           )}
@@ -144,18 +156,14 @@ export const ProjectListPage = () => {
           )}
 
           {projects.length > 0 && (
-            <ul>
+            <ul className="bg-surface-canvas">
               {projects.map((project) => {
-                const memberCount = project.memberCount ?? 0;
-                const visibleAvatars = Math.min(memberCount, 3);
-                const extraCount = Math.max(0, memberCount - visibleAvatars);
-
                 return (
-                  <li key={project.projectId} className="border-line-normal-neutral border-b">
+                  <li key={project.projectId} className="border-line-normal-neutral bg-surface-canvas border-b">
                     <button
                       type="button"
                       onClick={() => router.push(`/projects/${project.projectId}`)}
-                      className="hover:bg-fill-alternative flex w-full items-center gap-4 px-6 py-5 text-left transition-colors"
+                      className="bg-surface-canvas hover:bg-fill-alternative flex w-full items-center gap-4 px-6 py-5 text-left transition-colors"
                     >
                       {/* Project icon */}
                       <div className="shrink-0 overflow-hidden rounded-xl">
@@ -172,23 +180,14 @@ export const ProjectListPage = () => {
                         <span className="text-label-1 text-label-normal truncate font-semibold">
                           {project.name}
                         </span>
-                        <span className="text-caption-1 text-label-assistive font-normal">
-                          최종 수정일 {formatDate(project.updatedAt)}
+                        <span className="text-caption-1 text-label-alternative font-normal">
+                          최근 활동 {formatDate(project.lastActivityAt)}
                         </span>
                       </div>
 
                       {/* Members */}
                       <div className="flex shrink-0 items-center gap-2">
-                        {visibleAvatars > 0 && (
-                          <AvatarGroup size="xsmall">
-                            {Array.from({ length: visibleAvatars }).map((_, i) => (
-                              <Avatar key={i} variant="person" size="xsmall" />
-                            ))}
-                          </AvatarGroup>
-                        )}
-                        <Typography variant="label1" color="semantic.label.alternative">
-                          외 {extraCount}명
-                        </Typography>
+                        <ProjectMemberAvatars projectId={project.projectId} />
                       </div>
                     </button>
                   </li>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -421,7 +421,7 @@ body {
 @theme {
   /* 애니메이션 변수 정의 */
   --animate-slide-in: slide-in 0.22s cubic-bezier(0.32, 0.72, 0, 1);
-  --animate-slide-out: slide-out 0.22s cubic-bezier(0.32, 0.72, 0, 1);
+  --animate-slide-out: slide-out 0.22s cubic-bezier(0.32, 0.72, 0, 1) forwards;
 
   /* 키프레임 정의 */
   @keyframes slide-in {


### PR DESCRIPTION
## #️⃣연관된 이슈
#284 

## 📝작업 내용
프로젝트 목록/칸반/노드 사이드바 UX 개선

### 스크린샷 (선택)
<img width="495" height="423" alt="스크린샷 2026-05-21 오후 9 41 17" src="https://github.com/user-attachments/assets/c6fdfd47-43a4-4a42-b7f5-f209bc811916" />
<img width="1710" height="1016" alt="스크린샷 2026-05-21 오후 9 41 54" src="https://github.com/user-attachments/assets/376ec241-640e-42fa-9ffd-f6d26b2f97b8" />
<img width="1710" height="1107" alt="스크린샷 2026-05-21 오후 9 40 58" src="https://github.com/user-attachments/assets/e2569601-719a-4ced-8a55-6e30e228b455" />

## 💬리뷰 요구사항(선택)
나를봐줘
