### PR TITLE
[Feat/#341] MCP Tool 호출 로깅 추가

### DIFF
--- a/mcp-server/build.gradle
+++ b/mcp-server/build.gradle
@@ -25,6 +25,7 @@ dependencyManagement {
 
 dependencies {
     implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/logging/RequestIdFilter.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/logging/RequestIdFilter.java
@@ -1,0 +1,47 @@
+package kr.flowmeet.mcpserver.logging;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(1)
+public class RequestIdFilter implements Filter {
+
+    static final String REQUEST_ID_KEY = "requestId";
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String requestId = httpRequest.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString().substring(0, 8);
+        }
+
+        MDC.put(REQUEST_ID_KEY, requestId);
+        httpResponse.setHeader(REQUEST_ID_HEADER, requestId);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(REQUEST_ID_KEY);
+        }
+    }
+}

--- a/mcp-server/src/main/java/kr/flowmeet/mcpserver/logging/ToolLoggingAspect.java
+++ b/mcp-server/src/main/java/kr/flowmeet/mcpserver/logging/ToolLoggingAspect.java
@@ -1,0 +1,41 @@
+package kr.flowmeet.mcpserver.logging;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class ToolLoggingAspect {
+
+    @Around("@annotation(tool)")
+    public Object logToolCall(
+            ProceedingJoinPoint joinPoint,
+            Tool tool
+    ) throws Throwable {
+        String toolName = tool.name().isEmpty()
+                ? joinPoint.getSignature().getName()
+                : tool.name();
+        Object[] args = joinPoint.getArgs();
+
+        log.info("[Tool] {} 호출 — args: {}", toolName, Arrays.toString(args));
+        long startedAt = System.currentTimeMillis();
+
+        try {
+            Object result = joinPoint.proceed();
+            long elapsed = System.currentTimeMillis() - startedAt;
+            log.info("[Tool] {} 완료 — {}ms | result: {}", toolName, elapsed, result);
+            return result;
+        } catch (Throwable e) {
+            long elapsed = System.currentTimeMillis() - startedAt;
+            log.error("[Tool] {} 실패 — {}ms | error: {}", toolName, elapsed, e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/mcp-server/src/main/resources/application.yaml
+++ b/mcp-server/src/main/resources/application.yaml
@@ -12,3 +12,7 @@ server:
 
 backend:
   url: http://localhost:8080
+
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%X{requestId}] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #341

## 📝작업 내용

MCP Tool이 호출될 때마다 구조화된 로그를 남기도록 AOP Aspect와 Request ID Filter를 추가했습니다.

### 추가된 파일

#### `logging/RequestIdFilter.java`
- 모든 HTTP 요청 진입 시 UUID(앞 8자리)로 Request ID를 생성
- `X-Request-Id` 헤더가 이미 있으면 그 값을 재사용 (클라이언트 추적 지원)
- SLF4J MDC에 `requestId` 키로 등록 → 해당 스레드의 모든 로그에 자동 포함
- 응답 헤더 `X-Request-Id`로 돌려주어 클라이언트가 요청을 추적 가능
- `finally` 블록에서 `MDC.remove()` 호출 → 스레드 풀 오염 방지

#### `logging/ToolLoggingAspect.java`
- `@Around("@annotation(tool)")` 으로 `@Tool` 붙은 모든 메서드를 인터셉트
- **호출 시**: 툴 이름, 파라미터 배열 INFO 로그
- **성공 시**: 실행 시간(ms), 반환값 INFO 로그
- **실패 시**: 실행 시간(ms), 에러 메시지 ERROR 로그 (스택트레이스 포함)
- 새 Tool 메서드 추가 시 별도 코드 수정 없이 자동 적용

### 변경된 파일

#### `build.gradle`
- `spring-boot-starter-aop` 의존성 추가

#### `src/main/resources/application.yaml`
- 콘솔 로그 패턴에 `%X{requestId}` 추가

### 로그 출력 예시

```
10:23:41.512 [a3f1c2d4] INFO  k.f.m.tool.MeetingTools - [Tool] create_meeting 호출 — args: [1, 3, 2026-05-27T10:00:00, [1, 2], true]
10:23:41.654 [a3f1c2d4] INFO  k.f.m.tool.MeetingTools - [Tool] create_meeting 완료 — 142ms | result: {"code":"SUCCESS",...}
```

같은 `requestId`를 기준으로 로그를 필터링하면 특정 요청의 전체 흐름을 추적할 수 있습니다.

## 💬리뷰 요구사항(선택)

> - `ToolLoggingAspect`에서 result(반환값)를 통째로 로깅하고 있는데, 응답이 길어질 경우 잘라낼 필요가 있는지 검토 부탁드립니다.
