### PR TITLE
[Fix/#290] awareness 유저 중복 노출 수정

### DIFF
--- a/frontend/src/contexts/YjsContext.tsx
+++ b/frontend/src/contexts/YjsContext.tsx
@@ -141,14 +141,42 @@ function useAwarenessUsersFromContext(
     const { provider } = yjsCtx;
 
     const updateUsers = () => {
-      const result: YjsAwarenessState['user'][] = [];
+      // 같은 유저가 새로고침/다중 탭 등으로 여러 awareness 엔트리를 갖는 경우가 있어
+      // 실제 유저 식별자(email) 기준으로 dedupe 한다.
+      // - 로컬 클라이언트 엔트리는 항상 우선 (새로고침 직후 자신의 stale 엔트리 덮어쓰기)
+      // - 그 외에는 `awareness.meta.lastUpdated`가 더 큰(최근) 엔트리 우선
+      //   (서버가 stale 엔트리를 정리하기 전에도 stale activeNodeId 등이 노출되지 않도록)
+      const localClientId = provider.awareness.clientID;
+      const meta = provider.awareness.meta;
+      const byEmail = new Map<
+        string,
+        { user: YjsAwarenessState['user']; lastUpdated: number; isLocal: boolean }
+      >();
+
       provider.awareness.getStates().forEach((state, clientId) => {
         const s = state as Partial<YjsAwarenessState>;
-        if (s.user?.nickname) {
-          result.push({ ...s.user, userId: clientId });
+        if (!s.user?.nickname) return;
+
+        const user = { ...s.user, userId: clientId };
+        const key = s.user.email || `__client_${clientId}`;
+        const isLocal = clientId === localClientId;
+        const lastUpdated = meta.get(clientId)?.lastUpdated ?? 0;
+
+        const existing = byEmail.get(key);
+        if (!existing) {
+          byEmail.set(key, { user, lastUpdated, isLocal });
+          return;
+        }
+        if (isLocal && !existing.isLocal) {
+          byEmail.set(key, { user, lastUpdated, isLocal });
+          return;
+        }
+        if (!existing.isLocal && lastUpdated > existing.lastUpdated) {
+          byEmail.set(key, { user, lastUpdated, isLocal });
         }
       });
-      setUsers(result);
+
+      setUsers(Array.from(byEmail.values()).map((v) => v.user));
     };
 
     updateUsers();


### PR DESCRIPTION
## #️⃣연관된 이슈
#290 

## 📝작업 내용
새로고침/다중 탭 등으로 같은 유저의 stale awareness 엔트리가 서버 정리(30초) 전까지 남아있어, 프로젝트 헤더 온라인 유저 영역과 노드 보고있는 유저 영역에 같은 유저가 중복 표시되던 문제를 수정했습니다.

- email 기준 dedupe: `clientID`는 WebSocket 연결마다 새로 발급되어 유저 식별자로 부적합. 실제 유저 식별자인 `email`을 키로 dedupe
- 로컬 클라이언트 우선: 새로고침 직후 자신의 stale 엔트리가 남아있어도 본인의 최신 상태로 덮어쓰기
- lastUpdated 우선: 그 외 중복은 `awareness.meta.lastUpdated`가 더 큰(최근) 엔트리 우선 → stale `activeNodeId`로 잘못된 노드에 본인이 노출되는 것 방지


### 스크린샷 (선택)
<img width="129" height="54" alt="스크린샷 2026-05-21 오후 10 37 38" src="https://github.com/user-attachments/assets/29e6ea55-739e-497f-80b1-9eaf6fcff3f7" />

## 💬리뷰 요구사항(선택)
테스트해주세여
