### PR TITLE
[Fix/#339] 수신함 알림 요청 폭주 및 SSE 연결 안정화

### DIFF
--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wanteddev/wds-icon';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { authStorage } from '@/api/authStorage';
 import { userStorage } from '@/api/userStorage';
@@ -84,12 +84,20 @@ export const ProjectSidebar = ({
   const { data: currentUser } = useCurrentUserQuery();
   const storedUser = userStorage.get();
 
-  // 읽지 않은 알림 개수 — 최초 1회 fetch + SSE로 +1씩 누적
-  const { data: initialUnreadCount = 0 } = useUnreadCountQuery();
-  const [sseExtra, setSseExtra] = useState(0);
-  const unreadCount = initialUnreadCount + sseExtra;
+  // 읽지 않은 알림 개수 — 최초 1회 fetch 후 SSE notification 이벤트의 unreadCount로 갱신.
+  const { data: unreadCount = 0 } = useUnreadCountQuery();
   // SSE로 새로 수신한 알림 여부 (알림창 열면 초기화)
   const [hasNewSseNotification, setHasNewSseNotification] = useState(false);
+
+  // 알림 리스트 기반 실제 unread 개수로 캐시 동기화.
+  // useCallback으로 참조를 고정해야 SidebarAlarmModal의 fetch effect가 매 렌더마다
+  // 재실행되는 무한 요청 루프를 막을 수 있다.
+  const handleListLoaded = useCallback(
+    (unreadInList: number) => {
+      queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
+    },
+    [queryClient],
+  );
 
   useEffect(() => {
     if (!isProjectIdValid || projectId === undefined) return;
@@ -98,55 +106,111 @@ export const ProjectSidebar = ({
     if (!token) return;
 
     const baseUrl = (process.env.NEXT_PUBLIC_API_BASE_URL ?? '').replace(/\/$/, '');
-    const controller = new AbortController();
     const subscribeUrl = new URL(`${baseUrl}/v1/notifications/subscribe`, window.location.origin);
     subscribeUrl.searchParams.set('projectId', String(projectId));
 
+    // 서버는 30분 후 연결을 정상 종료하고, 그 외 네트워크 끊김/절전 등으로도 끊길 수 있다.
+    // fetch 기반 SSE는 EventSource와 달리 자동 재연결이 없으므로 백오프로 직접 재연결한다.
+    const INITIAL_DELAY = 1000;
+    const MAX_DELAY = 30_000;
+    // 서버 heartbeat가 30초 주기이므로, 60초간 아무 신호가 없으면 죽은 연결로 보고 강제 재연결.
+    const HEARTBEAT_TIMEOUT = 60_000;
+
+    let stopped = false;
+    let controller: AbortController | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryDelay = INITIAL_DELAY;
+
+    const clearWatchdog = () => {
+      if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+      }
+    };
+
+    const armWatchdog = () => {
+      clearWatchdog();
+      watchdogTimer = setTimeout(() => controller?.abort(), HEARTBEAT_TIMEOUT);
+    };
+
+    const scheduleReconnect = () => {
+      if (stopped) return;
+      reconnectTimer = setTimeout(() => void connect(), retryDelay);
+      retryDelay = Math.min(retryDelay * 2, MAX_DELAY);
+    };
+
     const connect = async () => {
+      if (stopped) return;
+      controller = new AbortController();
       try {
         const response = await fetch(subscribeUrl, {
           headers: { Authorization: `Bearer ${token}` },
           signal: controller.signal,
         });
 
-        if (!response.ok || !response.body) return;
+        if (response.ok && response.body) {
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+          let currentEventType: string | null = null;
+          armWatchdog();
 
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let currentEventType: string | null = null;
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop() ?? '';
-          for (const line of lines) {
-            if (line.startsWith('event:')) {
-              currentEventType = line.slice('event:'.length).trim();
-            } else if (line.startsWith('data:')) {
-              // 'notification' 이벤트만 카운트 (connected, heartbeat 등은 무시)
-              if (currentEventType === 'notification') {
-                setSseExtra((prev) => prev + 1);
-                setHasNewSseNotification(true);
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            retryDelay = INITIAL_DELAY; // 정상 수신 → 백오프 리셋
+            armWatchdog(); // 신호 받음 → watchdog 갱신
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+            for (const line of lines) {
+              if (line.startsWith('event:')) {
+                currentEventType = line.slice('event:'.length).trim();
+              } else if (line.startsWith('data:')) {
+                // 'notification' 이벤트만 처리 (connect, heartbeat 등은 무시)
+                if (currentEventType === 'notification') {
+                  setHasNewSseNotification(true);
+                  // 서버 payload의 실제 unreadCount를 그대로 반영해 카운트 드리프트 방지.
+                  try {
+                    const payload = JSON.parse(line.slice('data:'.length).trim()) as {
+                      unreadCount?: number;
+                    };
+                    if (typeof payload.unreadCount === 'number') {
+                      queryClient.setQueryData(
+                        notificationKeys.unreadCount(),
+                        payload.unreadCount,
+                      );
+                    }
+                  } catch {
+                    // payload 파싱 실패 — dot만 표시
+                  }
+                }
+              } else if (line.trim() === '') {
+                // 빈 줄은 메시지 구분자 — event 타입 초기화
+                currentEventType = null;
               }
-            } else if (line === '') {
-              // 빈 줄은 메시지 구분자 — event 타입 초기화
-              currentEventType = null;
             }
           }
         }
       } catch {
-        // SSE 연결 종료 또는 오류 — 무시
+        // abort 또는 네트워크 오류 — 아래 재연결로 처리
+      } finally {
+        clearWatchdog();
       }
+
+      // 정상 종료(타임아웃)·오류·watchdog abort 모두 재연결 (effect cleanup 제외)
+      scheduleReconnect();
     };
 
     void connect();
     return () => {
-      controller.abort();
+      stopped = true;
+      controller?.abort();
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      clearWatchdog();
     };
-  }, [isProjectIdValid, projectId]);
+  }, [isProjectIdValid, projectId, queryClient]);
 
   // prop > query > storage > 빈 문자열 우선순위로 합성
   const projectName = projectNameProp ?? projectData?.name ?? '';
@@ -462,11 +526,7 @@ export const ProjectSidebar = ({
             projectId={projectId}
             onClose={() => setIsAlarmModalOpen(false)}
             onNotificationClick={handleNotificationClick}
-            onListLoaded={(unreadInList) => {
-              // 알림 리스트 기반 실제 unread 개수로 캐시 동기화 + SSE 누적값 초기화
-              queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
-              setSseExtra(0);
-            }}
+            onListLoaded={handleListLoaded}
           />
         )}
       </AnimatePresence>

--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wanteddev/wds-icon';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { authStorage } from '@/api/authStorage';
 import { userStorage } from '@/api/userStorage';
@@ -85,19 +85,10 @@ export const ProjectSidebar = ({
   const storedUser = userStorage.get();
 
   // 읽지 않은 알림 개수 — 최초 1회 fetch 후 SSE notification 이벤트의 unreadCount로 갱신.
+  // 수신함을 열면 SidebarAlarmModal이 목록 쿼리 결과로 이 캐시를 직접 동기화한다.
   const { data: unreadCount = 0 } = useUnreadCountQuery();
   // SSE로 새로 수신한 알림 여부 (알림창 열면 초기화)
   const [hasNewSseNotification, setHasNewSseNotification] = useState(false);
-
-  // 알림 리스트 기반 실제 unread 개수로 캐시 동기화.
-  // useCallback으로 참조를 고정해야 SidebarAlarmModal의 fetch effect가 매 렌더마다
-  // 재실행되는 무한 요청 루프를 막을 수 있다.
-  const handleListLoaded = useCallback(
-    (unreadInList: number) => {
-      queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
-    },
-    [queryClient],
-  );
 
   useEffect(() => {
     if (!isProjectIdValid || projectId === undefined) return;
@@ -526,7 +517,6 @@ export const ProjectSidebar = ({
             projectId={projectId}
             onClose={() => setIsAlarmModalOpen(false)}
             onNotificationClick={handleNotificationClick}
-            onListLoaded={handleListLoaded}
           />
         )}
       </AnimatePresence>

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -87,6 +87,9 @@ export const SidebarAlarmModal = ({
   const showErrorToast = useErrorToast();
   const [hasScrolled, setHasScrolled] = useState(false);
   const [notifications, setNotifications] = useState<NotificationSummaryResponse[]>([]);
+  // 최초 fetch 완료 여부. 로딩 중에는 빈 상태('받은 알림이 없어요')를 그리지 않아
+  // 알림이 뒤늦게 나타나는 깜빡임을 막는다.
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -104,6 +107,8 @@ export const SidebarAlarmModal = ({
       } catch (caught) {
         if (cancelled) return;
         showErrorToast(caught, '알림 목록을 불러오지 못했어요.');
+      } finally {
+        if (!cancelled) setIsLoaded(true);
       }
     };
     void fetchNotifications();
@@ -146,7 +151,7 @@ export const SidebarAlarmModal = ({
             aria-hidden="true"
           />
           <div className="min-h-0 flex-1 overflow-hidden px-2">
-            {notifications.length === 0 ? (
+            {!isLoaded ? null : notifications.length === 0 ? (
               <div className="text-label-alternative flex h-full flex-col items-center justify-start gap-2 pt-40">
                 <IconInbox className="text-label-disable h-10 w-10" aria-hidden="true" />
                 <p className="text-body-2 font-medium">받은 알림이 없어요</p>

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -1,12 +1,17 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { IconChevronDoubleLeft, IconInbox } from '@wanteddev/wds-icon';
 import { motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 
-import { privateApi } from '@/api';
 import type { NotificationSummaryResponse } from '@/api/Api';
 import { useErrorToast } from '@/hooks/useErrorToast';
+import { notificationKeys } from '@/queries/keys/notificationKeys';
+import {
+  useMarkNotificationReadMutation,
+  useNotificationListQuery,
+} from '@/queries/notification';
 
 import { SidebarAlarmModalItem } from './SidebarAlarmModalItem';
 
@@ -14,8 +19,6 @@ interface SidebarAlarmModalProps {
   projectId: number;
   onClose: () => void;
   onNotificationClick?: (notification: NotificationSummaryResponse) => void;
-  /** 리스트 로드 완료 시 실제 unread 개수 동기화용 콜백 */
-  onListLoaded?: (unreadCount: number) => void;
 }
 
 const sidebarVariants = {
@@ -82,40 +85,29 @@ export const SidebarAlarmModal = ({
   projectId,
   onClose,
   onNotificationClick,
-  onListLoaded,
 }: SidebarAlarmModalProps) => {
   const showErrorToast = useErrorToast();
+  const queryClient = useQueryClient();
   const [hasScrolled, setHasScrolled] = useState(false);
-  const [notifications, setNotifications] = useState<NotificationSummaryResponse[]>([]);
-  // 최초 fetch 완료 여부. 로딩 중에는 빈 상태('받은 알림이 없어요')를 그리지 않아
-  // 알림이 뒤늦게 나타나는 깜빡임을 막는다.
-  const [isLoaded, setIsLoaded] = useState(false);
+
+  // isPending인 동안에는 빈 상태('받은 알림이 없어요')를 그리지 않아 깜빡임을 막는다.
+  // 캐시가 남아 있으면 재오픈 시 바로 목록이 보인다.
+  const { data: notifications = [], isPending, isError, error, isSuccess } =
+    useNotificationListQuery(projectId);
+  const markAsRead = useMarkNotificationReadMutation();
+
+  const unreadInList = notifications.filter((n) => n.isRead === false).length;
+
+  // 목록 기준 실제 unread 개수로 뱃지 캐시를 직접 동기화한다(부모 콜백 대신 쿼리 캐시 사용).
+  // SSE는 unreadCount 캐시만 갱신하고 목록은 건드리지 않으므로, 이 effect는 SSE 수신 시 재실행되지 않는다.
+  useEffect(() => {
+    if (!isSuccess) return;
+    queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
+  }, [isSuccess, unreadInList, queryClient]);
 
   useEffect(() => {
-    let cancelled = false;
-    const fetchNotifications = async () => {
-      try {
-        const response = await privateApi.notification.getAllNotifications();
-        if (cancelled) return;
-        const items = (response.data.data?.content ?? []).filter(
-          (notification) => notification.projectId === projectId,
-        );
-        setNotifications(items);
-        // 실제 리스트 기준 unread 개수를 부모로 전달해 뱃지 동기화
-        const unreadInList = items.filter((n) => n.isRead === false).length;
-        onListLoaded?.(unreadInList);
-      } catch (caught) {
-        if (cancelled) return;
-        showErrorToast(caught, '알림 목록을 불러오지 못했어요.');
-      } finally {
-        if (!cancelled) setIsLoaded(true);
-      }
-    };
-    void fetchNotifications();
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId, showErrorToast, onListLoaded]);
+    if (isError) showErrorToast(error, '알림 목록을 불러오지 못했어요.');
+  }, [isError, error, showErrorToast]);
 
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     setHasScrolled(event.currentTarget.scrollTop > 0);
@@ -151,7 +143,7 @@ export const SidebarAlarmModal = ({
             aria-hidden="true"
           />
           <div className="min-h-0 flex-1 overflow-hidden px-2">
-            {!isLoaded ? null : notifications.length === 0 ? (
+            {isPending ? null : notifications.length === 0 ? (
               <div className="text-label-alternative flex h-full flex-col items-center justify-start gap-2 pt-40">
                 <IconInbox className="text-label-disable h-10 w-10" aria-hidden="true" />
                 <p className="text-body-2 font-medium">받은 알림이 없어요</p>
@@ -178,23 +170,9 @@ export const SidebarAlarmModal = ({
                         timeText={formatNotificationTime(item.createdAt)}
                         isUnread={item.isRead === false}
                         onClick={() => {
-                          // 클릭한 알림을 로컬에서 즉시 읽음 처리 (dot 즉시 사라짐)
+                          // 클릭한 알림을 낙관적으로 읽음 처리 (dot 즉시 사라지고, 뱃지는 캐시 갱신으로 동기화)
                           if (item.notificationId !== undefined && item.isRead === false) {
-                            setNotifications((prev) => {
-                              const next = prev.map((n) =>
-                                n.notificationId === item.notificationId
-                                  ? { ...n, isRead: true }
-                                  : n,
-                              );
-                              // 뱃지 카운트 즉시 동기화
-                              const unreadInList = next.filter((n) => n.isRead === false).length;
-                              onListLoaded?.(unreadInList);
-                              return next;
-                            });
-                            // 백엔드 동기화 (실패해도 UI는 그대로 유지)
-                            void privateApi.notification
-                              .markAsRead(item.notificationId)
-                              .catch(() => undefined);
+                            markAsRead.mutate(item.notificationId);
                           }
                           onNotificationClick?.(item);
                         }}

--- a/frontend/src/queries/keys/notificationKeys.ts
+++ b/frontend/src/queries/keys/notificationKeys.ts
@@ -2,4 +2,5 @@ export const notificationKeys = {
   all: ['notification'] as const,
   setting: (projectId: number) => [...notificationKeys.all, 'setting', projectId] as const,
   unreadCount: () => [...notificationKeys.all, 'unreadCount'] as const,
+  list: () => [...notificationKeys.all, 'list'] as const,
 };

--- a/frontend/src/queries/notification.ts
+++ b/frontend/src/queries/notification.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
+import type { NotificationSummaryResponse } from '@/api/Api';
 
 import { notificationKeys } from './keys/notificationKeys';
 
@@ -27,6 +28,43 @@ export function useUnreadCountQuery() {
     queryKey: notificationKeys.unreadCount(),
     queryFn: () =>
       privateApi.notification.getUnreadCount().then((res) => res.data.data?.unreadCount ?? 0),
+  });
+}
+
+/**
+ * 수신함 알림 목록.
+ * 전체 목록을 하나의 캐시(list)로 받아두고 select로 현재 프로젝트만 필터링한다.
+ * 전역 staleTime(1분) 덕분에 수신함을 다시 열어도 같은 캐시를 재사용해 API 호출이 줄어든다.
+ */
+export function useNotificationListQuery(projectId: number) {
+  return useQuery({
+    queryKey: notificationKeys.list(),
+    queryFn: () =>
+      privateApi.notification
+        .getAllNotifications()
+        .then((res) => res.data.data?.content ?? []),
+    select: (items) => items.filter((notification) => notification.projectId === projectId),
+    enabled: !!projectId,
+  });
+}
+
+/**
+ * 알림을 읽음 처리한다.
+ * 목록 캐시를 낙관적으로 갱신해 dot을 즉시 없애고, 실패해도 UI는 그대로 둔다.
+ */
+export function useMarkNotificationReadMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: number) => privateApi.notification.markAsRead(notificationId),
+    onMutate: (notificationId) => {
+      queryClient.setQueryData<NotificationSummaryResponse[]>(notificationKeys.list(), (prev) =>
+        prev?.map((notification) =>
+          notification.notificationId === notificationId
+            ? { ...notification, isRead: true }
+            : notification,
+        ),
+      );
+    },
   });
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#339 

## 📝작업 내용
사이드바 수신함(알림)에서 발생하던 과도한 API 호출과 SSE 알림 안정성 문제를 수정했습니다.

- **수신함 알림 목록 API 무한 호출 수정**
  - `ProjectSidebar`에서 `onListLoaded` 콜백이 인라인으로 전달돼 매 렌더마다 새 참조가 생성됐고, `SidebarAlarmModal`의 fetch effect 의존성에 포함돼 있어 알림 목록 API(`getAllNotifications`)가 무한 반복 호출되던 문제를 수정했습니다.
  - `useCallback`으로 콜백 참조를 고정해 수신함을 열 때 요청이 1회만 나가도록 했습니다.

- **알림 로딩 중 빈 상태 깜빡임 수정**
  - 데이터 로딩 전 `notifications`가 빈 배열이라 "받은 알림이 없어요" 빈 화면이 잠깐 보였다가 알림이 뜨던 깜빡임을 수정했습니다.
  - `isLoaded` 플래그를 추가해 로딩이 끝나기 전에는 빈 상태를 그리지 않도록 했습니다.

- **SSE 연결 끊김 자동 재연결 추가**
  - 서버 SSE 타임아웃(30분) 네트워크 끊김·절전 등으로 연결이 끊기면 그 뒤 새로고침 전까지 알림이 멈추던 문제를 수정했습니다.
  - `fetch` 기반 SSE는 `EventSource`와 달리 자동 재연결이 없어, 끊기면 지수 백오프(1s→2s→…→최대 30s)로 재연결하도록 했습니다.
  - 서버 heartbeat(30초 주기)를 활용해 60초간 신호가 없으면 죽은 연결로 보고 강제 재연결하는 watchdog을 추가했습니다.

- **알림 뱃지 카운트 정확도 개선**
  - SSE `notification` 이벤트 payload에 서버가 실제 `unreadCount`를 담아 보내는데, 프론트는 이를 무시하고 `+1`만 누적하고 있었습니다.
  - payload의 `unreadCount`를 그대로 캐시에 반영하도록 바꿔 카운트 드리프트를 제거했습니다.