### PR TITLE
[Feat/#329] 드래그 노드 분석에 노트 요약 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AnalyzeDraggedNodesResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/AnalyzeDraggedNodesResponse.java
@@ -14,6 +14,8 @@ public record AnalyzeDraggedNodesResponse(
         ActionItemsAnalysisItem actionItemsAnalysis,
         @Schema(description = "회의 내용 기반 AI 발전 아이디어 제안 (마크다운)")
         String developmentIdeas,
+        @Schema(description = "노트 내용 기반 AI 요약")
+        String notesSummary,
         @Schema(description = "회의 관계 시각화 Mermaid 코드")
         String mermaidCode
 ) {
@@ -25,6 +27,7 @@ public record AnalyzeDraggedNodesResponse(
                         .toList(),
                 ActionItemsAnalysisItem.from(result.actionItemsAnalysis()),
                 result.developmentIdeas(),
+                result.notesSummary(),
                 result.mermaidCode()
         );
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -291,7 +291,6 @@ public class NodeFacade {
         return RequestNodeSummaryResponse.from(aiTask.getId());
     }
 
-    // TODO: 추후 노트(noteContent) 포함 여부 검토
     public AnalyzeDraggedNodesResponse analyzeDraggedNodes(
             final Long userId,
             final Long projectId,
@@ -317,11 +316,21 @@ public class NodeFacade {
         int count = 0;
         for (Node node : nodes) {
             Meeting meeting = meetingByNodeId.get(node.getId());
-            if (meeting == null) {
+            boolean hasSummary = meeting != null;
+            boolean hasNote = node.getNoteContent() != null && !node.getNoteContent().isBlank();
+
+            if (!hasSummary && !hasNote) {
                 continue;
             }
-            sb.append("name: ").append(node.getTitle()).append("\n")
-                    .append("\"").append(meeting.getSummary()).append("\"\n\n");
+
+            sb.append("name: ").append(node.getTitle()).append("\n");
+            if (hasSummary) {
+                sb.append("meeting: \"").append(meeting.getSummary()).append("\"\n");
+            }
+            if (hasNote) {
+                sb.append("note: \"").append(node.getNoteContent()).append("\"\n");
+            }
+            sb.append("\n");
             count++;
         }
 

--- a/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/NodeAnalysisResult.java
+++ b/backend/flowmeet-external/src/main/java/kr/flowmeet/external/ai/dto/NodeAnalysisResult.java
@@ -11,6 +11,8 @@ public record NodeAnalysisResult(
         ActionItemsAnalysis actionItemsAnalysis,
         @JsonProperty("development_ideas")
         String developmentIdeas,
+        @JsonProperty("notes_summary")
+        String notesSummary,
         @JsonProperty("mermaid_code")
         String mermaidCode
 ) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #329

## 📝작업 내용

### 드래그 노드 분석에 노트 요약 추가

- 분석 입력 텍스트에 노드 노트(`noteContent`) 포함 (기존엔 회의 요약만 전달)
- 회의 요약 없이 노트만 있는 노드도 분석 대상에 포함
- `NodeAnalysisResult`에 `notes_summary` 필드 추가
- `AnalyzeDraggedNodesResponse`에 `notesSummary` 필드 추가 및 매핑 반영

## 변경 파일

| 파일 | 변경 |
|------|------|
| `external/.../ai/dto/NodeAnalysisResult.java` | 수정 - `notes_summary` 필드 추가 |
| `api/.../node/dto/response/AnalyzeDraggedNodesResponse.java` | 수정 - `notesSummary` 필드 추가 |
| `api/.../node/facade/NodeFacade.java` | 수정 - 분석 텍스트 빌드 로직에 노트 포함 |

## 💬리뷰 요구사항(선택)

## 💬논의 사항(선택)
