### PR TITLE
[Feat/#297] 인증 페이지 UI 개선 및 노드 상세/삭제 UX 보강

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -20,8 +20,8 @@ export default function LoginPage() {
 
   return (
     <main className="flex min-h-screen">
-      {/* 왼쪽 1/3 */}
-      <div className="w-1/3">
+      {/* 왼쪽 영상 영역 */}
+      <div className="w-1/2">
         <video
           autoPlay
           loop
@@ -34,7 +34,17 @@ export default function LoginPage() {
         </video>
       </div>
 
-      <div className="flex w-2/3 items-start justify-center pt-[35vh]">
+      <div className="relative flex w-1/2 items-start justify-center pt-[35vh]">
+        {/* 랜딩페이지로 이동하는 로고 */}
+        <Link
+          href="https://kookmin-sw.github.io/2026-capstone-09/#top"
+          aria-label="flowMeet 홈으로 이동"
+          className="absolute top-8 left-8 transition-transform hover:scale-[1.03]"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/flowmeet-logo.svg" alt="flowMeet" className="h-8 w-auto" />
+        </Link>
+
         <div className="flex flex-col gap-8">
           <div className="inline-flex items-start justify-start overflow-hidden">
             <h1 className="text-title-1 font-bold">로그인</h1>

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { FormField, FormLabel, FormControl, TextField, Button } from '@wanteddev/wds';
+import { FormField, FormLabel, FormControl, IconButton, TextField, Button } from '@wanteddev/wds';
 import type { Theme } from '@wanteddev/wds-engine';
+import { IconChevronLeft } from '@wanteddev/wds-icon';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect, useMemo } from 'react';
 import { EmailVerificationFields } from '@/components/auth/EmailVerificationFields';
@@ -109,8 +110,8 @@ export default function SignupPage() {
           box-shadow: inset 0 0 0 2px #04E6A2 !important;
         }
       `}</style>
-      {/* 왼쪽 1/3 */}
-      <div className="w-1/3">
+      {/* 왼쪽 영상 영역 */}
+      <div className="w-1/2">
         <video
           autoPlay
           loop
@@ -123,7 +124,19 @@ export default function SignupPage() {
         </video>
       </div>
 
-      <div className="flex w-2/3 items-center justify-center">
+      <div className="relative flex w-1/2 items-center justify-center">
+        {/* 뒤로가기 (로그인 페이지로 이동) */}
+        <div className="absolute top-8 left-8">
+          <IconButton
+            color="semantic.label.alternative"
+            onClick={() => router.replace('/auth/login')}
+            size={28}
+            aria-label="로그인 페이지로 이동"
+          >
+            <IconChevronLeft />
+          </IconButton>
+        </div>
+
         <div className="flex flex-col gap-8">
           <div className="inline-flex items-start justify-start overflow-hidden">
             <h1 className="text-title-1 font-bold">회원가입</h1>

--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -96,8 +96,8 @@ export function NodeDetailLayout({
       : 'sub-without-meeting';
 
   return (
-    <div className="flex h-full flex-col overflow-y-scroll [&::-webkit-scrollbar]:hidden">
-      <div className="flex items-center justify-between pt-1">
+    <div className="flex h-full flex-col overflow-x-hidden overflow-y-scroll [&::-webkit-scrollbar]:hidden">
+      <div className="flex items-center justify-between pt-1 pr-2">
         {nodeDetail?.parentId ? (
           <ContentBadge color="neutral" size="xsmall" variant="outlined">
             #{nodeDetail?.number}
@@ -112,8 +112,8 @@ export function NodeDetailLayout({
           </ContentBadge>
         )}
 
-        <div className="flex items-center gap-1 py-0.5">
-          <Users users={activeUsers} />
+        <div className="flex items-center gap-3 py-0.5">
+          <Users users={activeUsers} size="xsmall" />
           <NodeMenu
             variant={menuVariant}
             position="bottom-end"

--- a/frontend/src/components/projects/node-flow/CustomNode.tsx
+++ b/frontend/src/components/projects/node-flow/CustomNode.tsx
@@ -198,8 +198,8 @@ function CustomFlowNodeComponent({ data, selected }: NodeProps<CustomNodeData>) 
         </div>
 
         {activeUsers.length > 0 && (
-          <div className="shrink-0">
-            <Users users={activeUsers} maxVisible={2} compact />
+          <div className="shrink-0 -my-1.5 origin-right scale-75">
+            <Users users={activeUsers} maxVisible={2} compact size="xsmall" />
           </div>
         )}
       </div>

--- a/frontend/src/components/projects/project-detail/node-delete/NodeDeleteConfirmContent.tsx
+++ b/frontend/src/components/projects/project-detail/node-delete/NodeDeleteConfirmContent.tsx
@@ -62,18 +62,24 @@ export const NodeDeleteConfirmContent = ({
       </div>
 
       <p className="text-body-2 text-label-alternative whitespace-pre-line">
-        노드를 삭제하시면 복구할 수 없으며, 모든 정보가 영구적으로 사라져요. 계속 진행하려면 노드
-        이름을 입력해 주세요.
+        노드를 삭제하시면 복구할 수 없으며, 모든 정보가 영구적으로 사라져요. 계속 진행하려면 아래
+        노드 이름을 입력해 주세요.
       </p>
 
-      <TextField
-        id="node-delete-confirm-name"
-        value={nameInput}
-        onChange={(event) => setNameInput(event.target.value)}
-        placeholder={nodeName}
-        width="100%"
-        invalid={isInvalid}
-      />
+      <div className="flex flex-col gap-2">
+        <p className="text-label-2 text-label-alternative font-normal">
+          삭제할 노드:{' '}
+          <span className="text-label-normal font-semibold break-all">{nodeName}</span>
+        </p>
+        <TextField
+          id="node-delete-confirm-name"
+          value={nameInput}
+          onChange={(event) => setNameInput(event.target.value)}
+          placeholder={nodeName}
+          width="100%"
+          invalid={isInvalid}
+        />
+      </div>
 
       <button
         type="button"


### PR DESCRIPTION
## #️⃣연관된 이슈
#297 

## 📝작업 내용
인증 페이지 UI 개선과 노드 상세/삭제 모달 UX 보강 작업입니다.

### 인증 페이지
- 로그인/회원가입의 좌측 영상 영역 너비를 1/3 → 1/2로 확대
- 로그인 페이지 좌상단에 flowMeet 로고 + 텍스트 추가, 클릭 시 랜딩 페이지(`https://kookmin-sw.github.io/2026-capstone-09/#top`)로 이동
- 회원가입 페이지 좌상단에 뒤로가기 버튼 추가, 클릭 시 로그인 페이지로 이동

### 노드 사이드바
- 사이드바 내부 가로 스크롤 방지 (`overflow-y-scroll` → `overflow-x-hidden`까지 명시)
- 헤더 우측 `...` 메뉴 버튼의 호버 원이 스크롤 컨테이너에 잘리지 않도록 우측 패딩 추가
- 헤더에 표시되는 "노드 보고있는 유저" 아바타 크기 축소 (`small` → `xsmall`) 및 NodeMenu와의 간격 확대 (`gap-1` → `gap-3`)

### 노드 플로우 카드 (CustomNode)
- 노드 카드 우하단의 active 유저 아바타 크기 축소 (`scale-75` 적용)
- 음수 margin(`-my-1.5`)으로 아바타 layout box가 row 높이를 늘리지 않도록 처리

### 노드 삭제 모달
- 입력 필드 위에 삭제 대상 노드 이름을 명시적으로 표시 (placeholder뿐 아니라 본문에서도 확인 가능)

### 스크린샷 (선택)
<img width="1709" height="1010" alt="스크린샷 2026-05-21 오후 11 31 48" src="https://github.com/user-attachments/assets/c69a9d60-5cab-4466-a801-e7bc9636a5bf" />
<img width="444" height="368" alt="스크린샷 2026-05-21 오후 11 32 23" src="https://github.com/user-attachments/assets/40bc2df2-826d-44b0-baaf-6687391ec09c" />
<img width="280" height="154" alt="스크린샷 2026-05-21 오후 11 32 32" src="https://github.com/user-attachments/assets/89cc8180-015b-4f71-bc00-cfa7c903a43f" />


## 💬리뷰 요구사항(선택)
