### PR TITLE
[Fix/#351] 태그 중복 생성 오류 해결

### DIFF
--- a/frontend/src/components/node-datail/fields/TagField.tsx
+++ b/frontend/src/components/node-datail/fields/TagField.tsx
@@ -50,7 +50,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
   const { data: allTags = [] } = useProjectTagsQuery(projectId);
   const { mutate: addTag } = useAddNodeTagMutation(projectId, nodeId);
   const { mutate: removeTag } = useRemoveNodeTagMutation(projectId, nodeId);
-  const { mutate: createTag } = useCreateTagMutation(projectId);
+  const { mutate: createTag, isPending: isCreating } = useCreateTagMutation(projectId);
   const { mutate: deleteTag } = useDeleteTagMutation(projectId);
   const { mutate: updateTagColor } = useUpdateTagColorMutation(projectId);
 
@@ -123,7 +123,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
 
   const handleCreateTag = () => {
     const trimmed = inputValue.trim();
-    if (!trimmed) return;
+    if (!trimmed || isCreating) return;
 
     const exactMatch = allTags.find((t) => t.name?.toLowerCase() === trimmed.toLowerCase());
     if (exactMatch) {
@@ -131,6 +131,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
       return;
     }
 
+    resetInput();
     createTag(
       { name: trimmed, color: randomColor() },
       {
@@ -143,7 +144,6 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
               showErrorToast(err, '태그 추가에 실패했어요.');
             },
           });
-          resetInput();
         },
         onError: (err) => showErrorToast(err, '태그 생성에 실패했어요.'),
       },

--- a/frontend/src/components/node-datail/fields/TagField.tsx
+++ b/frontend/src/components/node-datail/fields/TagField.tsx
@@ -131,19 +131,12 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
       return;
     }
 
-    resetInput();
     createTag(
       { name: trimmed, color: randomColor() },
       {
         onSuccess: (newTag) => {
           if (!newTag?.tagId) return;
-          yAddTag(newTag);
-          addTag(newTag.tagId, {
-            onError: (err) => {
-              yRemoveTag(newTag.tagId!);
-              showErrorToast(err, '태그 추가에 실패했어요.');
-            },
-          });
+          handleAdd(newTag);
         },
         onError: (err) => showErrorToast(err, '태그 생성에 실패했어요.'),
       },
@@ -151,6 +144,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setSelectedIndex((prev) => Math.min(prev + 1, totalItems - 1));

--- a/frontend/src/components/node-datail/fields/TagField.tsx
+++ b/frontend/src/components/node-datail/fields/TagField.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { ContentBadge, ThemeColorsToken, Typography } from '@wanteddev/wds';
 import { IconClose } from '@wanteddev/wds-icon';
+import { useRef } from 'react';
 
 import { TagItem } from '@/api/Api';
 import { ColorType } from '@/constants/badgeColor';
 import { useErrorToast } from '@/hooks/useErrorToast';
+import { tagKeys } from '@/queries/keys/tagKeys';
 import {
   useAddNodeTagMutation,
   useCreateTagMutation,
@@ -45,14 +48,18 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
     setOutsideCloseDisabled,
   } = usePickerState();
 
+  const queryClient = useQueryClient();
   const showErrorToast = useErrorToast();
   const { tags, yAddTag, yRemoveTag } = useYjsTags(initialTags);
   const { data: allTags = [] } = useProjectTagsQuery(projectId);
   const { mutate: addTag } = useAddNodeTagMutation(projectId, nodeId);
   const { mutate: removeTag } = useRemoveNodeTagMutation(projectId, nodeId);
-  const { mutate: createTag, isPending: isCreating } = useCreateTagMutation(projectId);
+  const { mutate: createTag } = useCreateTagMutation(projectId);
   const { mutate: deleteTag } = useDeleteTagMutation(projectId);
   const { mutate: updateTagColor } = useUpdateTagColorMutation(projectId);
+
+  const isSubmittingRef = useRef(false);
+  const pendingEnterRef = useRef(false);
 
   const assignedTagIds = new Set(tags.map((t) => t.tagId));
 
@@ -121,9 +128,10 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
     !allTags.some((t) => t.name?.toLowerCase() === inputValue.trim().toLowerCase());
   const totalItems = filteredTags.length + (canCreate ? 1 : 0);
 
-  const handleCreateTag = () => {
-    const trimmed = inputValue.trim();
-    if (!trimmed || isCreating) return;
+  const handleCreateTag = (overrideValue?: string) => {
+    if (isSubmittingRef.current) return;
+    const trimmed = (overrideValue ?? inputValue).trim();
+    if (!trimmed) return;
 
     const exactMatch = allTags.find((t) => t.name?.toLowerCase() === trimmed.toLowerCase());
     if (exactMatch) {
@@ -131,20 +139,41 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
       return;
     }
 
+    isSubmittingRef.current = true;
     createTag(
       { name: trimmed, color: randomColor() },
       {
-        onSuccess: (newTag) => {
-          if (!newTag?.tagId) return;
-          handleAdd(newTag);
+        onSuccess: async (newTag) => {
+          isSubmittingRef.current = false;
+          if (newTag?.tagId) {
+            handleAdd(newTag);
+            return;
+          }
+          // API가 tagId를 응답에 포함하지 않는 경우: tags 목록을 refetch 후 이름으로 탐색
+          await queryClient.refetchQueries({ queryKey: tagKeys.list(projectId) });
+          const freshTags = queryClient.getQueryData<TagItem[]>(tagKeys.list(projectId));
+          const created = freshTags?.find((t) => t.name?.toLowerCase() === trimmed.toLowerCase());
+          if (created?.tagId) handleAdd(created);
         },
-        onError: (err) => showErrorToast(err, '태그 생성에 실패했어요.'),
+        onError: (err) => {
+          isSubmittingRef.current = false;
+          showErrorToast(err, '태그 생성에 실패했어요.');
+        },
       },
     );
   };
 
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    if (!pendingEnterRef.current) return;
+    pendingEnterRef.current = false;
+    if (selectedIndex >= 0 && selectedIndex < filteredTags.length) {
+      handleAdd(filteredTags[selectedIndex]);
+    } else {
+      handleCreateTag(e.currentTarget.value);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.nativeEvent.isComposing) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setSelectedIndex((prev) => Math.min(prev + 1, totalItems - 1));
@@ -153,6 +182,10 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
       setSelectedIndex((prev) => Math.max(prev - 1, -1));
     } else if (e.key === 'Enter') {
       e.preventDefault();
+      if (e.nativeEvent.isComposing) {
+        pendingEnterRef.current = true;
+        return;
+      }
       if (selectedIndex >= 0 && selectedIndex < filteredTags.length) {
         handleAdd(filteredTags[selectedIndex]);
       } else if (selectedIndex === filteredTags.length && canCreate) {
@@ -202,6 +235,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onCompositionEnd={handleCompositionEnd}
             className="text-label-normal min-w-20 flex-1 border-0 bg-transparent text-sm outline-none"
             onClick={(e) => e.stopPropagation()}
           />
@@ -250,7 +284,7 @@ export function TagField({ projectId, nodeId, initialTags }: TagFieldProps) {
                 <button
                   type="button"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={handleCreateTag}
+                  onClick={() => handleCreateTag()}
                   className={`text-label-alternative flex w-full items-center gap-2 px-3 py-2 ${selectedIndex === filteredTags.length ? 'bg-gray-100' : 'bg-white hover:bg-gray-50'}`}
                 >
                   <Typography variant="caption1">


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #351 

## 📝작업 내용


## TagField 태그 생성 버그 수정

### 문제 1: 새 태그 생성 API 중복 호출

**원인**
`resetInput()`이 `onSuccess` 콜백 안에서 비동기로 호출되어, API 응답 전까지 입력창이 그대로 남아 있어서 중복 호출되는 오류가 있었습니다!

**해결**
`useCreateTagMutation`의 `isPending`은 React 상태라 동기 흐름에서 반영되지 않으므로, 동기 ref(`isSubmittingRef`)로 중복 제출을 방지하였습니다. 
`createTag` 호출 직전 `isSubmittingRef.current = true` 설정, `onSuccess`/`onError`에서 해제.

---

### 문제 2: 한국어 IME 조합 중 Enter 시 마지막 글자가 입력창에 남음

**원인**
`resetInput()`을 `createTag` 호출 전에 실행하도록 변경했더니, 이후 IME의 `compositionEnd` → `onChange` 이벤트가 발생하며 마지막 조합 글자(예: 테스트를 입력할 경우 "트")가 입력창에 다시 기록되고 있었습니다.

**해결**
`pendingEnterRef` + `onCompositionEnd` 패턴 도입.
Enter를 IME 조합 중 누르면 플래그만 설정하고, `compositionEnd` 이후 `e.currentTarget.value`(DOM 값, 항상 완성된 텍스트)로 처리했습니다.

- Chrome/Mac 등 두 번째 keydown이 발생하는 환경: `isSubmittingRef`로 중복 호출 방지
- 두 번째 keydown이 발생하지 않는 환경: `compositionEnd`에서 직접 처리

---

### 문제 3: 새 태그 생성 후 노드에 태그가 등록되지 않음 (Enter 두 번 필요)

**원인**
`createTag` API 응답 타입이 `data?: object`로만 정의되어, 런타임에 `newTag?.tagId`가 `undefined`인 경우
`if (!newTag?.tagId) return`에서 조기 종료됨.
이후 `invalidateQueries`로 `allTags`가 refetch되면 새 태그가 드롭다운에 노출되고,
사용자가 두 번째 Enter로 직접 등록해야 했습니다. 즉, 엔터를 두 번 입력해야만 새 태그 추가 + 태그 등록까지 가능합니다.

**해결**
`onSuccess`에서 두 가지 경로로 처리:

1. API 응답에 `tagId`가 있으면 바로 `handleAdd(newTag)` 호출
2. 없으면 `queryClient.refetchQueries`로 tags 목록 강제 갱신 후 이름으로 탐색해 `handleAdd` 호출

`handleAdd`는 기존 태그 선택과 동일한 흐름(`yAddTag` → `resetInput` → `addTag`)을 재사용하여
새 태그 생성 + 노드 등록이 Enter 한 번으로 처리됨.
