### PR TITLE
[Fix/#310] 플로우차트 뷰포트 위치 refetch 후 유지하도록 수정

### DIFF
--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -124,6 +124,21 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     localStorage.setItem('showDashedLines', JSON.stringify(showDashedLines));
   }, [showDashedLines]);
 
+  // 뷰포트 위치 복원 (refetch 후에도 마지막 위치 유지)
+  useEffect(() => {
+    const saved = localStorage.getItem(`flowchart_viewport_${projectId}`);
+    if (saved) {
+      try {
+        const viewport = JSON.parse(saved);
+        requestAnimationFrame(() => {
+          setViewport(viewport, { duration: 0 });
+        });
+      } catch {
+        // JSON 파싱 실패 시 무시
+      }
+    }
+  }, [projectId, setViewport]);
+
   // 알림 클릭으로 넘어온 openNode param 처리
   useEffect(() => {
     const openNodeParam = searchParams.get('openNode');
@@ -410,6 +425,9 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
         onNodeMouseEnter={onNodeMouseEnter}
         onPaneClick={clearSelection}
         onSelectionChange={onSelectionChange}
+        onMove={(_event, viewport) => {
+          localStorage.setItem(`flowchart_viewport_${projectId}`, JSON.stringify(viewport));
+        }}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         nodesDraggable={false}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#310 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

플로우차트에서 refetch 발생 시(AI 응답, 새로고침 등) 뷰포트 위치가 defaultViewport로 리셋되는 문제 수정했습니다.

- localStorage에 `flowchart_viewport_${projectId}` 키로 저장
- 컴포넌트 마운트 시 localStorage에서 저장된 위치 로드
- `requestAnimationFrame`으로 ReactFlow 렌더링 완료 후 복원


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
