### PR TITLE
[Fix/#316] 진행 중이던 회의 삭제되지 않던 현상 수정

### DIFF
--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
@@ -168,10 +168,6 @@ public class MeetingService {
 
     @Transactional
     public void delete(final ProjectMember projectMember, final Meeting meeting) {
-        if (meeting.isInProgress()) {
-            throw new BusinessException(MeetingErrorCode.MEETING_IN_PROGRESS);
-        }
-
         validateCreatorOrOwner(meeting, projectMember);
 
         meetingParticipantRepository.deleteAllByMeetingId(meeting.getId());


### PR DESCRIPTION
## #️⃣연관된 이슈

#316

## 📝작업 내용

`MeetingService.delete()`에서 회의가 진행 중일 때 삭제를 막던 조건을 제거했습니다.

회의 삭제 요청 시 `meeting.isInProgress()` 검사로 인해 진행 중 상태인 회의는 삭제할 수 없었습니다.
진행 중인 회의도 생성자 또는 프로젝트 오너가 삭제할 수 있어야 하므로, 해당 조건을 제거합니다.

### Before

```java
@Transactional
public void delete(final ProjectMember projectMember, final Meeting meeting) {
    if (meeting.isInProgress()) {
        throw new BusinessException(MeetingErrorCode.MEETING_IN_PROGRESS);
    }

    validateCreatorOrOwner(meeting, projectMember);

    meetingParticipantRepository.deleteAllByMeetingId(meeting.getId());
    meetingRepository.delete(meeting);
}
```

### After

```java
@Transactional
public void delete(final ProjectMember projectMember, final Meeting meeting) {
    validateCreatorOrOwner(meeting, projectMember);

    meetingParticipantRepository.deleteAllByMeetingId(meeting.getId());
    meetingRepository.delete(meeting);
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

별 거 없어서 바로 머지합니다~
