### PR TITLE
[Fix/#367] 회의 생성 모달 프로필 사진 추가

### DIFF
--- a/frontend/src/components/projects/node-flow/ParticipantsSelect.tsx
+++ b/frontend/src/components/projects/node-flow/ParticipantsSelect.tsx
@@ -11,6 +11,7 @@ export interface ParticipantOption {
   id: number;
   name: string;
   email?: string;
+  profileImageUrl?: string;
 }
 
 interface ParticipantsSelectProps {
@@ -136,7 +137,7 @@ export const ParticipantsSelect = ({
                   onClick={() => addParticipant(option)}
                   className="hover:bg-fill-normal flex w-full items-center gap-3 border-none bg-transparent px-5 py-2 text-left"
                 >
-                  <Avatar variant="person" size="xsmall" alt={option.name} />
+                  <Avatar variant="person" size="xsmall" src={option.profileImageUrl} alt={option.name} />
                   <span className="text-body-1 text-label-normal flex-1 truncate font-normal">
                     {option.name}
                   </span>
@@ -164,7 +165,7 @@ export const ParticipantsSelect = ({
           inputRef.current?.focus();
         }}
         className={cn(
-          'border-line-normal-neutral shadow-normal-xsmall flex h-12 w-full cursor-text items-center gap-2 overflow-hidden rounded-xl border bg-transparent focus-within:border-primary-40',
+          'border-line-normal-neutral shadow-normal-xsmall focus-within:border-primary-40 flex h-12 w-full cursor-text items-center gap-2 overflow-hidden rounded-xl border bg-transparent',
           open && 'border-primary-40',
         )}
       >
@@ -175,7 +176,7 @@ export const ParticipantsSelect = ({
                 size="medium"
                 variant="solid"
                 disableInteraction
-                leadingContent={<Avatar variant="person" size="xsmall" alt={item.name} />}
+                leadingContent={<Avatar variant="person" size="xsmall" src={item.profileImageUrl} alt={item.name} />}
                 trailingContent={
                   <span
                     role="button"

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -53,6 +53,7 @@ function ConnectedMeetingCreateModal({
         id: m.userId ?? 0,
         name: m.nickname ?? '',
         email: m.email,
+        profileImageUrl: m.profileImageUrl ?? undefined,
       }))}
       onClose={onClose}
       onCreate={async (payload) => {
@@ -142,6 +143,7 @@ function ConnectedMeetingEditModal({
         id: m.userId ?? 0,
         name: m.nickname ?? '',
         email: m.email ?? '',
+        profileImageUrl: m.profileImageUrl ?? undefined,
       }))}
       initialValues={initialValues}
       onClose={onClose}


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #367

## 📝작업 내용

- 기존에 회의 생성 모달에서 프로필 사진을 띄워주고 있지 않아 프로필 사진을 추가했습니다

### 스크린샷 (선택)

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/13d82e4f-0d18-40d8-b27f-2a1d7bb3147c" />

