### PR TITLE
[Fix/#331] 소셜 로그인 시 이메일 중복 에러 처리 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/auth/facade/AuthFacade.java
@@ -15,6 +15,7 @@ import kr.flowmeet.auth.exception.AuthErrorCode;
 import kr.flowmeet.auth.exception.AuthException;
 import kr.flowmeet.auth.jwt.JwtProvider;
 import kr.flowmeet.domain.auth.service.RefreshTokenService;
+import kr.flowmeet.domain.common.exception.ParameterizedBusinessException;
 import kr.flowmeet.domain.emailverification.service.EmailVerificationService;
 import kr.flowmeet.domain.user.entity.SocialProvider;
 import kr.flowmeet.domain.user.entity.User;
@@ -42,6 +43,16 @@ public class AuthFacade {
         SocialUserInfo userInfo = oauthGateway.fetchUserInfo(provider, tokens.accessToken());
 
         Optional<User> existing = userService.findBySocialIdentity(new SocialIdentity(provider, userInfo.socialId()));
+
+        if (existing.isEmpty()) {
+            userService.findOptionalByEmail(userInfo.email()).ifPresent(conflictUser -> {
+                throw new ParameterizedBusinessException(
+                        AuthErrorCode.AUTH_EMAIL_ALREADY_REGISTERED,
+                        conflictUser.getSocialProvider().getDisplayName(),
+                        conflictUser.getSocialEmail()
+                );
+            });
+        }
 
         return existing
                 .map(user -> handleExistingUser(user, tokens))

--- a/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/exception/AuthErrorCode.java
+++ b/backend/flowmeet-auth/src/main/java/kr/flowmeet/auth/exception/AuthErrorCode.java
@@ -17,7 +17,8 @@ public enum AuthErrorCode implements ErrorCode {
     AUTH_SOCIAL_ID_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 소셜 로그인 계정이 있어요."),
     AUTH_INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "소셜 로그인 정보가 유효하지 않아요. 다시 로그인해 주세요."),
     AUTH_PROVIDER_MISMATCH(HttpStatus.BAD_REQUEST, "소셜 로그인 정보가 일치하지 않아요. 다시 로그인해 주세요."),
-    AUTH_PROVIDER_UNSUPPORTED(HttpStatus.BAD_REQUEST, "아직 이 소셜 로그인은 지원하지 않아요.");
+    AUTH_PROVIDER_UNSUPPORTED(HttpStatus.BAD_REQUEST, "아직 이 소셜 로그인은 지원하지 않아요."),
+    AUTH_EMAIL_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 %s(%s)로 가입된 이메일이에요. 기존 계정으로 로그인해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/common/exception/ParameterizedBusinessException.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/common/exception/ParameterizedBusinessException.java
@@ -1,0 +1,37 @@
+package kr.flowmeet.domain.common.exception;
+
+import kr.flowmeet.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class ParameterizedBusinessException extends BusinessException {
+
+    public ParameterizedBusinessException(final ErrorCode errorCode, final Object... args) {
+        super(new FormattedErrorCode(errorCode, args));
+    }
+
+    private static class FormattedErrorCode implements ErrorCode {
+
+        private final ErrorCode base;
+        private final String formattedMessage;
+
+        FormattedErrorCode(final ErrorCode base, final Object... args) {
+            this.base = base;
+            this.formattedMessage = String.format(base.getMessage(), args);
+        }
+
+        @Override
+        public HttpStatus getHttpStatus() {
+            return base.getHttpStatus();
+        }
+
+        @Override
+        public String getMessage() {
+            return formattedMessage;
+        }
+
+        @Override
+        public String name() {
+            return base.name();
+        }
+    }
+}

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/entity/SocialProvider.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/user/entity/SocialProvider.java
@@ -2,9 +2,15 @@ package kr.flowmeet.domain.user.entity;
 
 import kr.flowmeet.domain.auth.exception.AuthDomainErrorCode;
 import kr.flowmeet.domain.common.exception.BusinessException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public enum SocialProvider {
-    GOOGLE, KAKAO;
+    GOOGLE("구글"), KAKAO("카카오");
+
+    private final String displayName;
 
     public static SocialProvider from(String provider) {
         try {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #331

## 📝작업 내용

### 배경

`User` 엔티티에는 소셜 플랫폼으로부터 받은 `socialEmail`과 회원가입 시 사용자가 직접 입력한 `email` 두 개의 이메일 필드가 존재합니다.
두 값이 다를 수 있는데, 어떤 Google 계정의 이메일이 기존 유저의 `email`과 일치하지만 `socialId`가 다른 경우, 기존에는 `SIGNUP_REQUIRED`를 반환했습니다.
이는 이미 가입된 계정이 있음에도 회원가입 화면으로 안내하는 잘못된 동작입니다.

**발생 시나리오**

1. 유저 A가 `socialEmail=A@gmail.com`, `email=B@custom.com`으로 회원가입
2. 누군가 `socialEmail=B@custom.com`인 Google 계정으로 로그인 시도
3. `socialProvider + socialId`로 조회 → 없음 → 기존: `SIGNUP_REQUIRED` 반환
4. 변경 후: `AUTH_EMAIL_ALREADY_REGISTERED(409)` 반환

---

### 1. `ParameterizedBusinessException` 추가

`ErrorCode`의 메시지에 포함된 `%s` 포맷 문자열을 동적 인자로 치환해 응답에 반환하는 예외 클래스를 추가했습니다.

- `BusinessException`을 상속
- 내부 `FormattedErrorCode`로 원본 `ErrorCode`를 래핑, `getMessage()`가 `String.format()` 결과를 반환
- `GlobalExceptionHandler` 변경 없이 동작: `errorCode.getMessage()`가 포맷된 문자열을 그대로 반환

```java
throw new ParameterizedBusinessException(
        AuthErrorCode.AUTH_EMAIL_ALREADY_REGISTERED,
        conflictUser.getSocialProvider().getDisplayName(),
        conflictUser.getSocialEmail()
);
// → "이미 구글(A@gmail.com)로 가입된 이메일이에요. 기존 계정으로 로그인해 주세요."
```

### 2. `AUTH_EMAIL_ALREADY_REGISTERED` 에러코드 추가

| 항목 | 내용 |
|------|------|
| HTTP Status | `409 CONFLICT` |
| 메시지 | `이미 %s(%s)로 가입된 이메일이에요. 기존 계정으로 로그인해 주세요.` |
| `%s` 첫 번째 | 기존 계정의 소셜 provider 표시명 (예: `구글`) |
| `%s` 두 번째 | 기존 계정의 `socialEmail` (예: `A@gmail.com`) |

### 3. `SocialProvider`에 `displayName` 및 `@Getter` 추가

에러 메시지에 provider 표시명을 포함하기 위해 `displayName` 필드와 `@Getter`를 추가했습니다.

| enum 값 | displayName |
|---------|-------------|
| `GOOGLE` | `구글` |
| `KAKAO` | `카카오` |

### 4. `AuthFacade.login()` 수정

`socialId`로 기존 유저를 찾지 못한 경우, Google OAuth가 반환한 이메일(`userInfo.email()`)이 기존 유저의 `email` 필드와 일치하는지 추가로 확인합니다.

**변경 전**

- `socialProvider + socialId`로 조회 → 없으면 무조건 `SIGNUP_REQUIRED` 반환

**변경 후**

- `socialProvider + socialId`로 조회 → 없으면
  - `userInfo.email()`이 기존 유저의 `email`과 일치하는지 확인
  - 일치하면 `AUTH_EMAIL_ALREADY_REGISTERED(409)` 반환 (기존 provider + socialEmail 포함)
  - 일치하지 않으면 기존과 동일하게 `SIGNUP_REQUIRED` 반환

## 💬리뷰 요구사항(선택)

없음