### PR TITLE
[Feat/#369] 노트 내 툴바 추가 및 이미지 업로드 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "@tanstack/react-query-devtools": "^5.100.9",
     "@tiptap/core": "^3.22.4",
     "@tiptap/extension-collaboration": "^3.20.1",
+    "@tiptap/extension-image": "^3.20.1",
     "@tiptap/extensions": "^3.20.4",
     "@tiptap/react": "^3.20.1",
     "@tiptap/starter-kit": "^3.20.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tiptap/extension-collaboration':
         specifier: ^3.20.1
         version: 3.20.4(@tiptap/core@3.22.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
+      '@tiptap/extension-image':
+        specifier: ^3.20.1
+        version: 3.20.1(@tiptap/core@3.22.4(@tiptap/pm@3.20.4))
       '@tiptap/extensions':
         specifier: ^3.20.4
         version: 3.20.4(@tiptap/core@3.22.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
@@ -1924,6 +1927,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.20.4
       '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-image@3.20.1':
+    resolution: {integrity: sha512-/GPFSLNdYSZQ0E6VBXSAk0UFtDdn98HT1Aa2tO+STELqc5jAdFB42dfFnTC6KQzTvcUOUYkE2S1Q22YC5H2XNQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.1
 
   '@tiptap/extension-italic@3.20.4':
     resolution: {integrity: sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ==}
@@ -7781,6 +7789,10 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.20.4)
       '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-image@3.20.1(@tiptap/core@3.22.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.20.4)
 
   '@tiptap/extension-italic@3.20.4(@tiptap/core@3.22.4(@tiptap/pm@3.20.4))':
     dependencies:

--- a/frontend/src/app/api/upload-image/route.ts
+++ b/frontend/src/app/api/upload-image/route.ts
@@ -1,0 +1,59 @@
+export async function POST(request: Request) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader) {
+    return Response.json({ error: '인증 정보가 없습니다.' }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return Response.json({ error: '파일이 없습니다.' }, { status: 400 });
+  }
+
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const extension = file.name.split('.').pop() ?? '';
+
+  // 1. Presigned URL 발급 (서버→백엔드, CORS 없음)
+  const presignRes = await fetch(`${apiBase}/v1/files/presigned-url`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+    body: JSON.stringify({ fileName: file.name, fileSize: file.size, contentType: file.type }),
+  });
+
+  const presignJson = await presignRes.json();
+  const { fileKey, presignedUrl, uploadUrl } = presignJson.data ?? {};
+
+  if (!fileKey || !presignedUrl || !uploadUrl) {
+    return Response.json({ error: 'Presigned URL 발급 실패' }, { status: 500 });
+  }
+
+  // 2. S3 직접 PUT (서버→S3, CORS 없음)
+  const s3Res = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: await file.arrayBuffer(),
+    headers: { 'Content-Type': file.type },
+  });
+
+  if (!s3Res.ok) {
+    return Response.json({ error: 'S3 업로드 실패' }, { status: 500 });
+  }
+
+  // 3. 업로드 완료 확인
+  await fetch(`${apiBase}/v1/files`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+    body: JSON.stringify({
+      fileKey,
+      fileName: file.name,
+      fileSize: file.size,
+      extension,
+      contentType: file.type,
+    }),
+  });
+
+  // 프로토콜 보정 + 공백 등 인코딩 (마크다운 파서가 공백 있는 URL을 이미지로 인식 못함)
+  const normalizedUrl = /^https?:\/\//i.test(uploadUrl) ? uploadUrl : `https://${uploadUrl}`;
+  const encodedUrl = encodeURI(normalizedUrl);
+
+  return Response.json({ url: encodedUrl });
+}

--- a/frontend/src/components/commons/editor/EditorToolbar.tsx
+++ b/frontend/src/components/commons/editor/EditorToolbar.tsx
@@ -66,7 +66,7 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
   };
 
   return (
-    <div className="border-line-normal-neutral sticky top-0 z-10 flex flex-wrap items-center gap-y-1 border-b px-3 py-2">
+    <div className="border-line-normal-neutral bg-static-white sticky top-0 z-10 flex w-full flex-wrap items-center gap-y-1 border-b px-3 py-2">
       <Group>
         <ToolbarButton
           onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}

--- a/frontend/src/components/commons/editor/EditorToolbar.tsx
+++ b/frontend/src/components/commons/editor/EditorToolbar.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import type { Editor } from '@tiptap/react';
+import {
+  IconBold,
+  IconCode,
+  IconLineHorizontal,
+  IconList,
+  IconListOrdered,
+  IconQuote,
+  IconStrikethrough,
+} from '@wanteddev/wds-icon';
+import type { ReactNode } from 'react';
+
+interface ToolbarButtonProps {
+  onClick: () => void;
+  active?: boolean;
+  title: string;
+  children: ReactNode;
+}
+
+function ToolbarButton({ onClick, active, title, children }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+      className={`flex h-7 w-7 items-center justify-center rounded text-sm transition-colors ${
+        active
+          ? 'bg-fill-alternative text-label-normal'
+          : 'text-label-alternative hover:bg-fill-alternative hover:text-label-normal'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Separator() {
+  return <div className="mx-1 h-4 w-px bg-line-normal" />;
+}
+
+interface EditorToolbarProps {
+  editor: Editor | null;
+}
+
+export function EditorToolbar({ editor }: EditorToolbarProps) {
+  if (!editor) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-0.5 border-b border-line-normal px-2 py-1">
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        active={editor.isActive('heading', { level: 1 })}
+        title="제목 1"
+      >
+        <span className="text-xs font-bold">H1</span>
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        active={editor.isActive('heading', { level: 2 })}
+        title="제목 2"
+      >
+        <span className="text-xs font-bold">H2</span>
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        active={editor.isActive('heading', { level: 3 })}
+        title="제목 3"
+      >
+        <span className="text-xs font-bold">H3</span>
+      </ToolbarButton>
+
+      <Separator />
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        active={editor.isActive('bold')}
+        title="굵게"
+      >
+        <IconBold width={16} height={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        active={editor.isActive('italic')}
+        title="기울임"
+      >
+        <span className="font-serif italic">I</span>
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        active={editor.isActive('strike')}
+        title="취소선"
+      >
+        <IconStrikethrough width={16} height={16} />
+      </ToolbarButton>
+
+      <Separator />
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleCode().run()}
+        active={editor.isActive('code')}
+        title="인라인 코드"
+      >
+        <IconCode width={16} height={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        active={editor.isActive('codeBlock')}
+        title="코드 블록"
+      >
+        <span className="font-mono text-xs">{'{}'}</span>
+      </ToolbarButton>
+
+      <Separator />
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        active={editor.isActive('bulletList')}
+        title="글머리 기호 목록"
+      >
+        <IconList width={16} height={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        active={editor.isActive('orderedList')}
+        title="번호 매기기 목록"
+      >
+        <IconListOrdered width={16} height={16} />
+      </ToolbarButton>
+
+      <Separator />
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        active={editor.isActive('blockquote')}
+        title="인용구"
+      >
+        <IconQuote width={16} height={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setHorizontalRule().run()}
+        active={false}
+        title="구분선"
+      >
+        <IconLineHorizontal width={16} height={16} />
+      </ToolbarButton>
+    </div>
+  );
+}

--- a/frontend/src/components/commons/editor/EditorToolbar.tsx
+++ b/frontend/src/components/commons/editor/EditorToolbar.tsx
@@ -30,10 +30,8 @@ function ToolbarButton({ onClick, active, title, children }: ToolbarButtonProps)
       title={title}
       aria-label={title}
       aria-pressed={active}
-      className={`flex h-7 w-7 items-center justify-center rounded text-sm transition-colors ${
-        active
-          ? 'bg-fill-alternative text-label-normal'
-          : 'text-label-alternative hover:bg-fill-alternative hover:text-label-normal'
+      className={`flex h-7 w-7 shrink-0 items-center justify-center bg-transparent text-sm transition-colors ${
+        active ? 'text-primary-40' : 'text-label-alternative'
       }`}
     >
       {children}
@@ -41,8 +39,12 @@ function ToolbarButton({ onClick, active, title, children }: ToolbarButtonProps)
   );
 }
 
-function Separator() {
-  return <div className="mx-1 h-4 w-px bg-line-normal" />;
+function Group({ children }: { children: ReactNode }) {
+  return <div className="flex items-center gap-0.5">{children}</div>;
+}
+
+function Divider() {
+  return <div className="bg-line-normal-neutral mx-1.5 h-4 w-px shrink-0" />;
 }
 
 interface EditorToolbarProps {
@@ -53,103 +55,115 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
   if (!editor) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-0.5 border-b border-line-normal px-2 py-1">
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-        active={editor.isActive('heading', { level: 1 })}
-        title="제목 1"
-      >
-        <span className="text-xs font-bold">H1</span>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-        active={editor.isActive('heading', { level: 2 })}
-        title="제목 2"
-      >
-        <span className="text-xs font-bold">H2</span>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-        active={editor.isActive('heading', { level: 3 })}
-        title="제목 3"
-      >
-        <span className="text-xs font-bold">H3</span>
-      </ToolbarButton>
+    <div className="border-line-normal-neutral sticky top-0 z-10 flex flex-wrap items-center gap-y-1 border-b px-3 py-2">
+      <Group>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+          active={editor.isActive('heading', { level: 1 })}
+          title="제목 1"
+        >
+          <span className="text-[11px] font-bold tracking-tight">H1</span>
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          active={editor.isActive('heading', { level: 2 })}
+          title="제목 2"
+        >
+          <span className="text-[11px] font-bold tracking-tight">H2</span>
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+          active={editor.isActive('heading', { level: 3 })}
+          title="제목 3"
+        >
+          <span className="text-[11px] font-bold tracking-tight">H3</span>
+        </ToolbarButton>
+      </Group>
 
-      <Separator />
+      <Divider />
 
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        active={editor.isActive('bold')}
-        title="굵게"
-      >
-        <IconBold width={16} height={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        active={editor.isActive('italic')}
-        title="기울임"
-      >
-        <span className="font-serif italic">I</span>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        active={editor.isActive('strike')}
-        title="취소선"
-      >
-        <IconStrikethrough width={16} height={16} />
-      </ToolbarButton>
+      <Group>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          active={editor.isActive('bold')}
+          title="굵게"
+        >
+          <IconBold width={15} height={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          active={editor.isActive('italic')}
+          title="기울임"
+        >
+          <span className="text-sm" style={{ fontStyle: 'italic', fontFamily: 'Georgia, serif' }}>
+            I
+          </span>
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+          active={editor.isActive('strike')}
+          title="취소선"
+        >
+          <IconStrikethrough width={15} height={15} />
+        </ToolbarButton>
+      </Group>
 
-      <Separator />
+      <Divider />
 
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleCode().run()}
-        active={editor.isActive('code')}
-        title="인라인 코드"
-      >
-        <IconCode width={16} height={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-        active={editor.isActive('codeBlock')}
-        title="코드 블록"
-      >
-        <span className="font-mono text-xs">{'{}'}</span>
-      </ToolbarButton>
+      <Group>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleCode().run()}
+          active={editor.isActive('code')}
+          title="인라인 코드"
+        >
+          <IconCode width={15} height={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+          active={editor.isActive('codeBlock')}
+          title="코드 블록"
+        >
+          <span className="font-mono text-[11px] font-medium">{'{}'}</span>
+        </ToolbarButton>
+      </Group>
 
-      <Separator />
+      <Divider />
 
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBulletList().run()}
-        active={editor.isActive('bulletList')}
-        title="글머리 기호 목록"
-      >
-        <IconList width={16} height={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleOrderedList().run()}
-        active={editor.isActive('orderedList')}
-        title="번호 매기기 목록"
-      >
-        <IconListOrdered width={16} height={16} />
-      </ToolbarButton>
+      <Group>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          active={editor.isActive('bulletList')}
+          title="글머리 기호 목록"
+        >
+          <IconList width={15} height={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          active={editor.isActive('orderedList')}
+          title="번호 매기기 목록"
+        >
+          <IconListOrdered width={15} height={15} />
+        </ToolbarButton>
+      </Group>
 
-      <Separator />
+      <Divider />
 
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBlockquote().run()}
-        active={editor.isActive('blockquote')}
-        title="인용구"
-      >
-        <IconQuote width={16} height={16} />
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().setHorizontalRule().run()}
-        active={false}
-        title="구분선"
-      >
-        <IconLineHorizontal width={16} height={16} />
-      </ToolbarButton>
+      <Group>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          active={editor.isActive('blockquote')}
+          title="인용구"
+        >
+          <IconQuote width={15} height={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().setHorizontalRule().run()}
+          active={false}
+          title="구분선"
+        >
+          <IconLineHorizontal width={15} height={15} />
+        </ToolbarButton>
+      </Group>
     </div>
   );
 }

--- a/frontend/src/components/commons/editor/EditorToolbar.tsx
+++ b/frontend/src/components/commons/editor/EditorToolbar.tsx
@@ -4,13 +4,16 @@ import type { Editor } from '@tiptap/react';
 import {
   IconBold,
   IconCode,
+  IconImage,
   IconLineHorizontal,
   IconList,
   IconListOrdered,
   IconQuote,
   IconStrikethrough,
 } from '@wanteddev/wds-icon';
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
+
+import { uploadImage } from './uploadImage';
 
 interface ToolbarButtonProps {
   onClick: () => void;
@@ -52,7 +55,15 @@ interface EditorToolbarProps {
 }
 
 export function EditorToolbar({ editor }: EditorToolbarProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   if (!editor) return null;
+
+  const handleImageFile = (file: File) => {
+    uploadImage(file).then((url) => {
+      editor.chain().focus().setImage({ src: url }).run();
+    });
+  };
 
   return (
     <div className="border-line-normal-neutral sticky top-0 z-10 flex flex-wrap items-center gap-y-1 border-b px-3 py-2">
@@ -164,6 +175,26 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
           <IconLineHorizontal width={15} height={15} />
         </ToolbarButton>
       </Group>
+
+      <Divider />
+
+      <Group>
+        <ToolbarButton onClick={() => fileInputRef.current?.click()} active={false} title="이미지">
+          <IconImage width={15} height={15} />
+        </ToolbarButton>
+      </Group>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleImageFile(file);
+          e.target.value = '';
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -79,15 +79,14 @@ export default function Editor({
   }, [content, editor, fragment]);
 
   return (
-    <div
-      className="prose relative [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0"
-      data-typing-profile-container
-    >
+    <div className="relative" data-typing-profile-container>
       {editable && <EditorToolbar editor={editor} />}
-      <EditorContent editor={editor} />
-      {fragment && collaborationField && editable && (
-        <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />
-      )}
+      <div className="prose relative [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0">
+        <EditorContent editor={editor} />
+        {fragment && collaborationField && editable && (
+          <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -10,6 +10,7 @@ import type { XmlFragment } from 'yjs';
 
 import { useYjsContext } from '@/contexts/YjsContext';
 import { useYjsFragmentInit } from '@/hooks/useYjsFragmentInit';
+import { EditorToolbar } from './EditorToolbar';
 import { TypingProfilePresence } from './TypingProfilePresence';
 
 const SAVE_DEBOUNCE_MS = 1000;
@@ -82,6 +83,7 @@ export default function Editor({
       className="prose relative [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0"
       data-typing-profile-container
     >
+      {editable && <EditorToolbar editor={editor} />}
       <EditorContent editor={editor} />
       {fragment && collaborationField && editable && (
         <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Collaboration, isChangeOrigin } from '@tiptap/extension-collaboration';
+import { Image } from '@tiptap/extension-image';
 import { Placeholder } from '@tiptap/extensions';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -12,6 +13,7 @@ import { useYjsContext } from '@/contexts/YjsContext';
 import { useYjsFragmentInit } from '@/hooks/useYjsFragmentInit';
 import { EditorToolbar } from './EditorToolbar';
 import { TypingProfilePresence } from './TypingProfilePresence';
+import { uploadImage } from './uploadImage';
 
 const SAVE_DEBOUNCE_MS = 1000;
 
@@ -49,6 +51,7 @@ export default function Editor({
         StarterKit.configure({ undoRedo: false }),
         Markdown,
         Placeholder.configure({ placeholder: '내용을 입력하세요.' }),
+        Image.configure({ inline: false, allowBase64: false }),
         ...(fragment ? [Collaboration.configure({ fragment })] : []),
       ],
       editable,
@@ -65,6 +68,43 @@ export default function Editor({
       },
       editorProps: {
         attributes: { class: 'prose focus:outline-none m-5 pb-40 pl-5' },
+        handlePaste(view, event) {
+          const items = Array.from(event.clipboardData?.items ?? []);
+          const imageItem = items.find((item) => item.type.startsWith('image/'));
+          if (!imageItem) return false;
+
+          event.preventDefault();
+          const file = imageItem.getAsFile();
+          if (!file) return false;
+
+          uploadImage(file).then((url) => {
+            view.dispatch(
+              view.state.tr.replaceSelectionWith(
+                view.state.schema.nodes.image.create({ src: url }),
+              ),
+            );
+          });
+          return true;
+        },
+        handleDrop(view, event) {
+          const files = Array.from(event.dataTransfer?.files ?? []).filter((f) =>
+            f.type.startsWith('image/'),
+          );
+          if (!files.length) return false;
+
+          event.preventDefault();
+          const pos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos;
+          if (pos === undefined) return false;
+
+          files.forEach((file) => {
+            uploadImage(file).then((url) => {
+              view.dispatch(
+                view.state.tr.insert(pos, view.state.schema.nodes.image.create({ src: url })),
+              );
+            });
+          });
+          return true;
+        },
       },
       immediatelyRender: false,
     },

--- a/frontend/src/components/commons/editor/editor.tsx
+++ b/frontend/src/components/commons/editor/editor.tsx
@@ -119,9 +119,9 @@ export default function Editor({
   }, [content, editor, fragment]);
 
   return (
-    <div className="relative" data-typing-profile-container>
+    <div className="relative w-full" data-typing-profile-container>
       {editable && <EditorToolbar editor={editor} />}
-      <div className="prose relative [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0">
+      <div className="prose relative overflow-x-hidden [&_.ProseMirror]:leading-[1.4] [&_.ProseMirror_p]:my-0">
         <EditorContent editor={editor} />
         {fragment && collaborationField && editable && (
           <TypingProfilePresence editor={editor} yjsCtx={yjsCtx} field={collaborationField} />

--- a/frontend/src/components/commons/editor/uploadImage.ts
+++ b/frontend/src/components/commons/editor/uploadImage.ts
@@ -1,30 +1,21 @@
-import { privateApi } from '@/api';
+import { authStorage } from '@/api/authStorage';
 
 export async function uploadImage(file: File): Promise<string> {
-  const extension = file.name.split('.').pop() ?? '';
+  const token = authStorage.getAccess();
 
-  const presignRes = await privateApi.file.createPresignedUrl({
-    fileName: file.name,
-    fileSize: file.size,
-    contentType: file.type,
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch('/api/upload-image', {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
   });
 
-  const { fileKey, presignedUrl, uploadUrl } = presignRes.data.data ?? {};
-  if (!fileKey || !presignedUrl || !uploadUrl) throw new Error('Presigned URL 발급 실패');
+  if (!res.ok) throw new Error('이미지 업로드에 실패했습니다.');
 
-  await fetch(presignedUrl, {
-    method: 'PUT',
-    body: file,
-    headers: { 'Content-Type': file.type },
-  });
+  const json = (await res.json()) as { url?: string };
+  if (!json.url) throw new Error('업로드 URL을 받지 못했습니다.');
 
-  await privateApi.file.confirmUpload({
-    fileKey,
-    fileName: file.name,
-    fileSize: file.size,
-    extension,
-    contentType: file.type,
-  });
-
-  return uploadUrl;
+  return json.url;
 }

--- a/frontend/src/components/commons/editor/uploadImage.ts
+++ b/frontend/src/components/commons/editor/uploadImage.ts
@@ -1,0 +1,30 @@
+import { privateApi } from '@/api';
+
+export async function uploadImage(file: File): Promise<string> {
+  const extension = file.name.split('.').pop() ?? '';
+
+  const presignRes = await privateApi.file.createPresignedUrl({
+    fileName: file.name,
+    fileSize: file.size,
+    contentType: file.type,
+  });
+
+  const { fileKey, presignedUrl, uploadUrl } = presignRes.data.data ?? {};
+  if (!fileKey || !presignedUrl || !uploadUrl) throw new Error('Presigned URL 발급 실패');
+
+  await fetch(presignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': file.type },
+  });
+
+  await privateApi.file.confirmUpload({
+    fileKey,
+    fileName: file.name,
+    fileSize: file.size,
+    extension,
+    contentType: file.type,
+  });
+
+  return uploadUrl;
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -448,6 +448,11 @@ body {
   max-width: none;
 }
 
+/* WDS CSS 리셋이 em { font: inherit } 으로 font-style을 초기화하므로 복원 */
+.ProseMirror em {
+  font-style: italic;
+}
+
 /* placeholder용 스타일 */
 .tiptap p.is-editor-empty:first-child::before {
   color: #adb5bd;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -453,6 +453,13 @@ body {
   font-style: italic;
 }
 
+/* 이미지: 컨테이너 너비에 맞게 */
+.ProseMirror img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
 /* 인라인 코드: GitHub 스타일 */
 .ProseMirror code:not(pre > code) {
   background: var(--color-primary-99);

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -453,6 +453,23 @@ body {
   font-style: italic;
 }
 
+/* 인라인 코드: GitHub 스타일 */
+.ProseMirror code:not(pre > code) {
+  background: var(--color-primary-99);
+  color: var(--color-primary-20);
+  border-radius: 4px;
+  padding: 0.15em 0.4em;
+  font-size: 85%;
+  font-family: var(--font-mono);
+  font-weight: 400;
+}
+
+/* prose 플러그인이 code 앞뒤에 붙이는 백틱 제거 */
+.ProseMirror code::before,
+.ProseMirror code::after {
+  content: '' !important;
+}
+
 /* placeholder용 스타일 */
 .tiptap p.is-editor-empty:first-child::before {
   color: #adb5bd;


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #369 

## 📝작업 내용

- TipTap 에디터에 서식 툴바 추가 (H1~H3, Bold, Italic, Strike, Code, CodeBlock, BulletList, OrderedList, Blockquote, HorizontalRule, 이미지 업로드)
- `editable={false}`일 때 툴바 숨김
- S3 presigned URL 기반 이미지 업로드 지원 (파일 선택 / 클립보드 붙여넣기 / 드래그 앤 드롭)

### `src/components/commons/editor/EditorToolbar.tsx` (신규)
- 에디터 툴바 컴포넌트 구현

### `src/components/commons/editor/editor.tsx`
- `EditorToolbar` 연결, `editable` prop 으로 노출 조건 처리
- `handlePaste` / `handleDrop` 핸들러 추가 — 이미지 파일 자동 업로드

### `src/components/commons/editor/uploadImage.ts` (신규)
- 브라우저 → `/api/upload-image` Route Handler 로 파일 전송
- `authStorage`에서 토큰 읽어 Authorization 헤더 포함

### `src/app/api/upload-image/route.ts` (신규)
- 브라우저 직접 S3 PUT 시 발생하는 CORS 문제를 서버 사이드 프록시로 해결
- 흐름: `POST /v1/files/presigned-url` → S3 PUT → `POST /v1/files` (confirm)
- `uploadUrl` 반환 전 `https://` 프로토콜 보정 + `encodeURI` (공백 등 특수문자 인코딩)
