### PR TITLE
[Fix/#357] 회의 생성/수정 관련 오류들 해결

### DIFF
--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1813,6 +1813,11 @@ export interface NodeItem {
    */
   hasMeeting?: boolean;
   /**
+   * 회의 종료 여부 (회의가 없는 경우 false)
+   * @example false
+   */
+  isMeetingEnded?: boolean;
+  /**
    * 하위 노드 ID 목록
    * @example [110,111]
    */
@@ -2632,14 +2637,7 @@ export interface NotificationSummaryResponse {
    * 알림 유형
    * @example "MEETING_CREATED"
    */
-  type?:
-    | "MEETING_CREATED"
-    | "MEETING_INVITE"
-    | "MEETING_REMINDER"
-    | "MEETING_ENDED"
-    | "MEMBER_INVITE"
-    | "NODE_ASSIGNED"
-    | "NODE_UPDATED";
+  type?: "MEETING_INVITE" | "MEETING_REMINDER" | "NODE_ASSIGNED";
   /**
    * 알림 제목
    * @example "새 회의"

--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -87,6 +87,7 @@ export function NodeDetailLayout({
     projectId,
     nodeTitle: nodeDetail?.title,
     nodeNumber: nodeDetail?.number,
+    meetingStatus: nodeDetail?.meeting?.status,
     onDeleteSuccess,
   });
 

--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -87,7 +87,7 @@ export function NodeDetailLayout({
     projectId,
     nodeTitle: nodeDetail?.title,
     nodeNumber: nodeDetail?.number,
-    meetingStatus: nodeDetail?.meeting?.status,
+    isMeetingEnded: nodeDetail?.meeting?.status === 'ENDED',
     onDeleteSuccess,
   });
 

--- a/frontend/src/components/projects/list/ListCard.tsx
+++ b/frontend/src/components/projects/list/ListCard.tsx
@@ -31,6 +31,7 @@ interface ListCardProps {
   assignees?: ListCardAssignee[];
   isMainNode?: boolean;
   hasMeeting?: boolean;
+  isMeetingEnded?: boolean;
   onDoubleClick?: () => void;
 }
 
@@ -45,6 +46,7 @@ export function ListCard({
   assignees = [],
   isMainNode = false,
   hasMeeting = false,
+  isMeetingEnded = false,
   onDoubleClick,
 }: ListCardProps) {
   const { visibleTags, remainingTagsCount } = getVisibleTags(tags, 8);
@@ -55,7 +57,7 @@ export function ListCard({
       ? 'sub-with-meeting'
       : 'sub-without-meeting';
 
-  const menuActions = useNodeMenuActions({ nodeId, projectId, nodeTitle: title, nodeNumber });
+  const menuActions = useNodeMenuActions({ nodeId, projectId, nodeTitle: title, nodeNumber, isMeetingEnded });
 
   return (
     <div

--- a/frontend/src/components/projects/node-flow/CustomNode.tsx
+++ b/frontend/src/components/projects/node-flow/CustomNode.tsx
@@ -33,6 +33,7 @@ function CustomFlowNodeComponent({ id, data, selected }: NodeProps<CustomNodeDat
     projectId: data.projectId,
     nodeTitle: data.title ?? undefined,
     nodeNumber,
+    isMeetingEnded: data.isMeetingEnded,
     onBeforeAction: () => {
       if (data.nodeId !== undefined) data.onSelectNode?.(data.nodeId);
     },

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -442,6 +442,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     projectId,
     nodeTitle: selectedNodeData?.title ?? '',
     nodeNumber: selectedNodeData?.number,
+    isMeetingEnded: selectedNodeData?.isMeetingEnded,
     onBeforeAction: clearSelection,
   });
 

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -30,6 +30,7 @@ import { EdgeDeleteConfirmContent } from '@/components/projects/project-detail/e
 import { MultiNodeSummaryModalContent } from '@/components/projects/project-detail/multi-node-summary/MultiNodeSummaryModalContent';
 import type { MultiNodeSummaryNode } from '@/components/projects/project-detail/multi-node-summary/types';
 import { useErrorToast } from '@/hooks/useErrorToast';
+import { useNodeMenuActions } from '@/hooks/useNodeMenuActions';
 import { useDeleteEdgeMutation } from '@/queries/edge';
 import { nodeKeys } from '@/queries/keys/nodeKeys';
 import { useFlowchartQuery } from '@/queries/node';
@@ -435,6 +436,15 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
 
   const isMultiNodeSelected = selectedNodes.length > 1;
 
+  const selectedNodeData = !isMultiNodeSelected ? selectedNodes[0]?.data : null;
+  const { onCreateMeeting } = useNodeMenuActions({
+    nodeId: selectedNodeId ?? 0,
+    projectId,
+    nodeTitle: selectedNodeData?.title ?? '',
+    nodeNumber: selectedNodeData?.number,
+    onBeforeAction: clearSelection,
+  });
+
   const visibleEdges = useMemo(() => {
     if (showDashedLines) {
       return edgesWithHandlers;
@@ -496,10 +506,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
             }
             onAddMeeting={
               selectedNodeId && !isMultiNodeSelected && !selectedNodes[0]?.data.isMainNode
-                ? () => {
-                    clearSelection();
-                    /* TODO: 모달 열기 */
-                  }
+                ? onCreateMeeting
                 : undefined
             }
             onAISummary={selectedNodes.length > 1 ? handleAISummary : undefined}

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -505,7 +505,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
                 : undefined
             }
             onAddMeeting={
-              selectedNodeId && !isMultiNodeSelected && !selectedNodes[0]?.data.isMainNode
+              selectedNodeId && !isMultiNodeSelected && !selectedNodes[0]?.data.isMainNode && !selectedNodes[0]?.data.hasMeeting
                 ? onCreateMeeting
                 : undefined
             }

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -495,7 +495,7 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
                 : undefined
             }
             onAddMeeting={
-              selectedNodeId && !isMultiNodeSelected
+              selectedNodeId && !isMultiNodeSelected && !selectedNodes[0]?.data.isMainNode
                 ? () => {
                     clearSelection();
                     /* TODO: 모달 열기 */

--- a/frontend/src/components/projects/node-flow/NodeMenu.tsx
+++ b/frontend/src/components/projects/node-flow/NodeMenu.tsx
@@ -112,7 +112,7 @@ export function NodeMenu({
             </CustomMenuItem>
           )}
 
-          {variant === 'sub-with-meeting' && (
+          {variant === 'sub-with-meeting' && !!onEditMeeting && (
             <CustomMenuItem
               value="edit-meeting"
               icon={<IconPencil />}

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -211,6 +211,7 @@ interface NodeMenuActionsOptions {
   projectId: number;
   nodeTitle?: string;
   nodeNumber?: number | string;
+  meetingStatus?: string;
   onBeforeAction?: () => void;
   onDeleteSuccess?: () => void;
 }
@@ -220,6 +221,7 @@ export function useNodeMenuActions({
   projectId,
   nodeTitle = '',
   nodeNumber,
+  meetingStatus,
   onBeforeAction,
   onDeleteSuccess,
 }: NodeMenuActionsOptions) {
@@ -250,15 +252,17 @@ export function useNodeMenuActions({
         ),
       });
     },
-    onEditMeeting: () => {
-      before();
-      openModal({
-        closeOnBackdrop: true,
-        content: (
-          <ConnectedMeetingEditModal projectId={projectId} nodeId={nodeId} onClose={closeModal} />
-        ),
-      });
-    },
+    ...(meetingStatus !== 'ENDED' && {
+      onEditMeeting: () => {
+        before();
+        openModal({
+          closeOnBackdrop: true,
+          content: (
+            <ConnectedMeetingEditModal projectId={projectId} nodeId={nodeId} onClose={closeModal} />
+          ),
+        });
+      },
+    }),
     onDeleteMeeting: () => {
       before();
       openModal({

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -211,7 +211,7 @@ interface NodeMenuActionsOptions {
   projectId: number;
   nodeTitle?: string;
   nodeNumber?: number | string;
-  meetingStatus?: string;
+  isMeetingEnded?: boolean;
   onBeforeAction?: () => void;
   onDeleteSuccess?: () => void;
 }
@@ -221,7 +221,7 @@ export function useNodeMenuActions({
   projectId,
   nodeTitle = '',
   nodeNumber,
-  meetingStatus,
+  isMeetingEnded,
   onBeforeAction,
   onDeleteSuccess,
 }: NodeMenuActionsOptions) {
@@ -252,7 +252,7 @@ export function useNodeMenuActions({
         ),
       });
     },
-    ...(meetingStatus !== 'ENDED' && {
+    ...(!isMeetingEnded && {
       onEditMeeting: () => {
         before();
         openModal({


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #357

## 📝작업 내용

### 1. 종료된 회의(ENDED)의 "회의 수정" 메뉴 항목 숨김

`meeting.status === 'ENDED'`인 경우 회의가 종료된 상태이므로 수정이 불가능해야 합니다.

**변경 파일:**
- `hooks/useNodeMenuActions.tsx` — `isMeetingEnded?: boolean` 옵션 추가. `true`일 경우 `onEditMeeting` 반환하지 않음
- `components/projects/node-flow/NodeMenu.tsx` — "회의 수정" 렌더 조건에 `!!onEditMeeting` 추가
- `components/node-datail/NodeDetailLayout.tsx` — `isMeetingEnded={meeting.status === 'ENDED'}` 전달
- `components/projects/node-flow/CustomNode.tsx` — `isMeetingEnded={data.isMeetingEnded}` 전달 (백엔드에서 `NodeItem`에 필드 추가됨)
- `components/projects/node-flow/NodeFlowView.tsx` — `isMeetingEnded={selectedNodeData?.isMeetingEnded}` 전달
- `components/projects/list/ListCard.tsx` — `isMeetingEnded` prop 추가 및 hook 전달

---

### 2. 메인 노드 선택 시 NodeButton "회의 추가" 버튼 비활성화

메인 노드에는 회의를 추가할 수 없으므로 `isMainNode`일 때 버튼을 disabled 처리합니다.

**변경 파일:**
- `components/projects/node-flow/NodeFlowView.tsx` — `onAddMeeting` 조건에 `!selectedNodes[0]?.data.isMainNode` 추가

---

### 3. 이미 회의가 있는 노드 선택 시 NodeButton "회의 추가" 버튼 비활성화

회의가 이미 존재하는 경우(`hasMeeting`) 버튼을 disabled 처리합니다.

**변경 파일:**
- `components/projects/node-flow/NodeFlowView.tsx` — `onAddMeeting` 조건에 `!selectedNodes[0]?.data.hasMeeting` 추가

---

### 4. NodeButton "회의 추가" 버튼 → 실제 모달 연결

기존에 `/* TODO: 모달 열기 */`로만 남아 있던 부분을 `useNodeMenuActions`의 `onCreateMeeting`으로 연결합니다.

**변경 파일:**
- `components/projects/node-flow/NodeFlowView.tsx` — `useNodeMenuActions` 호출 추가, `onAddMeeting`에 `onCreateMeeting` 연결

