### PR TITLE
[Fix/#348] 점선 ui 및 멤버 권한 설정 수정

### DIFF
--- a/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
+++ b/frontend/src/components/commons/project-sidebar/setting-modal/MembersSettingsPanel.tsx
@@ -44,7 +44,7 @@ const ROLE_LABEL_MAP: Record<ProjectMemberRole, string> = {
   VIEWER: '뷰어',
 };
 
-const ASSIGNABLE_ROLES: readonly ProjectMemberRole[] = ['MEMBER', 'VIEWER'];
+const ASSIGNABLE_ROLES: readonly ProjectMemberRole[] = ['OWNER', 'MEMBER', 'VIEWER'];
 
 interface MembersSettingsPanelProps {
   projectId: number;
@@ -87,8 +87,8 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
       role: m.role as ProjectMemberRole,
     }));
 
-  const isViewer = myRole === 'VIEWER';
   const isOwner = myRole === 'OWNER';
+  const isMember = myRole === 'MEMBER';
 
   const handleEmailKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter') return;
@@ -234,8 +234,10 @@ export const MembersSettingsPanel = ({ projectId, myRole }: MembersSettingsPanel
         <ul className="custom-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-2">
           {members.map((member) => {
             const rowIsOwner = member.role === 'OWNER';
-            const showRoleDropdown = !isViewer && !rowIsOwner;
-            const showDeleteButton = isOwner && !rowIsOwner;
+            // 관리자(OWNER): 모든 멤버 권한 변경 가능 / 멤버(MEMBER): 관리자 행 제외하고 변경 가능 / 뷰어: 변경 불가
+            const showRoleDropdown = isOwner || (isMember && !rowIsOwner);
+            // 관리자(OWNER)는 관리자 행을 포함한 모든 멤버를 삭제할 수 있다.
+            const showDeleteButton = isOwner;
             return (
               <li
                 key={member.memberId}

--- a/frontend/src/components/projects/node-flow/CustomNode.tsx
+++ b/frontend/src/components/projects/node-flow/CustomNode.tsx
@@ -8,6 +8,7 @@ import { useActiveNodeUsers } from '@/contexts/YjsContext';
 import { useNodeMenuActions } from '@/hooks/useNodeMenuActions';
 import { getColorToken } from '@/utils/getBadgeColorInfo';
 import { formatDate, getVisibleTags } from '@/utils/nodeUtils';
+import { useEdgeHover } from './EdgeHoverContext';
 import { NodeMenu } from './NodeMenu';
 
 interface CustomNodeData extends NodeItem {
@@ -17,11 +18,15 @@ interface CustomNodeData extends NodeItem {
   onSelectNode?: (nodeId: number) => void;
 }
 
-function CustomFlowNodeComponent({ data, selected }: NodeProps<CustomNodeData>) {
+function CustomFlowNodeComponent({ id, data, selected }: NodeProps<CustomNodeData>) {
   const { visibleTags, remainingTagsCount } = getVisibleTags(data.tags ?? []);
   const activeUsers = useActiveNodeUsers(data.nodeId);
   const isMain = data.isMainNode;
   const nodeNumber = data.number ?? data.nodeId;
+
+  // 참조 점선 호버 시 연결된 노드를 포커스된 것처럼 보이게 (실제 선택 아님)
+  const { highlightedNodeIds } = useEdgeHover();
+  const focused = selected || highlightedNodeIds.has(id);
 
   const menuActions = useNodeMenuActions({
     nodeId: data.nodeId ?? 0,
@@ -50,10 +55,10 @@ function CustomFlowNodeComponent({ data, selected }: NodeProps<CustomNodeData>) 
     <div
       data-node-id={data.nodeId ?? ''}
       className={`flex cursor-pointer flex-col overflow-hidden rounded-xl bg-white p-4 outline outline-1 outline-offset-[-1px] transition-all ${isMain ? 'w-64 gap-5' : 'w-60 gap-3'} ${
-        selected ? 'outline-primary-40' : 'hover:outline-primary-40 outline-neutral-200'
+        focused ? 'outline-primary-40' : 'hover:outline-primary-40 outline-neutral-200'
       }`}
       style={
-        selected
+        focused
           ? {
               boxShadow:
                 '-2px -2px 4px 0px color-mix(in srgb, var(--color-primary-40) 20%, transparent), 2px 2px 4px 0px color-mix(in srgb, var(--color-primary-40) 20%, transparent)',

--- a/frontend/src/components/projects/node-flow/EdgeHoverContext.tsx
+++ b/frontend/src/components/projects/node-flow/EdgeHoverContext.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+interface EdgeHoverContextValue {
+  /** 현재 호버된 참조 엣지가 연결한 노드 id 집합 (시각적 포커스용, 실제 선택 아님) */
+  highlightedNodeIds: ReadonlySet<string>;
+  /** 하이라이트할 노드 id를 설정. null/빈 배열이면 해제 */
+  setHighlightedNodes: (ids: readonly string[] | null) => void;
+}
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+const EdgeHoverContext = createContext<EdgeHoverContextValue | null>(null);
+
+export function EdgeHoverProvider({ children }: { children: ReactNode }) {
+  const [highlightedNodeIds, setIds] = useState<ReadonlySet<string>>(EMPTY);
+
+  const setHighlightedNodes = useCallback((ids: readonly string[] | null) => {
+    setIds(ids && ids.length > 0 ? new Set(ids) : EMPTY);
+  }, []);
+
+  const value = useMemo(
+    () => ({ highlightedNodeIds, setHighlightedNodes }),
+    [highlightedNodeIds, setHighlightedNodes],
+  );
+
+  return <EdgeHoverContext.Provider value={value}>{children}</EdgeHoverContext.Provider>;
+}
+
+export function useEdgeHover(): EdgeHoverContextValue {
+  return (
+    useContext(EdgeHoverContext) ?? {
+      highlightedNodeIds: EMPTY,
+      setHighlightedNodes: () => {},
+    }
+  );
+}

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -36,6 +36,7 @@ import { useFlowchartQuery } from '@/queries/node';
 import { useAnalyzeDraggedNodesMutation } from '@/queries/nodeAnalysis';
 import { convertToReactFlow } from '@/utils/flowchartToReactFlow';
 import { CustomNode } from './CustomNode';
+import { EdgeHoverProvider } from './EdgeHoverContext';
 import { NodeButton } from './NodeButton';
 import { ReferenceEdge } from './ReferenceEdge';
 
@@ -52,6 +53,7 @@ const SUMMARY_LOADING_MESSAGES = [
 ];
 
 const SUMMARY_MESSAGE_INTERVAL_MS = 3000;
+const REFERENCE_EDGE_CREATED_EVENT = 'flowmeet:reference-edge-created';
 
 const nodeTypes: NodeTypes = {
   mainNode: CustomNode,
@@ -76,10 +78,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const { data: flowChart, isFetching: loading } = useFlowchartQuery(projectId);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [sidebarNodeId, setSidebarNodeId] = useState<number | null>(null);
-  const [showDashedLines, setShowDashedLines] = useState(() => {
-    const saved = localStorage.getItem('showDashedLines');
-    return saved !== null ? JSON.parse(saved) : false;
-  });
+  const [showDashedLines, setShowDashedLines] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [summaryMessageIndex, setSummaryMessageIndex] = useState(0);
@@ -90,9 +89,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
       return;
     }
     const interval = setInterval(() => {
-      setSummaryMessageIndex((prev) =>
-        Math.min(prev + 1, SUMMARY_LOADING_MESSAGES.length - 1),
-      );
+      setSummaryMessageIndex((prev) => Math.min(prev + 1, SUMMARY_LOADING_MESSAGES.length - 1));
     }, SUMMARY_MESSAGE_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [isSummaryPending]);
@@ -136,10 +133,29 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     [nodes, setNodes],
   );
 
+  // localStorage에서 점선 표시 상태 불러오기
+  useEffect(() => {
+    const saved = localStorage.getItem('showDashedLines');
+    if (saved !== null) {
+      queueMicrotask(() => {
+        setShowDashedLines(JSON.parse(saved));
+      });
+    }
+  }, []);
+
   // 점선 토글 상태를 localStorage에 저장
   useEffect(() => {
     localStorage.setItem('showDashedLines', JSON.stringify(showDashedLines));
   }, [showDashedLines]);
+
+  useEffect(() => {
+    const handleReferenceEdgeCreated = () => setShowDashedLines(true);
+
+    window.addEventListener(REFERENCE_EDGE_CREATED_EVENT, handleReferenceEdgeCreated);
+    return () => {
+      window.removeEventListener(REFERENCE_EDGE_CREATED_EVENT, handleReferenceEdgeCreated);
+    };
+  }, []);
 
   // 뷰포트 위치 복원 (refetch 후에도 마지막 위치 유지)
   useEffect(() => {
@@ -276,12 +292,12 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
               y: topPadding - newFlowNode.position.y * currentViewport.zoom,
               zoom: currentViewport.zoom,
             },
-            { duration: 800 }
+            { duration: 800 },
           );
         }
       }, 100);
     },
-    [setNodes, setEdges, setSelectedNodeId, getViewport, setViewport]
+    [setNodes, setEdges, setSelectedNodeId, getViewport, setViewport],
   );
 
   // 서브 노드 생성
@@ -318,7 +334,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
         setIsCreating(false);
       }
     },
-    [flowChart, updateFlowAndMoveToNode, projectId, isCreating, queryClient, clearSelection]
+    [flowChart, updateFlowAndMoveToNode, projectId, isCreating, queryClient, clearSelection],
   );
 
   // 메인 노드 생성
@@ -497,13 +513,13 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
 
       {isSummaryPending && (
         <div
-          className="fixed inset-0 z-9998 flex items-center justify-center bg-material-dimmer"
+          className="bg-material-dimmer fixed inset-0 z-9998 flex items-center justify-center"
           role="status"
           aria-live="polite"
         >
           <div className="flex flex-col items-center gap-4">
             <div
-              className="h-12 w-12 animate-spin rounded-full border-4 border-primary-90 border-t-primary-40"
+              className="border-primary-90 border-t-primary-40 h-12 w-12 animate-spin rounded-full border-4"
               aria-label="AI 요약 생성 중"
             />
             <span className="text-body-1 text-static-white font-medium">
@@ -513,7 +529,11 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
         </div>
       )}
 
-      <NodeSidebar projectId={projectId} nodeId={sidebarNodeId} onClose={() => setSidebarNodeId(null)} />
+      <NodeSidebar
+        projectId={projectId}
+        nodeId={sidebarNodeId}
+        onClose={() => setSidebarNodeId(null)}
+      />
     </div>
   );
 }
@@ -521,7 +541,9 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
 export function NodeFlowView({ projectId }: NodeFlowViewProps) {
   return (
     <ReactFlowProvider>
-      <NodeFlowContent projectId={projectId} />
+      <EdgeHoverProvider>
+        <NodeFlowContent projectId={projectId} />
+      </EdgeHoverProvider>
     </ReactFlowProvider>
   );
 }

--- a/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
+++ b/frontend/src/components/projects/node-flow/ReferenceEdge.tsx
@@ -1,13 +1,164 @@
-import { useState, useCallback } from 'react';
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, useNodes, useReactFlow, Position } from 'reactflow';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  EdgeLabelRenderer,
+  EdgeProps,
+  type Node as FlowNode,
+  Position,
+  useReactFlow,
+  useStore,
+} from 'reactflow';
 import type { Edge as FlowChartEdge } from '@/types/FlowChartTypes';
 import { DashedComment } from './DashedComment';
+import { useEdgeHover } from './EdgeHoverContext';
 
-/**
- * 참조 관계를 위한 점선 edge + DashedComment
- * React Flow의 getBezierPath를 활용하여 두 개의 곡선으로 구성
- */
+const EDGE_COLOR = 'var(--color-neutral-70)';
+const EDGE_COLOR_HOVER = 'var(--color-primary-40)';
+const EDGE_OPACITY = 0.5;
+const EDGE_OPACITY_HOVER = 1;
+const EDGE_CURVE_RATIO = 0.32;
+const EDGE_BEND_RATIO = 0.18;
+const EDGE_MIN_BEND = 64;
+const EDGE_MAX_BEND = 180;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Rect {
+  width: number;
+  height: number;
+  cx: number;
+  cy: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function getNodeRect(node: FlowNode): Rect {
+  const x = node.positionAbsolute?.x ?? node.position.x;
+  const y = node.positionAbsolute?.y ?? node.position.y;
+  const width = node.width ?? 0;
+  const height = node.height ?? 0;
+
+  return {
+    width,
+    height,
+    cx: x + width / 2,
+    cy: y + height / 2,
+    left: x,
+    right: x + width,
+    top: y,
+    bottom: y + height,
+  };
+}
+
+function getNodeIntersection(node: Rect, towards: Rect): Point {
+  const w = node.width / 2;
+  const h = node.height / 2;
+  const x2 = node.cx;
+  const y2 = node.cy;
+  const x1 = towards.cx;
+  const y1 = towards.cy;
+
+  const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
+  const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);
+  const a = 1 / (Math.abs(xx1) + Math.abs(yy1) || 1);
+  const xx3 = a * xx1;
+  const yy3 = a * yy1;
+
+  return { x: w * (xx3 + yy3) + x2, y: h * (-xx3 + yy3) + y2 };
+}
+
+function getEdgePosition(rect: Rect, point: Point): Position {
+  if (Math.round(point.x) <= Math.round(rect.left) + 1) return Position.Left;
+  if (Math.round(point.x) >= Math.round(rect.right) - 1) return Position.Right;
+  if (Math.round(point.y) <= Math.round(rect.top) + 1) return Position.Top;
+  if (Math.round(point.y) >= Math.round(rect.bottom) - 1) return Position.Bottom;
+  return Position.Top;
+}
+
+function getBendSign(sourcePosition: Position, targetPosition: Position): number {
+  if (sourcePosition === Position.Top || targetPosition === Position.Top) return -1;
+  if (sourcePosition === Position.Bottom || targetPosition === Position.Bottom) return 1;
+  return sourcePosition === Position.Left ? -1 : 1;
+}
+
+function getCubicPoint(
+  start: Point,
+  control1: Point,
+  control2: Point,
+  end: Point,
+  t: number,
+): Point {
+  const mt = 1 - t;
+  const x =
+    mt * mt * mt * start.x +
+    3 * mt * mt * t * control1.x +
+    3 * mt * t * t * control2.x +
+    t * t * t * end.x;
+  const y =
+    mt * mt * mt * start.y +
+    3 * mt * mt * t * control1.y +
+    3 * mt * t * t * control2.y +
+    t * t * t * end.y;
+
+  return { x, y };
+}
+
+function getStraightControlPoint(point: Point, position: Position, offset: number): Point {
+  if (position === Position.Left) return { x: point.x - offset, y: point.y };
+  if (position === Position.Right) return { x: point.x + offset, y: point.y };
+  if (position === Position.Top) return { x: point.x, y: point.y - offset };
+  return { x: point.x, y: point.y + offset };
+}
+
+function getReferencePath({
+  source,
+  target,
+  sourcePosition,
+  targetPosition,
+}: {
+  source: Point;
+  target: Point;
+  sourcePosition: Position;
+  targetPosition: Position;
+}) {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const distance = Math.hypot(dx, dy) || 1;
+  const curveOffset = Math.min(
+    Math.max(distance * EDGE_CURVE_RATIO, EDGE_MIN_BEND),
+    EDGE_MAX_BEND,
+  );
+  const bendOffset = Math.min(Math.max(distance * EDGE_BEND_RATIO, EDGE_MIN_BEND), EDGE_MAX_BEND);
+  const normal = {
+    x: -dy / distance,
+    y: dx / distance,
+  };
+  const bendSign = getBendSign(sourcePosition, targetPosition);
+
+  const control1 = {
+    x: source.x + dx * EDGE_CURVE_RATIO + normal.x * bendOffset * bendSign,
+    y: source.y + dy * EDGE_CURVE_RATIO + normal.y * bendOffset * bendSign,
+  };
+  const control2 = getStraightControlPoint(target, targetPosition, curveOffset);
+  const label = getCubicPoint(source, control1, control2, target, 0.5);
+
+  return {
+    path: `M ${source.x},${source.y} C ${control1.x},${control1.y} ${control2.x},${control2.y} ${target.x},${target.y}`,
+    labelX: label.x,
+    labelY: label.y,
+    control1,
+    control2,
+  };
+}
+
 export function ReferenceEdge({
+  id,
+  source,
+  target,
   sourceX,
   sourceY,
   targetX,
@@ -20,10 +171,19 @@ export function ReferenceEdge({
   const onDeleteEdgeFn = data?.onDeleteEdge as
     | ((edgeId: number, startNodeId: number, endNodeId: number) => void)
     | undefined;
-  const nodes = useNodes();
   const { screenToFlowPosition } = useReactFlow();
+  const { setHighlightedNodes } = useEdgeHover();
+  const sourceNode = useStore(useCallback((s) => s.nodeInternals.get(source), [source]));
+  const targetNode = useStore(useCallback((s) => s.nodeInternals.get(target), [target]));
   const [hovered, setHovered] = useState(false);
-  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+  const [mousePos, setMousePos] = useState<Point | null>(null);
+  const hoveredRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      if (hoveredRef.current) setHighlightedNodes(null);
+    };
+  }, [setHighlightedNodes]);
 
   const handleEdgeClick = () => {
     if (onDeleteEdgeFn && edgeData) {
@@ -39,124 +199,93 @@ export function ReferenceEdge({
     [screenToFlowPosition],
   );
 
-  const midX = (sourceX + targetX) / 2;
-  const midY = (sourceY + targetY) / 2;
-
-  // 노드들과 겹치지 않는 위치 찾기
-  const NODE_WIDTH = 280;
-  const NODE_HEIGHT = 120;
-  const COMMENT_WIDTH = 250;
-  const COMMENT_HEIGHT = 90;
-  const MIN_OFFSET = 120;
-  const OFFSET_STEP = 80;
-
-  function isOverlapping(x: number, y: number): boolean {
-    return nodes.some((node) => {
-      const nodeX = node.position.x;
-      const nodeY = node.position.y;
-
-      // 코멘트 박스와 노드가 겹치는지 확인
-      return (
-        x - COMMENT_WIDTH / 2 < nodeX + NODE_WIDTH &&
-        x + COMMENT_WIDTH / 2 > nodeX &&
-        y - COMMENT_HEIGHT / 2 < nodeY + NODE_HEIGHT &&
-        y + COMMENT_HEIGHT / 2 > nodeY
-      );
-    });
-  }
-
-  // 여러 위치를 시도 (아래 → 위 → 더 아래 → 더 위)
-  let referenceNodeX = midX;
-  let referenceNodeY = midY + MIN_OFFSET;
-
-  const positions = [
-    { x: midX, y: midY + MIN_OFFSET },           // 아래
-    { x: midX, y: midY - MIN_OFFSET },           // 위
-    { x: midX - MIN_OFFSET, y: midY },           // 왼쪽
-    { x: midX + MIN_OFFSET, y: midY },           // 오른쪽
-    { x: midX, y: midY + MIN_OFFSET + OFFSET_STEP }, // 더 아래
-    { x: midX, y: midY - MIN_OFFSET - OFFSET_STEP }, // 더 위
-  ];
-
-  for (const pos of positions) {
-    if (!isOverlapping(pos.x, pos.y)) {
-      referenceNodeX = pos.x;
-      referenceNodeY = pos.y;
-      break;
-    }
-  }
-
-  const getOppositePosition = (pos: Position) => {
-    if (pos === Position.Left) return Position.Right;
-    if (pos === Position.Right) return Position.Left;
-    if (pos === Position.Top) return Position.Bottom;
-    return Position.Top;
+  const handleMouseEnter = () => {
+    hoveredRef.current = true;
+    setHovered(true);
+    setHighlightedNodes([source, target]);
   };
 
-  const [path1] = getBezierPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX: referenceNodeX,
-    targetY: referenceNodeY,
-    targetPosition: getOppositePosition(sourcePosition),
-    curvature: 0.25,
+  const handleMouseLeave = () => {
+    hoveredRef.current = false;
+    setHovered(false);
+    setMousePos(null);
+    setHighlightedNodes(null);
+  };
+
+  let sx = sourceX;
+  let sy = sourceY;
+  let tx = targetX;
+  let ty = targetY;
+  let sPos = sourcePosition;
+  let tPos = targetPosition;
+
+  if (sourceNode?.width != null && targetNode?.width != null) {
+    const sourceRect = getNodeRect(sourceNode);
+    const targetRect = getNodeRect(targetNode);
+    const sourcePoint = getNodeIntersection(sourceRect, targetRect);
+    const targetPoint = getNodeIntersection(targetRect, sourceRect);
+
+    sx = sourcePoint.x;
+    sy = sourcePoint.y;
+    tx = targetPoint.x;
+    ty = targetPoint.y;
+    sPos = getEdgePosition(sourceRect, sourcePoint);
+    tPos = getEdgePosition(targetRect, targetPoint);
+  }
+
+  const {
+    path: edgePath,
+    labelX,
+    labelY,
+  } = getReferencePath({
+    source: { x: sx, y: sy },
+    target: { x: tx, y: ty },
+    sourcePosition: sPos,
+    targetPosition: tPos,
   });
 
-  const [path2] = getBezierPath({
-    sourceX: referenceNodeX,
-    sourceY: referenceNodeY,
-    sourcePosition: getOppositePosition(targetPosition),
-    targetX,
-    targetY,
-    targetPosition,
-    curvature: 0.25,
-  });
-
-  const commentX = mousePos?.x ?? referenceNodeX;
-  const commentY = mousePos?.y ?? referenceNodeY;
+  const strokeColor = hovered ? EDGE_COLOR_HOVER : EDGE_COLOR;
+  const strokeOpacity = hovered ? EDGE_OPACITY_HOVER : EDGE_OPACITY;
+  const markerId = `ref-arrow-${id}`;
+  const commentX = mousePos?.x ?? labelX;
+  const commentY = mousePos?.y ?? labelY;
 
   const sharedHoverProps = {
-    onMouseEnter: () => setHovered(true),
-    onMouseLeave: () => { setHovered(false); setMousePos(null); },
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
     onMouseMove: handleMouseMove,
   };
 
   return (
     <>
-      {/* 첫 번째 점선: 시작 노드 → 참조노드 (시각) */}
+      <defs>
+        <marker
+          id={markerId}
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="10"
+          markerHeight="10"
+          markerUnits="userSpaceOnUse"
+          orient="auto"
+        >
+          <path d="M 1 1 L 9 5 L 1 9 z" style={{ fill: strokeColor, opacity: strokeOpacity }} />
+        </marker>
+      </defs>
       <path
-        d={path1}
+        d={edgePath}
         fill="none"
+        markerEnd={`url(#${markerId})`}
         style={{
-          stroke: hovered ? 'var(--color-primary-40)' : 'var(--color-primary-50)',
+          stroke: strokeColor,
+          strokeOpacity,
           strokeWidth: 1,
           strokeDasharray: '5,5',
-          transition: 'stroke 0.15s',
+          transition: 'stroke 0.15s, stroke-opacity 0.15s',
         }}
       />
-      {/* 두 번째 점선: 참조노드 → 끝 노드 (시각) */}
       <path
-        d={path2}
-        fill="none"
-        style={{
-          stroke: hovered ? 'var(--color-primary-40)' : 'var(--color-primary-50)',
-          strokeWidth: 1,
-          strokeDasharray: '5,5',
-          transition: 'stroke 0.15s',
-        }}
-      />
-      {/* 투명 히트영역: path1 클릭/호버/마우스 감지 */}
-      <path
-        d={path1}
-        fill="none"
-        style={{ stroke: 'transparent', strokeWidth: 14, cursor: 'pointer' }}
-        onClick={handleEdgeClick}
-        {...sharedHoverProps}
-      />
-      {/* 투명 히트영역: path2 클릭/호버/마우스 감지 */}
-      <path
-        d={path2}
+        d={edgePath}
         fill="none"
         style={{ stroke: 'transparent', strokeWidth: 14, cursor: 'pointer' }}
         onClick={handleEdgeClick}

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 import { Loading } from '@/components/commons/loading/Loading';
@@ -9,13 +10,22 @@ import { MeetingEditModalContent } from '@/components/projects/node-flow/Meeting
 import { MeetingDeleteConfirmContent } from '@/components/projects/project-detail/meeting-delete/MeetingDeleteConfirmContent';
 import { NodeDeleteConfirmContent } from '@/components/projects/project-detail/node-delete/NodeDeleteConfirmContent';
 import { ReferenceNodeModalContent } from '@/components/projects/project-detail/reference-node/ReferenceNodeModalContent';
-import { useCreateEdgeMutation, useDeleteEdgeMutation, useLinkedNodesQuery, useNodeListQuery } from '@/queries/edge';
+import {
+  useCreateEdgeMutation,
+  useDeleteEdgeMutation,
+  useLinkedNodesQuery,
+  useNodeListQuery,
+} from '@/queries/edge';
+import { edgeKeys } from '@/queries/keys/edgeKeys';
+import { nodeKeys } from '@/queries/keys/nodeKeys';
 import { useCreateMeetingMutation, useUpdateMeetingMutation } from '@/queries/meeting';
 import { useDeleteMeetingMutation } from '@/queries/meetingDelete';
 import { useProjectMembersQuery } from '@/queries/member';
 import { useNodeDetailQuery } from '@/queries/node';
 import { useDeleteNodeMutation } from '@/queries/nodeDelete';
 import { useErrorToast } from './useErrorToast';
+
+const REFERENCE_EDGE_CREATED_EVENT = 'flowmeet:reference-edge-created';
 
 // 리스트를 받아야 하기 때문에 모달이 열릴 때만 마운트되어 쿼리를 실행
 function ConnectedMeetingCreateModal({
@@ -110,11 +120,7 @@ function ConnectedMeetingEditModal({
   const meeting = nodeDetail?.meeting;
   const meetingId = meeting?.meetingId;
 
-  const { mutate: updateMeeting } = useUpdateMeetingMutation(
-    projectId,
-    nodeId,
-    meetingId ?? 0,
-  );
+  const { mutate: updateMeeting } = useUpdateMeetingMutation(projectId, nodeId, meetingId ?? 0);
 
   useEffect(() => {
     if (!isLoading && !meetingId) onClose();
@@ -166,6 +172,7 @@ function ConnectedReferenceNodeModal({
   const { data: nodeList = [] } = useNodeListQuery(projectId);
   const { mutate: createEdge } = useCreateEdgeMutation(projectId);
   const { mutate: deleteEdge } = useDeleteEdgeMutation(projectId);
+  const queryClient = useQueryClient();
   const showErrorToast = useErrorToast();
 
   const nodeOptions = nodeList
@@ -180,8 +187,13 @@ function ConnectedReferenceNodeModal({
       currentNode={{ number: nodeNumber, title: nodeTitle }}
       onClose={onClose}
       onCreate={(payload) => {
+        window.dispatchEvent(new Event(REFERENCE_EDGE_CREATED_EVENT));
         createEdge(payload, {
-          onSuccess: onClose,
+          onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: nodeKeys.flowchart(projectId) });
+            void queryClient.invalidateQueries({ queryKey: edgeKeys.linked(projectId, nodeId) });
+            onClose();
+          },
           onError: (err) => showErrorToast(err, '참조 노드 연결에 실패했어요.'),
         });
       }}

--- a/frontend/src/queries/edge.ts
+++ b/frontend/src/queries/edge.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
-import type { CreateEdgeRequest } from '@/api/Api';
+import type { CreateEdgeRequest, EdgeItem, GetFlowchartResponse } from '@/api/Api';
 import { edgeKeys } from './keys/edgeKeys';
+import { nodeKeys } from './keys/nodeKeys';
 
 export function useLinkedNodesQuery(projectId: number, nodeId: number) {
   return useQuery({
@@ -20,15 +21,54 @@ export function useLinkedNodesQuery(projectId: number, nodeId: number) {
 export function useNodeListQuery(projectId: number) {
   return useQuery({
     queryKey: edgeKeys.nodeList(projectId),
-    queryFn: () =>
-      privateApi.node.getNodeList(projectId).then((res) => res.data.data?.nodes ?? []),
+    queryFn: () => privateApi.node.getNodeList(projectId).then((res) => res.data.data?.nodes ?? []),
     enabled: !!projectId,
   });
 }
 
 export function useCreateEdgeMutation(projectId: number) {
+  const queryClient = useQueryClient();
+  const flowchartKey = nodeKeys.flowchart(projectId);
+
   return useMutation({
     mutationFn: (data: CreateEdgeRequest) => privateApi.edge.createEdge(projectId, data),
+    onMutate: async (data) => {
+      await queryClient.cancelQueries({ queryKey: flowchartKey });
+
+      const previousFlowchart = queryClient.getQueryData<GetFlowchartResponse | null>(flowchartKey);
+      const tempEdgeId = -Date.now();
+      const tempEdge: EdgeItem = {
+        edgeId: tempEdgeId,
+        startNodeId: data.startNodeId,
+        endNodeId: data.endNodeId,
+        comment: data.comment,
+        createdBy: {
+          userId: 0,
+          nickname: '',
+          email: '',
+          profileImageUrl: '',
+        },
+      };
+
+      queryClient.setQueryData<GetFlowchartResponse | null>(flowchartKey, (old) =>
+        old
+          ? {
+              ...old,
+              edges: [...(old.edges ?? []), tempEdge],
+            }
+          : old,
+      );
+
+      return { previousFlowchart };
+    },
+    onError: (_err, _data, context) => {
+      if (context?.previousFlowchart !== undefined) {
+        queryClient.setQueryData(flowchartKey, context.previousFlowchart);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: flowchartKey });
+    },
   });
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#348 

## 📝작업 내용
- 참조 노드 연결 직후 새로고침 없이 점선이 바로 표시되도록 플로우차트 캐시를 즉시 갱신했습니다.
- 참조 점선 hover 시 연결된 노드가 포커스되도록 처리했습니다.
- 점선의 기본 투명도와 hover 색상 전환을 조정했습니다.
- 먼 노드 간 참조 점선이 보이지 않던 문제를 해결하기 위해 곡선 제어점 계산을 보정했습니다.
- 멤버 권한에 관리자 추가했습니다.