### PR TITLE
[Feat/#313] 프로젝트 목록 뷰 및 다중 노드 요약 로딩 UI 개선

### DIFF
--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -43,6 +43,16 @@ interface NodeFlowViewProps {
   projectId: number;
 }
 
+const SUMMARY_LOADING_MESSAGES = [
+  '선택한 노드를 모으고 있어요',
+  'AI가 회의 내용을 분석하고 있어요',
+  '회의 간 관계를 정리하고 있어요',
+  '액션 아이템을 추출하고 있어요',
+  '거의 다 됐어요, 잠시만 기다려 주세요',
+];
+
+const SUMMARY_MESSAGE_INTERVAL_MS = 3000;
+
 const nodeTypes: NodeTypes = {
   mainNode: CustomNode,
   subNode: CustomNode,
@@ -69,6 +79,20 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const [showDashedLines, setShowDashedLines] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
+  const [summaryMessageIndex, setSummaryMessageIndex] = useState(0);
+
+  useEffect(() => {
+    if (!isSummaryPending) {
+      setSummaryMessageIndex(0);
+      return;
+    }
+    const interval = setInterval(() => {
+      setSummaryMessageIndex((prev) =>
+        Math.min(prev + 1, SUMMARY_LOADING_MESSAGES.length - 1),
+      );
+    }, SUMMARY_MESSAGE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isSummaryPending]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -461,11 +485,20 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
       </ReactFlow>
 
       {isSummaryPending && (
-        <div className="fixed inset-0 z-9998 flex items-center justify-center bg-material-dimmer">
-          <div
-            className="h-12 w-12 animate-spin rounded-full border-4 border-primary-90 border-t-primary-40"
-            aria-label="AI 요약 생성 중"
-          />
+        <div
+          className="fixed inset-0 z-9998 flex items-center justify-center bg-material-dimmer"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex flex-col items-center gap-4">
+            <div
+              className="h-12 w-12 animate-spin rounded-full border-4 border-primary-90 border-t-primary-40"
+              aria-label="AI 요약 생성 중"
+            />
+            <span className="text-body-1 text-static-white font-medium">
+              {SUMMARY_LOADING_MESSAGES[summaryMessageIndex]}
+            </span>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/projects/project-list/ProjectListPage.tsx
+++ b/frontend/src/components/projects/project-list/ProjectListPage.tsx
@@ -89,56 +89,61 @@ export const ProjectListPage = () => {
 
       <main className="bg-surface-canvas flex h-full flex-1 flex-col overflow-hidden">
         {/* Toolbar */}
-        <div className="flex items-center gap-3 px-6 py-4">
-          <Menu
-            value={[sort]}
-            onValueChange={(vals) => {
-              if (!vals) return;
-              const next = vals[vals.length - 1] as SortType | undefined;
-              if (next) setSort(next);
-            }}
-          >
-            <MenuTrigger>
-              <button
-                type="button"
-                className="border-line-normal-neutral bg-static-white text-body-2 text-label-normal hover:bg-fill-alternative flex h-10 shrink-0 items-center gap-1.5 rounded-xl border px-3 transition-colors"
-              >
-                {currentSortLabel}
-                <IconChevronDownThickSmall
-                  className="text-label-assistive h-4 w-4"
-                  aria-hidden="true"
-                />
-              </button>
-            </MenuTrigger>
-            <MenuContent offset={4} position="bottom-start" sx={{ minWidth: '8rem' }}>
-              <MenuList>
-                {SORT_OPTIONS.map((opt) => (
-                  <MenuItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </MenuItem>
-                ))}
-              </MenuList>
-            </MenuContent>
-          </Menu>
+        <div className="px-10 py-10">
+          <div className="flex items-center gap-3 px-6">
+            <Menu
+              value={[sort]}
+              onValueChange={(vals) => {
+                if (!vals) return;
+                const next = vals[vals.length - 1] as SortType | undefined;
+                if (next) setSort(next);
+              }}
+            >
+              <MenuTrigger>
+                <button
+                  type="button"
+                  className="border-line-normal-neutral bg-static-white text-body-2 text-label-normal hover:bg-fill-alternative flex h-10 shrink-0 items-center gap-1.5 rounded-xl border px-3 transition-colors"
+                >
+                  {currentSortLabel}
+                  <IconChevronDownThickSmall
+                    className="text-label-assistive h-4 w-4"
+                    aria-hidden="true"
+                  />
+                </button>
+              </MenuTrigger>
+              <MenuContent offset={4} position="bottom-start" sx={{ minWidth: '8rem' }}>
+                <MenuList>
+                  {SORT_OPTIONS.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </MenuContent>
+            </Menu>
 
-          <div className="flex-1">
-            <TextField
-              id="project-search"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="프로젝트 검색"
-              width="100%"
-              leadingContent={
-                <TextFieldContent variant="icon">
-                  <IconSearchThick className="text-label-alternative h-5 w-5" aria-hidden="true" />
-                </TextFieldContent>
-              }
-            />
+            <div className="flex-1">
+              <TextField
+                id="project-search"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="프로젝트 검색"
+                width="100%"
+                leadingContent={
+                  <TextFieldContent variant="icon">
+                    <IconSearchThick
+                      className="text-label-alternative h-5 w-5"
+                      aria-hidden="true"
+                    />
+                  </TextFieldContent>
+                }
+              />
+            </div>
+
+            <Button onClick={handleNewProject} disabled={createMutation.isPending}>
+              {createMutation.isPending ? '생성 중...' : '새 프로젝트'}
+            </Button>
           </div>
-
-          <Button onClick={handleNewProject} disabled={createMutation.isPending}>
-            {createMutation.isPending ? '생성 중...' : '새 프로젝트'}
-          </Button>
         </div>
 
         {/* Project list */}
@@ -156,17 +161,14 @@ export const ProjectListPage = () => {
           )}
 
           {projects.length > 0 && (
-            <ul className="bg-surface-canvas">
+            <ul className="bg-surface-canvas px-10">
               {projects.map((project) => {
                 return (
-                  <li
-                    key={project.projectId}
-                    className="border-line-normal-neutral bg-surface-canvas border-b"
-                  >
+                  <li key={project.projectId} className="bg-surface-canvas">
                     <button
                       type="button"
                       onClick={() => router.push(`/projects/${project.projectId}`)}
-                      className="bg-surface-canvas hover:bg-fill-alternative flex w-full items-center gap-4 px-6 py-5 text-left transition-colors"
+                      className="bg-surface-canvas hover:bg-fill-alternative flex w-full items-center gap-4 px-6 py-5 text-left transition-colors hover:rounded-xl"
                     >
                       {/* Project icon */}
                       <div className="shrink-0 overflow-hidden rounded-xl">


### PR DESCRIPTION
## #️⃣연관된 이슈
#313 

## 📝작업 내용
- 프로젝트 목록 뷰 UI 수정
- 다중 노드 AI 요약 로딩 화면 하단에 진행 멘트 추가
- 3초 간격으로 5단계 멘트 순차 표시
  1. 선택한 노드를 모으고 있어요
  2. AI가 회의 내용을 분석하고 있어요
  3. 회의 간 관계를 정리하고 있어요
  4. 액션 아이템을 추출하고 있어요
  5. 거의 다 됐어요, 잠시만 기다려 주세요

### 스크린샷 (선택)
<img width="1710" height="1107" alt="스크린샷 2026-05-25 오전 10 51 53" src="https://github.com/user-attachments/assets/4de7c049-4b32-44b4-9d8c-49c2188daddb" />
<img width="1710" height="1107" alt="스크린샷 2026-05-25 오전 10 52 05" src="https://github.com/user-attachments/assets/a305ca8f-dead-4930-b9d9-740d2cd8f098" />

