### PR TITLE
[Fix/#324] 알림 설정 토글 false 깜빡임 수정

### DIFF
--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -17,7 +17,7 @@ import { authStorage } from '@/api/authStorage';
 import { userStorage } from '@/api/userStorage';
 import { useModal } from '@/components/commons/modal/ModalContext';
 import { notificationKeys } from '@/queries/keys/notificationKeys';
-import { useUnreadCountQuery } from '@/queries/notification';
+import { prefetchNotificationSetting, useUnreadCountQuery } from '@/queries/notification';
 import { useProjectListQuery, useProjectQuery } from '@/queries/project';
 import { useCurrentUserQuery } from '@/queries/user';
 import { cn } from '@/utils/cn';
@@ -219,6 +219,8 @@ export const ProjectSidebar = ({
     setIsProjectMenuOpen(false);
     onSettingClick?.();
     if (!isProjectIdValid || projectId === undefined) return;
+    // 알림 탭 토글 깜빡임 방지를 위해 모달 열기 전에 알림 설정을 미리 받아둔다.
+    void prefetchNotificationSetting(queryClient, projectId);
     openModal({
       variant: 'default',
       closeOnBackdrop: true,

--- a/frontend/src/components/commons/project-sidebar/setting-modal/useProjectNotificationsForm.ts
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/useProjectNotificationsForm.ts
@@ -1,7 +1,10 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 
+import type { GetNotificationSettingResponse } from '@/api/data-contracts';
+import { notificationKeys } from '@/queries/keys/notificationKeys';
 import {
   useNotificationSettingQuery,
   useUpdateNotificationSettingMutation,
@@ -27,6 +30,15 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   emailEnabled: false,
 };
 
+const toSettings = (
+  data: GetNotificationSettingResponse | null | undefined,
+): NotificationSettings => ({
+  meetingEnabled: data?.meetingEnabled ?? false,
+  nodeEnabled: data?.nodeEnabled ?? false,
+  desktopEnabled: data?.desktopEnabled ?? false,
+  emailEnabled: data?.emailEnabled ?? false,
+});
+
 const extractErrorCode = (caught: unknown): string | undefined => {
   if (typeof caught !== 'object' || caught === null) return undefined;
   const obj = caught as { error?: { code?: string }; code?: string };
@@ -38,20 +50,26 @@ export const useProjectNotificationsForm = ({
   onSaveSuccess,
   onSaveError,
 }: UseProjectNotificationsFormParams) => {
+  const queryClient = useQueryClient();
   const { data: queryData, isSuccess } = useNotificationSettingQuery(projectId);
   const updateMutation = useUpdateNotificationSettingMutation(projectId);
 
-  const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS);
-  const [isLoaded, setIsLoaded] = useState(false);
+  // 모달 열기 직전 prefetch 된 경우 캐시에서 바로 초기값을 잡아 토글이 false → 실제값으로
+  // 깜빡이는 문제를 막는다. 캐시가 비어 있으면 기존대로 useEffect 로 채운다.
+  const [settings, setSettings] = useState<NotificationSettings>(() => {
+    const cached = queryClient.getQueryData<GetNotificationSettingResponse | null>(
+      notificationKeys.setting(projectId),
+    );
+    return cached ? toSettings(cached) : DEFAULT_SETTINGS;
+  });
+  const [isLoaded, setIsLoaded] = useState<boolean>(() => {
+    const cached = queryClient.getQueryData(notificationKeys.setting(projectId));
+    return cached !== undefined;
+  });
 
   useEffect(() => {
     if (!isSuccess) return;
-    setSettings({
-      meetingEnabled: queryData?.meetingEnabled ?? false,
-      nodeEnabled: queryData?.nodeEnabled ?? false,
-      desktopEnabled: queryData?.desktopEnabled ?? false,
-      emailEnabled: queryData?.emailEnabled ?? false,
-    });
+    setSettings(toSettings(queryData));
     setIsLoaded(true);
   }, [isSuccess, queryData]);
 

--- a/frontend/src/queries/notification.ts
+++ b/frontend/src/queries/notification.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
 
@@ -10,6 +10,16 @@ const extractErrorCode = (caught: unknown): string | undefined => {
   if (typeof caught !== 'object' || caught === null) return undefined;
   const obj = caught as { error?: { code?: string }; code?: string };
   return obj.error?.code ?? obj.code;
+};
+
+const fetchNotificationSetting = async (projectId: number) => {
+  try {
+    const res = await privateApi.notificationSetting.getNotificationSetting(projectId);
+    return res.data.data ?? null;
+  } catch (caught) {
+    if (extractErrorCode(caught) === 'NOTIFICATION_SETTING_NOT_FOUND') return null;
+    throw caught;
+  }
 };
 
 export function useUnreadCountQuery() {
@@ -23,16 +33,19 @@ export function useUnreadCountQuery() {
 export function useNotificationSettingQuery(projectId: number) {
   return useQuery({
     queryKey: notificationKeys.setting(projectId),
-    queryFn: async () => {
-      try {
-        const res = await privateApi.notificationSetting.getNotificationSetting(projectId);
-        return res.data.data ?? null;
-      } catch (caught) {
-        if (extractErrorCode(caught) === 'NOTIFICATION_SETTING_NOT_FOUND') return null;
-        throw caught;
-      }
-    },
+    queryFn: () => fetchNotificationSetting(projectId),
     enabled: !!projectId,
+  });
+}
+
+/**
+ * 알림 설정을 미리 가져와 캐시에 채워둔다.
+ * 프로젝트 설정 모달이 열리기 직전에 호출해 알림 탭 토글 깜빡임을 방지하는 용도.
+ */
+export function prefetchNotificationSetting(queryClient: QueryClient, projectId: number) {
+  return queryClient.prefetchQuery({
+    queryKey: notificationKeys.setting(projectId),
+    queryFn: () => fetchNotificationSetting(projectId),
   });
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#324 

## 📝작업 내용
- 프로젝트 설정 모달을 여는 시점(`ProjectSidebar.handleSettingClick`)에 알림 설정을 `prefetchNotificationSetting`으로 미리 받아오도록 변경
- `useProjectNotificationsForm`의 `settings` 초기값을 lazy initializer로 변경해 `queryClient.getQueryData`로 캐시에서 즉시 읽도록 수정
- 캐시 hit 시 첫 렌더부터 실제 값으로 시작 → 토글이 false에서 실제값으로 깜빡이는 현상 제거
- 캐시 miss인 경우 기존 useEffect 폴백이 그대로 동작해 안전성 유지
- 부수적으로 `notification.ts`에서 `fetchNotificationSetting` 내부 함수로 queryFn을 분리, `useNotificationSettingQuery`와 `prefetchNotificationSetting`이 공유하도록 정리