### PR TITLE
[Fix/#355] 회의 삭제 시 노드 플로우와 상세보기에 반영되지 않던 오류 수정

### DIFF
--- a/frontend/src/queries/meetingDelete.ts
+++ b/frontend/src/queries/meetingDelete.ts
@@ -1,12 +1,19 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { privateApi } from '@/api';
+import { nodeKeys } from './keys/nodeKeys';
 
 export function useDeleteMeetingMutation(projectId: number) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: ({ nodeId, meetingId }: { nodeId: number; meetingId: number }) =>
       privateApi.meeting.deleteMeeting(projectId, nodeId, meetingId),
+    onSuccess: (_, { nodeId }) => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.detail(projectId, nodeId) });
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.flowchart(projectId) });
+    },
   });
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #355 

## 📝작업 내용

**문제**
- 회의를 삭제해도 `NodeDetailLayout`이 삭제된 회의 데이터를 계속 렌더링
- `CustomNode` 드롭다운에 "회의 삭제" 항목이 삭제 후에도 계속 표시

**원인**
`useDeleteMeetingMutation`에 `onSuccess` 핸들러가 없어 관련 쿼리 캐시가 invalidate되지 않음

**수정 내용** (`src/queries/meetingDelete.ts`)
- 회의 삭제 성공 시 `nodeKeys.detail` invalidate → `NodeDetailLayout` 최신 데이터 반영
- 회의 삭제 성공 시 `nodeKeys.flowchart` invalidate → `CustomNode`의 `hasMeeting` 플래그 갱신, 드롭다운 메뉴 항목 정상화
