### PR TITLE
[Fix/#327] 머메이드 오류 수정

### DIFF
--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -352,6 +352,8 @@ export interface AnalyzeDraggedNodesResponse {
   actionItemsAnalysis?: ActionItemsAnalysisItem;
   /** 회의 내용 기반 AI 발전 아이디어 제안 (마크다운) */
   developmentIdeas?: string;
+  /** 노트 내용 기반 AI 요약 */
+  notesSummary?: string;
   /** 회의 관계 시각화 Mermaid 코드 */
   mermaidCode?: string;
 }

--- a/frontend/src/components/commons/mermaid/MermaidDiagram.tsx
+++ b/frontend/src/components/commons/mermaid/MermaidDiagram.tsx
@@ -25,6 +25,73 @@ const readCssToken = (name: string): string => {
 // 라벨은 foreignObject 대신 순수 SVG text로 그린다 (htmlLabels:false).
 // mermaid 기본 CSS가 엣지 라벨을 반투명/검정 text로 그리는 걸 막기 위해, 토큰을 쓰는 !important
 // 스타일 태그를 head에 한 번 주입한다. 한 번만 실행되도록 flag로 가드.
+
+// flowchart/graph 다이어그램에서 노드 ID로 한글·공백·특수문자를 사용하면
+// mermaid 파서가 'UNICODE_TEXT' 토큰 오류를 낸다. 렌더링 전에 안전하지 않은
+// 노드 ID를 n1, n2, … 로 치환하고 라벨 텍스트는 원본을 유지한다.
+const sanitizeMermaidCode = (code: string): string => {
+  const firstLine = code.split('\n')[0].trim();
+  if (!firstLine.startsWith('graph ') && !firstLine.startsWith('flowchart ')) return code;
+
+  try {
+    // quotedMap, idMap 은 라인 간 공유 (같은 텍스트 → 같은 safe ID)
+    const quotedMap = new Map<string, string>();
+    let qn = 0;
+    const idMap = new Map<string, string>();
+    let seq = 0;
+
+    return code
+      .split('\n')
+      .map((line, i) => {
+        if (i === 0) return line;
+        const t = line.trim();
+        if (!t || t.startsWith('%%') || /^(subgraph|end)\b/.test(t)) return line;
+
+        // ── Step A: 기존 라벨/엣지 레이블 마스킹 (DEL \x7f 사용) ──────────────
+        // "quoted" 변환 전에 먼저 마스킹해야 A["라벨"] 안의 "..." 가 오인되지 않음
+        const slots: string[] = [];
+        const ph = (prefix: string) => (m: string) => {
+          const idx = slots.push(m) - 1;
+          return `\x7f${prefix}${idx}\x7f`;
+        };
+        let s = line
+          .replace(/\|[^|\n]+\|/g, ph('E'))
+          .replace(/\[[^\]\n]*\]/g, ph('L'))
+          .replace(/\([^)\n]*\)/g, ph('L'))
+          .replace(/\{[^}\n]*\}/g, ph('L'));
+
+        // ── Step B: "quoted text" 노드 ID → qnN["text"] ──────────────────────
+        // 기존 라벨은 이미 마스킹됐으므로 남은 "..." 는 모두 노드 ID
+        // 새로 생성한 ["text"] 라벨도 즉시 슬롯에 추가해 Step C 에서 오인 방지
+        s = s.replace(/"([^"\n\x7f]+)"/g, (_, nodeText) => {
+          if (!quotedMap.has(nodeText)) quotedMap.set(nodeText, `qn${++qn}`);
+          const label = `["${nodeText}"]`;
+          const idx = slots.push(label) - 1;
+          return `${quotedMap.get(nodeText)!}\x7fL${idx}\x7f`;
+        });
+
+        // ── Step C: 비안전 노드 ID → nN 치환 ────────────────────────────────
+        // \x7f 를 양쪽 문자 클래스에서 제외해 플레이스홀더 내부가 오인되지 않게 함
+        // Group 2: 후행 공백 재출력으로 edge 마커 앞 간격 유지
+        s = s.replace(
+          /([^\s\x7f[\](){}>|;,\-=\n][^\x7f[\](){}>|;,\-=\n]*?)(\s*)(?=[\x7f\[({>]|--+|==+|$)/g,
+          (_, id, space) => {
+            const raw = id.trim();
+            if (!raw || /^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(raw)) return id + space;
+            if (!idMap.has(raw)) idMap.set(raw, `n${++seq}`);
+            return idMap.get(raw)! + space;
+          },
+        );
+
+        // ── Step D: 마스킹 복원 ───────────────────────────────────────────────
+        return s.replace(/\x7f[EL](\d+)\x7f/g, (_, idx) => slots[+idx]);
+      })
+      .join('\n');
+  } catch {
+    return code;
+  }
+};
+
 let mermaidReady = false;
 const ensureMermaidReady = () => {
   if (mermaidReady || typeof window === 'undefined') return;
@@ -99,7 +166,7 @@ export const MermaidDiagram = ({ code }: MermaidDiagramProps) => {
     if (!container) return;
 
     const run = async () => {
-      const { svg } = await mermaid.render(`mermaid-${reactId}`, code);
+      const { svg } = await mermaid.render(`mermaid-${reactId}`, sanitizeMermaidCode(code));
       if (cancelled) return;
       container.innerHTML = svg;
 

--- a/frontend/src/components/projects/project-detail/multi-node-summary/MultiNodeSummaryModalContent.tsx
+++ b/frontend/src/components/projects/project-detail/multi-node-summary/MultiNodeSummaryModalContent.tsx
@@ -8,6 +8,7 @@ import { buildMermaidCode, parseDevelopmentIdeas } from '@/utils/mermaid';
 import { ActionItemsSection } from './ActionItemsSection';
 import { DevelopmentIdeasSection } from './DevelopmentIdeasSection';
 import { MeetingRelationshipsSection } from './MeetingRelationshipsSection';
+import { NotesSummarySection } from './NotesSummarySection';
 import { ReferenceNodesSection } from './ReferenceNodesSection';
 import { RelationDiagramSection } from './RelationDiagramSection';
 import type { MultiNodeSummaryNode, MultiNodeSummaryResult } from './types';
@@ -84,6 +85,7 @@ export const MultiNodeSummaryModalContent = ({
           className="custom-scrollbar flex max-h-150 w-full flex-col gap-6 overflow-y-auto pr-2"
         >
           <ReferenceNodesSection nodes={nodes} />
+          <NotesSummarySection summary={result.notesSummary} />
           <ActionItemsSection analysis={result.actionItemsAnalysis} />
           <MeetingRelationshipsSection relationships={result.meetingRelationships} />
           <DevelopmentIdeasSection ideas={ideas} />

--- a/frontend/src/components/projects/project-detail/multi-node-summary/NotesSummarySection.tsx
+++ b/frontend/src/components/projects/project-detail/multi-node-summary/NotesSummarySection.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+interface NotesSummarySectionProps {
+  summary: string | undefined | null;
+}
+
+export const NotesSummarySection = ({ summary }: NotesSummarySectionProps) => {
+  if (!summary) return null;
+
+  return (
+    <section className="flex w-full flex-col gap-2">
+      <span className="text-label-1 text-label-neutral font-semibold">노트 요약</span>
+      <div className="border-label-disable rounded-xl border p-3">
+        <p className="text-label-1 text-label-normal whitespace-pre-line">{summary}</p>
+      </div>
+    </section>
+  );
+};
+
+NotesSummarySection.displayName = 'NotesSummarySection';

--- a/frontend/src/components/projects/project-detail/multi-node-summary/types.ts
+++ b/frontend/src/components/projects/project-detail/multi-node-summary/types.ts
@@ -23,5 +23,6 @@ export interface MultiNodeSummaryResult {
   meetingRelationships?: readonly MeetingRelationship[];
   actionItemsAnalysis?: ActionItemsAnalysis;
   developmentIdeas?: string;
+  notesSummary?: string;
   mermaidCode?: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #319 

## 오류 원인

 Mermaid 다이어그램 코드에서 **노드 ID에 한글·공백·특수문자**를 사용할 경우 Mermaid 파서가 `UNICODE_TEXT` / `Lexical error` 를 내며 렌더링에 실패하고 있습니다!

AI는 아래 두 가지 패턴으로 Mermaid 코드를 생성하고 있기 때문에 양식이 달라져 오류가 발생합니다. 쉽게 말해서 머메이드 코드가 한 가지 양식이 아니라 두 가지 양식으로 오고 있었는데, 저희 코드는 한 가지만 대비하고 있어서 다른 양식으로 넘어오게 될 경우 에러를 뱉는다는 뜻!! 

| 패턴 | 예시 |
|---|---|
| 따옴표 quoted ID | `"드래그 요약" ---\|"시너지"\| "RAG 인덱싱"` |
| safe ID + 한글 라벨 | `A["드래그 요약"] ---\|"시너지"\| B["RAG 인덱싱"]` |

---

## 📝작업 내용

`MermaidDiagram.tsx` 에 `sanitizeMermaidCode` 전처리 함수를 추가해 `mermaid.render()` 호출 전에 코드를 정규화.

### 처리 흐름 
**Step A — 기존 라벨 선(先) 마스킹**
`|엣지 레이블|`, `[노드 라벨]`, `(...)`, `{...}` 를 `\x7f` DEL 문자 플레이스홀더로 교체.
→ 이후 단계에서 라벨 내부 텍스트가 노드 ID로 오인되지 않도록 보호.

**Step B — `"quoted text"` 노드 ID 변환**
Step A 이후 남은 `"..."` 는 모두 노드 ID로 간주해 `qn1["원본 텍스트"]` 형태로 변환하고, 생성된 라벨도 즉시 슬롯에 추가.

**Step C — 한글/특수문자 노드 ID → `n1`, `n2`, …**
플레이스홀더 외 영역에서 비안전 노드 ID를 치환. Group 2로 후행 공백을 분리·재출력해 `n1---n2` 가 아닌 `n1 --- n2` 로 edge 간격 보존.

**Step D — 플레이스홀더 복원**
슬롯에서 원본 라벨을 되살림.

### 노트 요약 추가
작업하는 김에 같이 작업할 수 있을 것 같아서 새로 추가된 `notesSummary` 필드도 보여줄 수 있도록 수정하였습니다
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/4b1a98f2-4b85-4ed6-a7b9-c39189779937" />


- 회의 관계랑 관계 다이어그램이랑 연결되는 거 같아서 순서를 회의 관계 - 관계 다이어그램 - 개선 아이디어로 변경하는 건 어떻게 생각하시나용

