### PR TITLE
[Fix/#314] `@TransactionalEventListener` 핸들러에 REQUIRES_NEW 트랜잭션 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectActivityEventListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectActivityEventListener.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import kr.flowmeet.domain.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 import kr.flowmeet.domain.node.event.NodeCreatedEvent;
 import kr.flowmeet.domain.node.event.NodeDeletedEvent;
@@ -16,16 +18,19 @@ public class ProjectActivityEventListener {
     private final ProjectService projectService;
 
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleNodeCreated(final NodeCreatedEvent event) {
         touch(event.projectId());
     }
 
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleNodeUpdated(final NodeUpdatedEvent event) {
         touch(event.projectId());
     }
 
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleNodeDeleted(final NodeDeletedEvent event) {
         touch(event.projectId());
     }

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectMemberJoinedEventListener.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/project/event/ProjectMemberJoinedEventListener.java
@@ -4,6 +4,8 @@ import kr.flowmeet.domain.notification.service.NotificationSettingService;
 import kr.flowmeet.domain.project.event.ProjectMemberJoinedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
@@ -13,6 +15,7 @@ public class ProjectMemberJoinedEventListener {
     private final NotificationSettingService notificationSettingService;
 
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(final ProjectMemberJoinedEvent event) {
         notificationSettingService.create(event.userId(), event.projectId());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #314

## 📝작업 내용

### 문제 상황

프로젝트 초대를 수락하면 해당 사용자의 `NotificationSetting`이 생성되어야 하지만, 실제로는 DB에 데이터가 저장되지 않는 문제가 있었습니다.

### 원인: `@TransactionalEventListener` + 트랜잭션 누락

`ProjectMemberService.create()`에서 `ProjectMemberJoinedEvent`를 발행하면, `ProjectMemberJoinedEventListener`가 이를 수신해 `NotificationSettingService.create()`를 호출하는 구조입니다.

```
ProjectMemberService.create()  →  publishEvent()
                                        ↓ (AFTER_COMMIT)
                               ProjectMemberJoinedEventListener.handle()
                                        ↓
                               NotificationSettingService.create()  →  save() ← 저장 안 됨
```

`@TransactionalEventListener`의 기본 페이즈는 `AFTER_COMMIT`으로, 원본 트랜잭션이 **커밋된 이후**에 리스너가 실행됩니다.

이 시점에서 `TransactionSynchronizationManager`는 이미 완료(completed) 상태입니다. 리스너 메서드 자체에 `@Transactional`이 없으면, 내부에서 호출한 `NotificationSettingService.create()`의 `@Transactional`이 새 트랜잭션을 시도해도 동기화 완료 상태로 인해 **커밋이 정상적으로 이루어지지 않아** 데이터가 저장되지 않습니다.

동일 패턴으로 구현된 `ProjectActivityEventListener`(노드 이벤트 시 `lastActivityAt` 갱신)도 같은 문제를 갖고 있어 함께 수정했습니다.

### 해결 방법: 리스너 메서드에 `@Transactional(propagation = REQUIRES_NEW)` 추가

`REQUIRES_NEW`는 현재 트랜잭션 컨텍스트와 완전히 독립된 새 트랜잭션을 강제로 시작합니다. 이를 통해 `AFTER_COMMIT` 페이즈의 동기화 상태 문제를 우회하고 정상적으로 커밋됩니다.

#### `ProjectMemberJoinedEventListener`

```java
@TransactionalEventListener
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void handle(final ProjectMemberJoinedEvent event) {
    notificationSettingService.create(event.userId(), event.projectId());
}
```

#### `ProjectActivityEventListener`

```java
@TransactionalEventListener
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void handleNodeCreated(final NodeCreatedEvent event) { ... }

@TransactionalEventListener
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void handleNodeUpdated(final NodeUpdatedEvent event) { ... }

@TransactionalEventListener
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void handleNodeDeleted(final NodeDeletedEvent event) { ... }
```

## 💬리뷰 요구사항(선택)

- `@TransactionalEventListener`를 사용하는 리스너에서 DB 쓰기가 필요한 경우 `REQUIRES_NEW`를 붙이는 것을 컨벤션으로 가져가면 좋을 것 같습니다.
