### PR TITLE
[Feat/#360] 입력 시 프로필 띄우기

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import { IconButton } from '@wanteddev/wds';
-import { IconTemplate } from '@wanteddev/wds-icon';
+import { IconClose, IconTemplate } from '@wanteddev/wds-icon';
 
 interface ChatHeaderProps {
   isSidebarOpen: boolean;
   onOpenSidebar: () => void;
+  onClose: () => void;
 }
 
-export function ChatHeader({ isSidebarOpen, onOpenSidebar }: ChatHeaderProps) {
+export function ChatHeader({ isSidebarOpen, onOpenSidebar, onClose }: ChatHeaderProps) {
   return (
-    <div className={`px-5 py-4 flex justify-between items-center ${isSidebarOpen ? 'rounded-tr-xl' : 'rounded-t-xl'}`}>
+    <div
+      className={`flex items-center justify-between px-5 py-4 ${isSidebarOpen ? 'rounded-tr-xl' : 'rounded-t-xl'}`}
+    >
       <div className="flex items-center gap-4">
         {!isSidebarOpen && (
           <IconButton
@@ -24,9 +27,19 @@ export function ChatHeader({ isSidebarOpen, onOpenSidebar }: ChatHeaderProps) {
         )}
         <div className="flex flex-col">
           <p className="text-caption-1 font-medium">플로밋 AI 에이전트</p>
-          <p className="text-caption-2 font-regular text-interaction-inactive">새 대화를 시작하세요</p>
+          <p className="text-caption-2 font-regular text-interaction-inactive">
+            새 대화를 시작하세요
+          </p>
         </div>
       </div>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="채팅 닫기"
+        className="text-label-alternative hover:text-label-neutral flex h-7 w-7 items-center justify-center border-none bg-transparent p-0"
+      >
+        <IconClose className="h-6 w-6" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -4,8 +4,21 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useState, useEffect, useRef } from 'react';
 import { privateApi } from '@/api';
-import { type MultiSelectInputValue, type NodeOption, type UserOption } from '@/components/commons/custom-input/MultiSelectInput';
-import { useStartChat, useSendMessage, useGetAllChatSessions, useGetChatSessionDetail, useGetReferenceNodes, useGetReferenceUsers, useAddChatNode, useRemoveChatNode } from '@/queries/chat';
+import {
+  type MultiSelectInputValue,
+  type NodeOption,
+  type UserOption,
+} from '@/components/commons/custom-input/MultiSelectInput';
+import {
+  useStartChat,
+  useSendMessage,
+  useGetAllChatSessions,
+  useGetChatSessionDetail,
+  useGetReferenceNodes,
+  useGetReferenceUsers,
+  useAddChatNode,
+  useRemoveChatNode,
+} from '@/queries/chat';
 import { chatKeys } from '@/queries/keys/chatKeys';
 import { nodeKeys } from '@/queries/keys/nodeKeys';
 import { ChatHeader } from './ChatHeader';
@@ -99,7 +112,7 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
 
   const chatSessions = chatSessionsData?.data?.content || [];
 
-  // 선택된 채팅 상세 조회 
+  // 선택된 채팅 상세 조회
   const { data: chatDetail } = useGetChatSessionDetail({
     projectId,
     chatSessionId: selectedChatId ?? chatSessionId ?? 0,
@@ -240,7 +253,10 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
               try {
                 const flowchartResponse = await privateApi.node.getFlowchart(projectId);
                 if (flowchartResponse.data.data) {
-                  queryClient.setQueryData(nodeKeys.flowchart(projectId), flowchartResponse.data.data);
+                  queryClient.setQueryData(
+                    nodeKeys.flowchart(projectId),
+                    flowchartResponse.data.data,
+                  );
                 }
               } catch (error) {
                 console.error('Failed to update flowchart:', error);
@@ -260,7 +276,7 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
             };
             setMessages((prev) => [...prev, errorMessage]);
           },
-        }
+        },
       );
     } else {
       // 기존 세션에 메시지 추가
@@ -289,7 +305,10 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
             try {
               const flowchartResponse = await privateApi.node.getFlowchart(projectId);
               if (flowchartResponse.data.data) {
-                queryClient.setQueryData(nodeKeys.flowchart(projectId), flowchartResponse.data.data);
+                queryClient.setQueryData(
+                  nodeKeys.flowchart(projectId),
+                  flowchartResponse.data.data,
+                );
               }
             } catch (error) {
               console.error('Failed to update flowchart:', error);
@@ -298,9 +317,15 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
             // 선택된 채팅의 메시지 목록도 백그라운드에서 조용히 업데이트
             if (currentChatSessionId) {
               try {
-                const chatDetailResponse = await privateApi.chat.getChatSessionDetail(projectId, currentChatSessionId);
+                const chatDetailResponse = await privateApi.chat.getChatSessionDetail(
+                  projectId,
+                  currentChatSessionId,
+                );
                 if (chatDetailResponse.data.data) {
-                  queryClient.setQueryData(chatKeys.detail(projectId, currentChatSessionId), chatDetailResponse.data.data);
+                  queryClient.setQueryData(
+                    chatKeys.detail(projectId, currentChatSessionId),
+                    chatDetailResponse.data.data,
+                  );
                 }
               } catch (error) {
                 console.error('Failed to update chat detail:', error);
@@ -320,7 +345,7 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
             };
             setMessages((prev) => [...prev, errorMessage]);
           },
-        }
+        },
       );
     }
   };
@@ -341,13 +366,13 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
     <>
       <div
         ref={chatWindowRef}
-        className={`fixed bottom-6 z-50 pointer-events-auto ${isSidebarOpen ? 'shadow-normal-small' : ''}`}
+        className={`pointer-events-auto fixed bottom-6 z-50 ${isSidebarOpen ? 'shadow-normal-small' : ''}`}
         style={{
           right: isNodeSidebarOpen ? 24 + sidebarWidth : 24,
           transition: 'right 0.25s ease',
         }}
       >
-        <div className="relative w-96 h-[563px]">
+        <div className="relative h-[563px] w-96">
           <ChatSidebar
             isOpen={isSidebarOpen}
             onClose={() => setIsSidebarOpen(false)}
@@ -372,10 +397,13 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
             }}
           />
 
-          <div className={`relative w-full h-full bg-white flex flex-col transition-all duration-300 ${isSidebarOpen ? 'rounded-r-xl' : 'rounded-xl shadow-normal-small'}`}>
+          <div
+            className={`relative flex h-full w-full flex-col bg-white transition-all duration-300 ${isSidebarOpen ? 'rounded-r-xl' : 'shadow-normal-small rounded-xl'}`}
+          >
             <ChatHeader
               isSidebarOpen={isSidebarOpen}
               onOpenSidebar={() => setIsSidebarOpen(true)}
+              onClose={onClose}
             />
 
             <ChatMessageList
@@ -389,13 +417,17 @@ export function ChatWindow({ onClose, isNodeSidebarOpen, sidebarWidth }: ChatWin
                 const addedNodes = newValue.mentions.filter(
                   (mention) =>
                     mention.type === 'node' &&
-                    !inputValue.mentions.some((prev) => prev.id === mention.id && prev.type === 'node')
+                    !inputValue.mentions.some(
+                      (prev) => prev.id === mention.id && prev.type === 'node',
+                    ),
                 );
 
                 const removedNodes = inputValue.mentions.filter(
                   (mention) =>
                     mention.type === 'node' &&
-                    !newValue.mentions.some((next) => next.id === mention.id && next.type === 'node')
+                    !newValue.mentions.some(
+                      (next) => next.id === mention.id && next.type === 'node',
+                    ),
                 );
 
                 if (currentChatSessionId) {

--- a/frontend/src/components/commons/editor/TypingProfilePresence.tsx
+++ b/frontend/src/components/commons/editor/TypingProfilePresence.tsx
@@ -7,7 +7,7 @@ import type { YjsAwarenessState, YjsContextValue } from '@/contexts/YjsContext';
 import { normalizeImageUrl } from '@/utils/normalizeImageUrl';
 
 const AVATAR_SIZE = 24;
-const AVATAR_GAP = 8;
+const AVATAR_GAP = 16;
 const TYPING_PRESENCE_MAX_AGE_MS = 30000;
 
 interface TypingProfilePresenceProps {
@@ -55,7 +55,7 @@ const setLocalTypingState = (
   });
 };
 
-const getRemoteTypingProfiles = (yjsCtx: YjsContextValue, field: string): TypingProfile[] => {
+const getTypingProfiles = (yjsCtx: YjsContextValue, field: string): TypingProfile[] => {
   const localClientId = yjsCtx.provider.awareness.clientID;
   const now = Date.now();
   const profiles: TypingProfile[] = [];
@@ -88,9 +88,14 @@ const getProfilePositions = (
 
   try {
     const view = editor.view;
+    const container =
+      (view.dom.closest('[data-typing-profile-container]') as HTMLElement | null) ??
+      view.dom.parentElement ??
+      view.dom;
+    const containerRect = container.getBoundingClientRect();
     const editorRect = view.dom.getBoundingClientRect();
 
-    return profiles.flatMap((profile, index) => {
+    return profiles.flatMap((profile) => {
       try {
         const docSize = editor.state.doc.content.size;
         const safeHead = Math.max(0, Math.min(profile.head, docSize));
@@ -99,8 +104,12 @@ const getProfilePositions = (
         return [
           {
             ...profile,
-            top: coords.top + (coords.bottom - coords.top) / 2 - AVATAR_SIZE / 2,
-            left: editorRect.left - AVATAR_SIZE - AVATAR_GAP - index * (AVATAR_SIZE + 4),
+            top: coords.top + (coords.bottom - coords.top) / 2 - AVATAR_SIZE / 2 - containerRect.top,
+            // 컨테이너 왼쪽 바깥(음수)으로 나가면 상위 overflow에 잘리므로 안쪽으로 클램프한다.
+            left: Math.max(
+              2,
+              editorRect.left - containerRect.left - AVATAR_SIZE - AVATAR_GAP,
+            ),
           },
         ];
       } catch {
@@ -146,7 +155,7 @@ export function TypingProfilePresence({ editor, yjsCtx, field }: TypingProfilePr
     }
 
     const updateProfiles = () => {
-      const typingProfiles = getRemoteTypingProfiles(yjsCtx, field);
+      const typingProfiles = getTypingProfiles(yjsCtx, field);
       setProfiles(getProfilePositions(editor, typingProfiles));
     };
 
@@ -170,8 +179,8 @@ export function TypingProfilePresence({ editor, yjsCtx, field }: TypingProfilePr
         return (
           <div
             key={profile.clientId}
-            className="border-static-white shadow-normal-small pointer-events-none fixed z-90 h-6 w-6 overflow-hidden rounded-full border"
-            style={{ top: profile.top, left: profile.left, backgroundColor: profile.color }}
+            className="border-static-white shadow-normal-small pointer-events-none absolute z-50 flex h-6 w-6 items-center justify-center overflow-hidden rounded-full border bg-gray-200"
+            style={{ top: profile.top, left: profile.left }}
             title={profile.nickname}
           >
             {profileImageUrl ? (
@@ -183,7 +192,7 @@ export function TypingProfilePresence({ editor, yjsCtx, field }: TypingProfilePr
                 draggable={false}
               />
             ) : (
-              <span className="text-caption-2 text-static-white flex h-full w-full items-center justify-center font-medium">
+              <span className="text-caption-2 text-label-alternative font-medium">
                 {getInitial(profile.nickname)}
               </span>
             )}

--- a/frontend/src/components/commons/editor/TypingProfilePresence.tsx
+++ b/frontend/src/components/commons/editor/TypingProfilePresence.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import type { Editor } from '@tiptap/react';
+import { useEffect, useState } from 'react';
+
+import type { YjsAwarenessState, YjsContextValue } from '@/contexts/YjsContext';
+import { normalizeImageUrl } from '@/utils/normalizeImageUrl';
+
+const AVATAR_SIZE = 24;
+const AVATAR_GAP = 8;
+const TYPING_PRESENCE_MAX_AGE_MS = 30000;
+
+interface TypingProfilePresenceProps {
+  editor: Editor | null;
+  yjsCtx: YjsContextValue | null;
+  field: string;
+}
+
+interface TypingProfile {
+  clientId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+  color: string;
+  head: number;
+}
+
+interface TypingProfilePosition extends TypingProfile {
+  top: number;
+  left: number;
+}
+
+const getInitial = (nickname: string) => nickname.trim().charAt(0) || '?';
+
+const getCurrentUser = (yjsCtx: YjsContextValue | null) =>
+  yjsCtx?.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null;
+
+const setLocalTypingState = (
+  yjsCtx: YjsContextValue | null,
+  field: string,
+  head: number | null,
+) => {
+  const user = getCurrentUser(yjsCtx)?.user;
+  if (!yjsCtx || !user) return;
+
+  yjsCtx.provider.awareness.setLocalStateField('user', {
+    ...user,
+    typing:
+      head === null
+        ? null
+        : {
+            field,
+            head,
+            updatedAt: Date.now(),
+          },
+  });
+};
+
+const getRemoteTypingProfiles = (yjsCtx: YjsContextValue, field: string): TypingProfile[] => {
+  const localClientId = yjsCtx.provider.awareness.clientID;
+  const now = Date.now();
+  const profiles: TypingProfile[] = [];
+
+  yjsCtx.provider.awareness.getStates().forEach((state, clientId) => {
+    if (clientId === localClientId) return;
+
+    const user = (state as Partial<YjsAwarenessState>).user;
+    const typing = user?.typing;
+    if (!user?.nickname || !typing || typing.field !== field) return;
+    if (now - typing.updatedAt > TYPING_PRESENCE_MAX_AGE_MS) return;
+
+    profiles.push({
+      clientId,
+      nickname: user.nickname,
+      profileImageUrl: user.profileImageUrl,
+      color: user.color,
+      head: typing.head,
+    });
+  });
+
+  return profiles;
+};
+
+const getProfilePositions = (
+  editor: Editor,
+  profiles: TypingProfile[],
+): TypingProfilePosition[] => {
+  if (editor.isDestroyed) return [];
+
+  try {
+    const view = editor.view;
+    const editorRect = view.dom.getBoundingClientRect();
+
+    return profiles.flatMap((profile, index) => {
+      try {
+        const docSize = editor.state.doc.content.size;
+        const safeHead = Math.max(0, Math.min(profile.head, docSize));
+        const coords = view.coordsAtPos(safeHead);
+
+        return [
+          {
+            ...profile,
+            top: coords.top + (coords.bottom - coords.top) / 2 - AVATAR_SIZE / 2,
+            left: editorRect.left - AVATAR_SIZE - AVATAR_GAP - index * (AVATAR_SIZE + 4),
+          },
+        ];
+      } catch {
+        return [];
+      }
+    });
+  } catch {
+    return [];
+  }
+};
+
+export function TypingProfilePresence({ editor, yjsCtx, field }: TypingProfilePresenceProps) {
+  const [profiles, setProfiles] = useState<TypingProfilePosition[]>([]);
+
+  useEffect(() => {
+    if (!editor || !yjsCtx) return;
+
+    const updateLocalTyping = () => {
+      if (!editor.isFocused) return;
+      setLocalTypingState(yjsCtx, field, editor.state.selection.head);
+    };
+
+    const clearLocalTyping = () => setLocalTypingState(yjsCtx, field, null);
+
+    editor.on('focus', updateLocalTyping);
+    editor.on('selectionUpdate', updateLocalTyping);
+    editor.on('update', updateLocalTyping);
+    editor.on('blur', clearLocalTyping);
+
+    return () => {
+      clearLocalTyping();
+      editor.off('focus', updateLocalTyping);
+      editor.off('selectionUpdate', updateLocalTyping);
+      editor.off('update', updateLocalTyping);
+      editor.off('blur', clearLocalTyping);
+    };
+  }, [editor, field, yjsCtx]);
+
+  useEffect(() => {
+    if (!editor || !yjsCtx) {
+      queueMicrotask(() => setProfiles([]));
+      return;
+    }
+
+    const updateProfiles = () => {
+      const typingProfiles = getRemoteTypingProfiles(yjsCtx, field);
+      setProfiles(getProfilePositions(editor, typingProfiles));
+    };
+
+    updateProfiles();
+    yjsCtx.provider.awareness.on('change', updateProfiles);
+    window.addEventListener('scroll', updateProfiles, true);
+    window.addEventListener('resize', updateProfiles);
+
+    return () => {
+      yjsCtx.provider.awareness.off('change', updateProfiles);
+      window.removeEventListener('scroll', updateProfiles, true);
+      window.removeEventListener('resize', updateProfiles);
+    };
+  }, [editor, field, yjsCtx]);
+
+  return (
+    <>
+      {profiles.map((profile) => {
+        const profileImageUrl = normalizeImageUrl(profile.profileImageUrl ?? undefined);
+
+        return (
+          <div
+            key={profile.clientId}
+            className="border-static-white shadow-normal-small pointer-events-none fixed z-90 h-6 w-6 overflow-hidden rounded-full border"
+            style={{ top: profile.top, left: profile.left, backgroundColor: profile.color }}
+            title={profile.nickname}
+          >
+            {profileImageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={profileImageUrl}
+                alt=""
+                className="h-full w-full object-cover"
+                draggable={false}
+              />
+            ) : (
+              <span className="text-caption-2 text-static-white flex h-full w-full items-center justify-center font-medium">
+                {getInitial(profile.nickname)}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -63,7 +63,7 @@ export default function Editor({
         }, SAVE_DEBOUNCE_MS);
       },
       editorProps: {
-        attributes: { class: 'prose focus:outline-none m-5 pb-40' },
+        attributes: { class: 'prose focus:outline-none m-5 pb-40 pl-5' },
       },
       immediatelyRender: false,
     },
@@ -78,7 +78,10 @@ export default function Editor({
   }, [content, editor, fragment]);
 
   return (
-    <div className="prose [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0">
+    <div
+      className="prose relative [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0"
+      data-typing-profile-container
+    >
       <EditorContent editor={editor} />
       {fragment && collaborationField && editable && (
         <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -8,7 +8,9 @@ import { useEffect, useRef } from 'react';
 import { Markdown, type MarkdownStorage } from 'tiptap-markdown';
 import type { XmlFragment } from 'yjs';
 
+import { useYjsContext } from '@/contexts/YjsContext';
 import { useYjsFragmentInit } from '@/hooks/useYjsFragmentInit';
+import { TypingProfilePresence } from './TypingProfilePresence';
 
 const SAVE_DEBOUNCE_MS = 1000;
 
@@ -20,9 +22,18 @@ interface EditorProps {
   onUpdate?: (markdown: string) => void;
   /** false 전달 시 읽기 전용 (기본값: true) */
   editable?: boolean;
+  /** Yjs awareness typing profile 표시 대상 필드 */
+  collaborationField?: string;
 }
 
-export default function Editor({ content, fragment, onUpdate, editable = true }: EditorProps) {
+export default function Editor({
+  content,
+  fragment,
+  onUpdate,
+  editable = true,
+  collaborationField,
+}: EditorProps) {
+  const yjsCtx = useYjsContext();
   const onUpdateRef = useRef(onUpdate);
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -46,7 +57,8 @@ export default function Editor({ content, fragment, onUpdate, editable = true }:
 
         if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
         saveTimerRef.current = setTimeout(() => {
-          const mdStorage = (e.storage as unknown as Record<string, unknown>).markdown as MarkdownStorage;
+          const mdStorage = (e.storage as unknown as Record<string, unknown>)
+            .markdown as MarkdownStorage;
           onUpdateRef.current?.(mdStorage.getMarkdown());
         }, SAVE_DEBOUNCE_MS);
       },
@@ -68,6 +80,9 @@ export default function Editor({ content, fragment, onUpdate, editable = true }:
   return (
     <div className="prose [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0">
       <EditorContent editor={editor} />
+      {fragment && collaborationField && editable && (
+        <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/commons/user/UserAvatarGroup.tsx
+++ b/frontend/src/components/commons/user/UserAvatarGroup.tsx
@@ -39,15 +39,11 @@ interface UserAvatarWithTooltipProps {
 
 const UserAvatarWithTooltip = ({ user, position, size }: UserAvatarWithTooltipProps) => {
   const profileImageUrl = normalizeImageUrl(user.profileImageUrl ?? undefined);
-  const borderStyle =
-    !profileImageUrl && user.color
-      ? { outline: `2.5px solid ${user.color}`, borderRadius: '50%' }
-      : undefined;
 
   return (
     <Tooltip>
       <TooltipTrigger>
-        <div style={borderStyle}>
+        <div>
           <Avatar
             variant="person"
             size={size}

--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -139,8 +139,10 @@ export function NodeDetailLayout({
       </div>
 
       <div className="flex flex-col gap-6 pb-5">
-        <EditorContent editor={titleEditor} />
-        <TypingProfilePresence editor={titleEditor} yjsCtx={yjsCtx} field={YJS_FIELDS.title} />
+        <div className="relative" data-typing-profile-container>
+          <EditorContent editor={titleEditor} />
+          <TypingProfilePresence editor={titleEditor} yjsCtx={yjsCtx} field={YJS_FIELDS.title} />
+        </div>
 
         <div className="flex flex-col gap-5">
           <MetaRow icon={<IconTag />} label="태그">

--- a/frontend/src/components/node-datail/NodeDetailLayout.tsx
+++ b/frontend/src/components/node-datail/NodeDetailLayout.tsx
@@ -8,9 +8,10 @@ import { useEffect } from 'react';
 
 import { GetFlowchartResponse, GetNodeResponse } from '@/api/Api';
 import { GoogleMeetIcon } from '@/assets/svgs/GoogleMeetIcon';
+import { TypingProfilePresence } from '@/components/commons/editor/TypingProfilePresence';
 import { Loading } from '@/components/commons/loading/Loading';
 import { NodeStatusType } from '@/constants/nodeStatus';
-import { useAwarenessUsers } from '@/contexts/YjsContext';
+import { YJS_FIELDS, useAwarenessUsers, useYjsContext } from '@/contexts/YjsContext';
 import { useErrorToast } from '@/hooks/useErrorToast';
 import { useNodeMenuActions } from '@/hooks/useNodeMenuActions';
 import { nodeKeys } from '@/queries/keys/nodeKeys';
@@ -50,6 +51,7 @@ export function NodeDetailLayout({
   const queryClient = useQueryClient();
   const { data: nodeDetail, error, isLoading } = useNodeDetailQuery(projectId, nodeId);
   const activeUsers = useAwarenessUsers();
+  const yjsCtx = useYjsContext();
   const showErrorToast = useErrorToast();
 
   useEffect(() => {
@@ -78,7 +80,12 @@ export function NodeDetailLayout({
   const handleDescriptionUpdate = (description: string) => {
     updateCache((prev) => ({ ...prev, description }));
     queryClient.setQueryData<GetFlowchartResponse>(nodeKeys.flowchart(projectId), (old) =>
-      old ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, description } : n)) } : old,
+      old
+        ? {
+            ...old,
+            nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, description } : n)),
+          }
+        : old,
     );
   };
 
@@ -133,6 +140,7 @@ export function NodeDetailLayout({
 
       <div className="flex flex-col gap-6 pb-5">
         <EditorContent editor={titleEditor} />
+        <TypingProfilePresence editor={titleEditor} yjsCtx={yjsCtx} field={YJS_FIELDS.title} />
 
         <div className="flex flex-col gap-5">
           <MetaRow icon={<IconTag />} label="태그">

--- a/frontend/src/components/node-datail/note/NodeNoteTab.tsx
+++ b/frontend/src/components/node-datail/note/NodeNoteTab.tsx
@@ -34,6 +34,7 @@ export default function NodeNoteTab({ nodeId, projectId }: NodeNoteTabProps) {
         <Editor
           content={nodeDetail?.noteContent}
           fragment={fragment}
+          collaborationField={YJS_FIELDS.note}
           onUpdate={handleUpdate}
         />
       )}

--- a/frontend/src/contexts/YjsContext.tsx
+++ b/frontend/src/contexts/YjsContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { WebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';
 
+import { userStorage } from '@/api/userStorage';
 import { useCurrentUserQuery } from '@/queries/user';
 
 /** awareness에 저장하는 현재 유저 상태 */
@@ -100,19 +101,22 @@ function YjsInstance({
 
   useEffect(() => {
     if (!value || !currentUser) return;
-    const existingColor =
-      (value.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null)?.user
-        ?.color ?? AWARENESS_COLORS[0];
-    const activeNodeId =
-      (value.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null)?.user
-        ?.activeNodeId ?? null;
+    const storedUser = userStorage.get();
+    const currentAwarenessUser = (
+      value.provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null
+    )?.user;
+    const existingColor = currentAwarenessUser?.color ?? AWARENESS_COLORS[0];
+    const activeNodeId = currentAwarenessUser?.activeNodeId ?? null;
+    const typing = currentAwarenessUser?.typing ?? null;
+
     value.provider.awareness.setLocalStateField('user', {
       userId: value.provider.awareness.clientID,
-      email: currentUser.email ?? '',
-      nickname: currentUser.nickname ?? '',
-      profileImageUrl: currentUser.profileImageUrl ?? null,
+      email: currentUser.email ?? storedUser?.email ?? '',
+      nickname: currentUser.nickname ?? storedUser?.nickname ?? '',
+      profileImageUrl: currentUser.profileImageUrl ?? storedUser?.profileImageUrl ?? null,
       color: existingColor,
       activeNodeId,
+      typing,
     });
   }, [value, currentUser]);
 

--- a/frontend/src/contexts/YjsContext.tsx
+++ b/frontend/src/contexts/YjsContext.tsx
@@ -15,6 +15,11 @@ export interface YjsAwarenessState {
     profileImageUrl: string | null;
     color: string;
     activeNodeId?: number | null;
+    typing?: {
+      field: string;
+      head: number;
+      updatedAt: number;
+    } | null;
   };
 }
 
@@ -111,7 +116,8 @@ function YjsInstance({
     });
   }, [value, currentUser]);
 
-  const ContextProvider = context === 'project' ? ProjectPresenceContext.Provider : YjsContext.Provider;
+  const ContextProvider =
+    context === 'project' ? ProjectPresenceContext.Provider : YjsContext.Provider;
 
   return <ContextProvider value={value}>{children}</ContextProvider>;
 }
@@ -126,9 +132,7 @@ export function useProjectAwarenessUsers(): YjsAwarenessState['user'][] {
   return useAwarenessUsersFromContext(yjsCtx);
 }
 
-function useAwarenessUsersFromContext(
-  yjsCtx: YjsContextValue | null,
-): YjsAwarenessState['user'][] {
+function useAwarenessUsersFromContext(yjsCtx: YjsContextValue | null): YjsAwarenessState['user'][] {
   const [users, setUsers] = useState<YjsAwarenessState['user'][]>([]);
 
   useEffect(() => {
@@ -205,9 +209,7 @@ export function useSetActiveAwarenessNode(nodeId?: number | null) {
     const { provider } = yjsCtx;
 
     const setActiveNodeId = (activeNodeId: number | null) => {
-      const localState = provider.awareness.getLocalState() as
-        | Partial<YjsAwarenessState>
-        | null;
+      const localState = provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null;
       const user = localState?.user;
       if (!user) return;
 
@@ -219,9 +221,7 @@ export function useSetActiveAwarenessNode(nodeId?: number | null) {
 
     setActiveNodeId(nodeId ?? null);
     return () => {
-      const localState = provider.awareness.getLocalState() as
-        | Partial<YjsAwarenessState>
-        | null;
+      const localState = provider.awareness.getLocalState() as Partial<YjsAwarenessState> | null;
       if (localState?.user?.activeNodeId === nodeId) {
         setActiveNodeId(null);
       }

--- a/frontend/src/queries/node.ts
+++ b/frontend/src/queries/node.ts
@@ -49,7 +49,9 @@ export function useNodeDetailQuery(projectId: number, nodeId: number | null) {
     queryFn: () => privateApi.node.getNode(projectId, nodeId!).then((res) => res.data.data),
     enabled: !!projectId && !!nodeId,
     placeholderData: () => {
-      const flowchart = queryClient.getQueryData<GetFlowchartResponse>(nodeKeys.flowchart(projectId));
+      const flowchart = queryClient.getQueryData<GetFlowchartResponse>(
+        nodeKeys.flowchart(projectId),
+      );
       const node = flowchart?.nodes?.find((item) => item.nodeId === nodeId);
 
       return node ? ({ ...node, projectId } satisfies GetNodeResponse) : undefined;
@@ -76,9 +78,27 @@ export function useUpdateNodeStatusMutation(projectId: number, nodeId: number) {
 }
 
 export function useUpdateNodeNoteMutation(projectId: number, nodeId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = nodeKeys.detail(projectId, nodeId);
+
   return useMutation({
     mutationFn: (noteContent: string) =>
       privateApi.node.updateNodeNote(projectId, nodeId, { noteContent }),
+    onMutate: async (noteContent) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<GetNodeResponse>(queryKey);
+
+      queryClient.setQueryData(queryKey, (old: GetNodeResponse | undefined) =>
+        old ? { ...old, noteContent } : old,
+      );
+
+      return { previous };
+    },
+    onError: (_err, _noteContent, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
   });
 }
 
@@ -98,8 +118,7 @@ export function useUpdateNodeTitleMutation(projectId: number, nodeId: number | n
   const queryKey = nodeKeys.detail(projectId, nodeId);
 
   return useMutation({
-    mutationFn: (title: string) =>
-      privateApi.node.updateNodeTitle(projectId, nodeId!, { title }),
+    mutationFn: (title: string) => privateApi.node.updateNodeTitle(projectId, nodeId!, { title }),
     onMutate: async (title) => {
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<GetNodeResponse>(queryKey);
@@ -109,7 +128,9 @@ export function useUpdateNodeTitleMutation(projectId: number, nodeId: number | n
       const flowchartKey = nodeKeys.flowchart(projectId);
       const previousFlowchart = queryClient.getQueryData<GetFlowchartResponse>(flowchartKey);
       queryClient.setQueryData<GetFlowchartResponse>(flowchartKey, (old) =>
-        old ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, title } : n)) } : old,
+        old
+          ? { ...old, nodes: old.nodes?.map((n) => (n.nodeId === nodeId ? { ...n, title } : n)) }
+          : old,
       );
       return { previous, previousFlowchart };
     },


### PR DESCRIPTION
## #️⃣연관된 이슈
#360 

## 📝작업 내용
노션처럼 **협업자가 입력 중인 줄에 프로필 아바타를 표시**하는 기능을 추가했습니다.

- **입력 중 프로필 표시 (TypingProfilePresence)**
  - Yjs awareness에 `typing` 필드(`field`/`head`/`updatedAt`) 추가 → 협업자가 입력 중인 위치를 공유
  - 노트 본문·제목 에디터에 적용, 본인은 제외, 마지막 입력 후 30초 지나면 자동으로 사라짐
  - 프로필 이미지가 있으면 사진, 없으면 중립 회색 배경 + 이니셜로 표시
  - 아바타가 상위 `overflow` 영역에 잘리던 문제 해결(좌측 위치 클램프) + 본문 좌측 패딩을 추가해 아바타가 글자를 가리지 않도록 간격 확보
- **기본 아바타 색상 테두리 제거 (UserAvatarGroup)**
  - 프로필 이미지가 없는 사용자에게만 들어가던 사용자 색상 outline 링 제거 → 이미지 유무와 무관하게 크기/스타일 통일
- **노트 저장 낙관적 업데이트 (useUpdateNodeNoteMutation)**
  - `onMutate`에서 캐시 선반영, 실패 시 `onError`로 롤백
- **챗봇 닫기 버튼 추가 (ChatHeader)**
  - 챗 헤더 우측에 닫기(X) 버튼 추가
