### PR TITLE
[Feat/#359] 플로우차트 노드 응답에 회의 종료 여부(isMeetingEnded) 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/dto/response/GetFlowchartResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import kr.flowmeet.domain.meeting.entity.MeetingStatus;
 import kr.flowmeet.domain.node.entity.Edge;
 import kr.flowmeet.domain.node.entity.Node;
 import kr.flowmeet.domain.node.entity.NodeAssignee;
@@ -24,7 +24,7 @@ public record GetFlowchartResponse(
             final List<Edge> edges,
             final Map<Long, List<NodeTag>> nodeTagMap,
             final Map<Long, List<NodeAssignee>> assigneeMap,
-            final Set<Long> meetingNodeIds,
+            final Map<Long, MeetingStatus> meetingStatusByNodeId,
             final Map<Long, List<Long>> childMap
     ) {
         List<NodeItem> nodeItems = nodes.stream()
@@ -32,7 +32,8 @@ public record GetFlowchartResponse(
                         node,
                         nodeTagMap.getOrDefault(node.getId(), List.of()),
                         assigneeMap.getOrDefault(node.getId(), List.of()),
-                        meetingNodeIds.contains(node.getId()),
+                        meetingStatusByNodeId.containsKey(node.getId()),
+                        meetingStatusByNodeId.get(node.getId()) == MeetingStatus.ENDED,
                         childMap.getOrDefault(node.getId(), List.of())
                 ))
                 .toList();
@@ -66,6 +67,8 @@ public record GetFlowchartResponse(
             List<AssigneeItem> assignees,
             @Schema(description = "연결된 회의 존재 여부", example = "true")
             boolean hasMeeting,
+            @Schema(description = "회의 종료 여부 (회의가 없는 경우 false)", example = "false")
+            boolean isMeetingEnded,
             @Schema(description = "하위 노드 ID 목록", example = "[110, 111]")
             List<Long> childNodeIds,
             @Schema(description = "마지막 수정 시각", example = "2026-04-19T10:15:30")
@@ -77,6 +80,7 @@ public record GetFlowchartResponse(
                 final List<NodeTag> nodeTags,
                 final List<NodeAssignee> nodeAssignees,
                 final boolean hasMeeting,
+                final boolean isMeetingEnded,
                 final List<Long> childNodeIds
         ) {
             return new NodeItem(
@@ -90,6 +94,7 @@ public record GetFlowchartResponse(
                     nodeTags.stream().map(nt -> TagItem.from(nt.getTag())).toList(),
                     nodeAssignees.stream().map(AssigneeItem::from).toList(),
                     hasMeeting,
+                    isMeetingEnded,
                     childNodeIds,
                     node.getUpdatedAt()
             );

--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/node/facade/NodeFacade.java
@@ -36,6 +36,7 @@ import kr.flowmeet.api.node.dto.response.SearchNodeResponse;
 import kr.flowmeet.domain.common.exception.BusinessException;
 import kr.flowmeet.domain.meeting.entity.Meeting;
 import kr.flowmeet.domain.meeting.entity.MeetingParticipant;
+import kr.flowmeet.domain.meeting.entity.MeetingStatus;
 import kr.flowmeet.domain.meeting.service.MeetingService;
 import kr.flowmeet.domain.node.entity.Edge;
 import kr.flowmeet.domain.node.entity.Node;
@@ -82,14 +83,14 @@ public class NodeFacade {
 
         Map<Long, List<NodeTag>> nodeTagMap = nodeTagService.findAllByNodeIdsAsMap(nodeIds);
         Map<Long, List<NodeAssignee>> assigneeMap = nodeAssigneeService.findAllByNodeIdsAsMap(nodeIds);
-        Set<Long> meetingNodeIds = meetingService.findAllMeetingNodeIds(nodeIds);
+        Map<Long, MeetingStatus> meetingStatusByNodeId = meetingService.findMeetingStatusByNodeIds(nodeIds);
         Map<Long, List<Long>> childIdMap = nodeService.getChildNodeIdMap(nodes);
 
         List<Node> sortedNodes = nodes.stream()
                 .sorted(NODE_NUMBER_ORDER)
                 .toList();
 
-        return GetFlowchartResponse.of(sortedNodes, edges, nodeTagMap, assigneeMap, meetingNodeIds, childIdMap);
+        return GetFlowchartResponse.of(sortedNodes, edges, nodeTagMap, assigneeMap, meetingStatusByNodeId, childIdMap);
     }
 
     public GetNodeResponse getNode(final Long userId, final Long projectId, final Long nodeId) {

--- a/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
+++ b/backend/flowmeet-domain/src/main/java/kr/flowmeet/domain/meeting/service/MeetingService.java
@@ -3,6 +3,7 @@ package kr.flowmeet.domain.meeting.service;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,6 +60,11 @@ public class MeetingService {
                 .stream()
                 .map(Meeting::getNodeId)
                 .collect(Collectors.toSet());
+    }
+
+    public Map<Long, MeetingStatus> findMeetingStatusByNodeIds(final List<Long> nodeIds) {
+        return findAllByNodeIds(nodeIds).stream()
+                .collect(Collectors.toMap(Meeting::getNodeId, Meeting::getStatus));
     }
 
     public List<Meeting> findScheduledToStart(final LocalDateTime now) {


### PR DESCRIPTION
# feat: 플로우차트 노드 응답에 회의 종료 여부 추가

## #️⃣연관된 이슈

- Closes #359

## 📝작업 내용

플로우차트 조회 시 노드에 연결된 회의가 있을 경우, 회의 종료 여부(`isMeetingEnded`)를 응답에 함께 포함하도록 추가했습니다.

### 변경 사항

**`MeetingService`** — `findMeetingStatusByNodeIds()` 메서드 추가

노드 ID 목록을 받아 각 노드의 `MeetingStatus`를 맵으로 반환합니다.
기존 `findAllMeetingNodeIds()`(칸반·노드 목록 뷰에서 사용 중)는 그대로 유지했습니다.

```java
public Map<Long, MeetingStatus> findMeetingStatusByNodeIds(final List<Long> nodeIds) {
    return findAllByNodeIds(nodeIds).stream()
            .collect(Collectors.toMap(Meeting::getNodeId, Meeting::getStatus));
}
```

**`NodeFacade.getFlowchart()`** — 기존 `Set<Long>` 대신 상태 맵 사용

```java
// Before
Set<Long> meetingNodeIds = meetingService.findAllMeetingNodeIds(nodeIds);

// After
Map<Long, MeetingStatus> meetingStatusByNodeId = meetingService.findMeetingStatusByNodeIds(nodeIds);
```

**`GetFlowchartResponse.NodeItem`** — `isMeetingEnded` 필드 추가

| 필드 | 타입 | 설명 |
|------|------|------|
| `hasMeeting` | `boolean` | 연결된 회의 존재 여부 (기존) |
| `isMeetingEnded` | `boolean` | 회의 종료 여부 (`ENDED` 상태일 때만 `true`, 회의 없으면 `false`) |

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
