### PR TITLE
[Fix/#335] 노드 상세 수정 시 뮤테이션 성공 후 초기화 수정 

### DIFF
--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -6,7 +6,7 @@ import { ContentBadge, Tab, TabList, TabListItem, TabPanel, Typography } from '@
 import { IconDocumentText, IconFire, IconPersons, IconTag } from '@wanteddev/wds-icon';
 import { useEffect } from 'react';
 
-import { GetNodeResponse } from '@/api/Api';
+import { GetFlowchartResponse, GetNodeResponse } from '@/api/Api';
 import { GoogleMeetIcon } from '@/assets/svgs/GoogleMeetIcon';
 import { Loading } from '@/components/commons/loading/Loading';
 import { NodeStatusType } from '@/constants/nodeStatus';
@@ -77,6 +77,9 @@ export function NodeDetailLayout({
 
   const handleDescriptionUpdate = (description: string) => {
     updateCache((prev) => ({ ...prev, description }));
+    queryClient.setQueryData<GetFlowchartResponse>(nodeKeys.flowchart(projectId), (old) =>
+      old ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, description } : n)) } : old,
+    );
   };
 
   const menuActions = useNodeMenuActions({

--- a/frontend/src/queries/member.ts
+++ b/frontend/src/queries/member.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
 import { memberKeys } from './keys/memberKeys';
+import { nodeKeys } from './keys/nodeKeys';
 
 export function useProjectMembersQuery(projectId: number) {
   return useQuery({
@@ -15,16 +16,24 @@ export function useProjectMembersQuery(projectId: number) {
 }
 
 export function useAddAssigneeMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (userId: number) =>
       privateApi.nodeAssignee.createAssignee(projectId, nodeId, { userId }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 
 export function useRemoveAssigneeMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (assigneeId: number) =>
       privateApi.nodeAssignee.deleteAssignee(projectId, nodeId, assigneeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 

--- a/frontend/src/queries/node.ts
+++ b/frontend/src/queries/node.ts
@@ -106,11 +106,19 @@ export function useUpdateNodeTitleMutation(projectId: number, nodeId: number | n
       queryClient.setQueryData(queryKey, (old: GetNodeResponse | undefined) =>
         old ? { ...old, title } : old,
       );
-      return { previous };
+      const flowchartKey = nodeKeys.flowchart(projectId);
+      const previousFlowchart = queryClient.getQueryData<GetFlowchartResponse>(flowchartKey);
+      queryClient.setQueryData<GetFlowchartResponse>(flowchartKey, (old) =>
+        old ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, title } : n)) } : old,
+      );
+      return { previous, previousFlowchart };
     },
     onError: (_err, _title, context) => {
       if (context?.previous !== undefined) {
         queryClient.setQueryData(queryKey, context.previous);
+      }
+      if (context?.previousFlowchart !== undefined) {
+        queryClient.setQueryData(nodeKeys.flowchart(projectId), context.previousFlowchart);
       }
     },
   });

--- a/frontend/src/queries/node.ts
+++ b/frontend/src/queries/node.ts
@@ -65,9 +65,13 @@ export function useUpdateNodeDescriptionMutation(projectId: number, nodeId: numb
 }
 
 export function useUpdateNodeStatusMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (status: NodeStatusType) =>
       privateApi.node.updateNodeStatus(projectId, nodeId, { status }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 

--- a/frontend/src/queries/tag.ts
+++ b/frontend/src/queries/tag.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
-import { CreateTagRequest, TagItem, UpdateTagRequest } from '@/api/Api';
+import { CreateTagRequest, GetFlowchartResponse, TagItem, UpdateTagRequest } from '@/api/Api';
 import { nodeKeys } from './keys/nodeKeys';
 import { tagKeys } from './keys/tagKeys';
 
@@ -21,7 +21,16 @@ export function useAddNodeTagMutation(projectId: number, nodeId: number) {
   return useMutation({
     mutationFn: (tagId: number) =>
       privateApi.tag.addNodeTag(projectId, nodeId, { tagId }),
-    onSuccess: () => {
+    onSuccess: (_data, tagId) => {
+      const allTags = queryClient.getQueryData<TagItem[]>(tagKeys.list(projectId));
+      const tag = allTags?.find((t) => t.tagId === tagId);
+      if (tag) {
+        queryClient.setQueryData<GetFlowchartResponse>(nodeKeys.flowchart(projectId), (old) =>
+          old
+            ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, tags: [...(n.tags ?? []), tag] } : n)) }
+            : old,
+        );
+      }
       void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
     },
   });
@@ -31,7 +40,12 @@ export function useRemoveNodeTagMutation(projectId: number, nodeId: number) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (tagId: number) => privateApi.tag.removeNodeTag(projectId, nodeId, tagId),
-    onSuccess: () => {
+    onSuccess: (_data, tagId) => {
+      queryClient.setQueryData<GetFlowchartResponse>(nodeKeys.flowchart(projectId), (old) =>
+        old
+          ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, tags: n.tags?.filter((t) => t.tagId !== tagId) } : n)) }
+          : old,
+      );
       void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
     },
   });

--- a/frontend/src/queries/tag.ts
+++ b/frontend/src/queries/tag.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
 import { CreateTagRequest, TagItem, UpdateTagRequest } from '@/api/Api';
+import { nodeKeys } from './keys/nodeKeys';
 import { tagKeys } from './keys/tagKeys';
 
 export function useProjectTagsQuery(projectId: number) {
@@ -16,15 +17,23 @@ export function useProjectTagsQuery(projectId: number) {
 }
 
 export function useAddNodeTagMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (tagId: number) =>
       privateApi.tag.addNodeTag(projectId, nodeId, { tagId }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 
 export function useRemoveNodeTagMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (tagId: number) => privateApi.tag.removeNodeTag(projectId, nodeId, tagId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+    },
   });
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #335 

## 📝작업 내용

### 1. 사이드바 재오픈 시 수정 내용이 반영되지 않는 버그 수정

사이드바에서 담당자·태그·상태를 수정한 뒤 닫았다가 다시 열면, API에는 최신 데이터가 있음에도 불구하고 수정 전 내용이 표시되는 버그를 수정했습니다.

**원인**: 담당자·태그·상태 뮤테이션이 성공 후 `nodeKeys.detail` 캐시를 invalidate하지 않아, 사이드바 재오픈 시 Yjs가 스테일 캐시 데이터로 초기화됐습니다.

**수정 파일**
- `src/queries/member.ts` — `useAddAssigneeMutation`, `useRemoveAssigneeMutation`에 `onSuccess` 추가
- `src/queries/tag.ts` — `useAddNodeTagMutation`, `useRemoveNodeTagMutation`에 `onSuccess` 추가
- `src/queries/node.ts` — `useUpdateNodeStatusMutation`에 `onSuccess` 추가

### 2. 사이드바 수정 내용을 노드 플로우 화면에 즉시 반영

사이드바에서 태그·제목·설명을 수정해도 노드 플로우 카드에 바로 반영되지 않던 문제를 개선했습니다.

**원인**: 뮤테이션 성공 시 `nodeKeys.detail`만 업데이트하고 `nodeKeys.flowchart` 캐시는 그대로 두었기 때문에, ReactFlow가 로컬 상태를 유지한 채로 구버전 카드를 표시했습니다.

**수정 방식**: 각 뮤테이션 성공(또는 `onMutate`) 시점에 `queryClient.setQueryData`로 flowchart 캐시의 해당 노드만 패치합니다.

- `useAddNodeTagMutation` — 성공 시 flowchart 캐시에 태그 추가
- `useRemoveNodeTagMutation` — 성공 시 flowchart 캐시에서 태그 제거
- `useUpdateNodeTitleMutation` — `onMutate`에서 flowchart 캐시 낙관적 업데이트, 에러 시 롤백
- `NodeDetailLayout.handleDescriptionUpdate` — flowchart 캐시의 description 즉시 패치


이슈는 담당자로 팠는데, 수정하다보니 태그/상태 부분도 적용이 안 되어 있고 비슷한 맥락으로 플로우 화면도 바로 적용될 수 있도록 수정하면 좋을 것 같아 함께 수정했습니다! 
