### PR TITLE
[Fix/#349] 노드 number 순서대로 정렬 및 점선 연결 위치 수정

### DIFF
--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -76,7 +76,10 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const { data: flowChart, isFetching: loading } = useFlowchartQuery(projectId);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [sidebarNodeId, setSidebarNodeId] = useState<number | null>(null);
-  const [showDashedLines, setShowDashedLines] = useState(false);
+  const [showDashedLines, setShowDashedLines] = useState(() => {
+    const saved = localStorage.getItem('showDashedLines');
+    return saved !== null ? JSON.parse(saved) : false;
+  });
   const [isCreating, setIsCreating] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [summaryMessageIndex, setSummaryMessageIndex] = useState(0);
@@ -132,16 +135,6 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     },
     [nodes, setNodes],
   );
-
-  // localStorage에서 점선 표시 상태 불러오기
-  useEffect(() => {
-    const saved = localStorage.getItem('showDashedLines');
-    if (saved !== null) {
-      queueMicrotask(() => {
-        setShowDashedLines(JSON.parse(saved));
-      });
-    }
-  }, []);
 
   // 점선 토글 상태를 localStorage에 저장
   useEffect(() => {

--- a/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
+++ b/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
@@ -8,7 +8,6 @@ import { DashedComment } from './DashedComment';
  * React Flow의 getBezierPath를 활용하여 두 개의 곡선으로 구성
  */
 export function ReferenceEdge({
-  id,
   sourceX,
   sourceY,
   targetX,
@@ -101,7 +100,7 @@ export function ReferenceEdge({
     targetX: referenceNodeX,
     targetY: referenceNodeY,
     targetPosition: getOppositePosition(sourcePosition),
-    curvature: 0.5,
+    curvature: 0.25,
   });
 
   const [path2] = getBezierPath({
@@ -111,7 +110,7 @@ export function ReferenceEdge({
     targetX,
     targetY,
     targetPosition,
-    curvature: 0.5,
+    curvature: 0.25,
   });
 
   const commentX = mousePos?.x ?? referenceNodeX;

--- a/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
+++ b/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
@@ -73,9 +73,10 @@ export function ReferenceEdge({
   const positions = [
     { x: midX, y: midY + MIN_OFFSET },           // 아래
     { x: midX, y: midY - MIN_OFFSET },           // 위
+    { x: midX - MIN_OFFSET, y: midY },           // 왼쪽
+    { x: midX + MIN_OFFSET, y: midY },           // 오른쪽
     { x: midX, y: midY + MIN_OFFSET + OFFSET_STEP }, // 더 아래
     { x: midX, y: midY - MIN_OFFSET - OFFSET_STEP }, // 더 위
-    { x: midX, y: midY + MIN_OFFSET + OFFSET_STEP * 2 }, // 훨씬 아래
   ];
 
   for (const pos of positions) {
@@ -100,7 +101,7 @@ export function ReferenceEdge({
     targetX: referenceNodeX,
     targetY: referenceNodeY,
     targetPosition: getOppositePosition(sourcePosition),
-    curvature: 0.25,
+    curvature: 0.5,
   });
 
   const [path2] = getBezierPath({
@@ -110,7 +111,7 @@ export function ReferenceEdge({
     targetX,
     targetY,
     targetPosition,
-    curvature: 0.25,
+    curvature: 0.5,
   });
 
   const commentX = mousePos?.x ?? referenceNodeX;

--- a/frontend/src/utils/flowchartToReactFlow.ts
+++ b/frontend/src/utils/flowchartToReactFlow.ts
@@ -195,14 +195,6 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
   if (flowchart.edges) {
     flowchart.edges.forEach((edge) => {
       if (edge.startNodeId && edge.endNodeId) {
-        const startNode = nodeMap.get(edge.startNodeId);
-        const endNode = nodeMap.get(edge.endNodeId);
-
-        // 메인 노드가 포함되어 있는지 확인
-        const isStartMain = startNode && !startNode.parentId;
-        const isEndMain = endNode && !endNode.parentId;
-        const hasMainNode = isStartMain || isEndMain;
-
         edges.push({
           id: `edge-${edge.edgeId}`,
           source: String(edge.startNodeId),

--- a/frontend/src/utils/flowchartToReactFlow.ts
+++ b/frontend/src/utils/flowchartToReactFlow.ts
@@ -208,10 +208,9 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
           source: String(edge.startNodeId),
           target: String(edge.endNodeId),
           type: 'reference',
-          // 메인 노드 포함: ref handle 사용 (왼쪽→오른쪽)
-          // 서브 노드끼리: 일반 handle 사용 (오른쪽→왼쪽)
-          sourceHandle: hasMainNode ? 'ref-source' : 'source',
-          targetHandle: hasMainNode ? 'ref-target' : 'target',
+          // 모든 참조 관계: ref handle 사용 (왼쪽→오른쪽)
+          sourceHandle: 'ref-source',
+          targetHandle: 'ref-target',
           data: { edgeData: edge },
         });
       }

--- a/frontend/src/utils/flowchartToReactFlow.ts
+++ b/frontend/src/utils/flowchartToReactFlow.ts
@@ -219,9 +219,9 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
           source: String(edge.startNodeId),
           target: String(edge.endNodeId),
           type: 'reference',
-          // 모든 참조 관계: ref handle 사용 (왼쪽→오른쪽)
-          sourceHandle: 'ref-source',
-          targetHandle: 'ref-target',
+          // 참조 관계: 시작 노드 오른쪽 → 끝 노드 왼쪽
+          sourceHandle: 'source',
+          targetHandle: 'target',
           data: { edgeData: edge },
         });
       }

--- a/frontend/src/utils/flowchartToReactFlow.ts
+++ b/frontend/src/utils/flowchartToReactFlow.ts
@@ -8,6 +8,15 @@ export interface FlowchartNode extends Node {
 }
 
 /**
+ * 노드를 number 필드 기준으로 정렬하는 헬퍼 함수
+ */
+function sortByNumber(a: NodeItem, b: NodeItem): number {
+  const numA = a.number ?? '';
+  const numB = b.number ?? '';
+  return numA.localeCompare(numB, undefined, { numeric: true });
+}
+
+/**
  * API 응답(GetFlowchartResponse)을 React Flow 형식으로 변환
  */
 export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
@@ -34,8 +43,10 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
     }
   });
 
-  // 메인 노드 찾기
-  const mainNodes = flowchart.nodes.filter((node) => !node.parentId);
+  // 메인 노드 찾기 및 정렬
+  const mainNodes = flowchart.nodes
+    .filter((node) => !node.parentId)
+    .sort(sortByNumber);
 
   // 각 메인 노드별 depth 1 자식들의 Y 위치
   const depth1YPositions = new Map<number, number>();
@@ -130,7 +141,15 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
     });
 
     if (node.childNodeIds && node.childNodeIds.length > 0) {
-      node.childNodeIds.forEach((childId, childIndex) => {
+      // 자식 노드를 number 필드 기준으로 정렬
+      const sortedChildIds = [...node.childNodeIds].sort((a, b) => {
+        const nodeA = nodeMap.get(a);
+        const nodeB = nodeMap.get(b);
+        if (!nodeA || !nodeB) return 0;
+        return sortByNumber(nodeA, nodeB);
+      });
+
+      sortedChildIds.forEach((childId, childIndex) => {
         const childNode = nodeMap.get(childId);
         if (childNode) {
           const isParentMain = depth === 0;


### PR DESCRIPTION
## #️⃣연관된 이슈

#349 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 노드 정렬 기능 추가
  - 메인 노드와 서브 노드를 `number` 필드 기준으로 오름차순 정렬

2. 참조 엣지(점선) 연결 방향 수정
  - 서브노드 간 참조 관계를 **시작 노드의 오른쪽 → 끝 노드의 왼쪽**으로 변경

3. 점선 토글 상태 새로고침 시에도 유지


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
