### PR TITLE
[Fix/#371] 메인 노드 참조 점선 표시 및 참조 모달 동작,UI 개선

### DIFF
--- a/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferenceNodeModalContent.tsx
@@ -3,7 +3,7 @@
 import { TextButton } from '@wanteddev/wds';
 import { IconClose, IconPlus } from '@wanteddev/wds-icon';
 
-import { ReferencedNodesList } from './ReferencedNodesList';
+import { NodeNumberBadge, ReferencedNodesList } from './ReferencedNodesList';
 import { ReferenceNodeAddForm } from './ReferenceNodeAddForm';
 import {
   type ReferencedNodeItem,
@@ -44,7 +44,12 @@ export const ReferenceNodeModalContent = ({
   return (
     <form className="flex w-full flex-col gap-8" onSubmit={handleCreate} noValidate>
       <header className="flex items-center justify-between overflow-hidden">
-        <h2 className="text-heading-1 text-label-normal font-medium">참조 노드</h2>
+        <h2 className="text-heading-1 text-label-normal flex min-w-0 items-center gap-2 font-medium">
+          {currentNode?.number && <NodeNumberBadge number={currentNode.number} />}
+          <span className="min-w-0 truncate">
+            {currentNode?.title ? `"${currentNode.title}"의 참조 노드` : '참조 노드'}
+          </span>
+        </h2>
         <button
           type="button"
           onClick={onClose}

--- a/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
@@ -13,7 +13,7 @@ export const NodeNumberBadge = ({ number }: { number: string }) => {
   const isMain = !number.includes('.');
   return isMain ? (
     <ContentBadge
-      size="medium"
+      size="small"
       variant="solid"
       color="accent"
       className="!bg-primary-40/10 !text-primary-40 shrink-0"
@@ -21,7 +21,7 @@ export const NodeNumberBadge = ({ number }: { number: string }) => {
       #{number}
     </ContentBadge>
   ) : (
-    <ContentBadge size="medium" variant="outlined" color="neutral" className="shrink-0">
+    <ContentBadge size="small" variant="outlined" color="neutral" className="shrink-0">
       #{number}
     </ContentBadge>
   );

--- a/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
+++ b/frontend/src/components/projects/project-detail/reference-node/ReferencedNodesList.tsx
@@ -1,13 +1,31 @@
 'use client';
 
 import { ContentBadge } from '@wanteddev/wds';
-import { IconTrash } from '@wanteddev/wds-icon';
+import { IconArrowRight, IconTrash } from '@wanteddev/wds-icon';
 
 import { useDialog } from '@/components/commons/custom-dialog/DialogContext';
 import { EdgeDeleteConfirmContent, type EdgeNodeInfo } from '@/components/projects/project-detail/edge-delete/EdgeDeleteConfirmContent';
 import { cn } from '@/utils/cn';
 
 import type { ReferencedNodeItem } from './useReferenceNodeForm';
+
+export const NodeNumberBadge = ({ number }: { number: string }) => {
+  const isMain = !number.includes('.');
+  return isMain ? (
+    <ContentBadge
+      size="medium"
+      variant="solid"
+      color="accent"
+      className="!bg-primary-40/10 !text-primary-40 shrink-0"
+    >
+      #{number}
+    </ContentBadge>
+  ) : (
+    <ContentBadge size="medium" variant="outlined" color="neutral" className="shrink-0">
+      #{number}
+    </ContentBadge>
+  );
+};
 
 interface ReferencedNodesListProps {
   items: readonly ReferencedNodeItem[];
@@ -58,7 +76,7 @@ export const ReferencedNodesList = ({
 
   return (
     <section className="flex w-full flex-col gap-2">
-      <h3 className="text-label-1 text-label-neutral font-semibold">참조 중인 노드 목록</h3>
+      <h3 className="text-label-1 text-label-neutral font-semibold">참조하고 있는 노드 목록</h3>
 
       {items.length === 0 ? (
         <div className="flex items-center justify-center py-8">
@@ -71,44 +89,54 @@ export const ReferencedNodesList = ({
             variant === 'list' ? 'max-h-95' : 'max-h-72',
           )}
         >
-          {items.map((item) => (
-            <li
-              key={item.edgeId}
-              className="bg-fill-alternative/50 flex items-start gap-2 rounded-lg px-4 py-2"
-            >
-              <ContentBadge
-                size="medium"
-                variant="solid"
-                color="accent"
-                className="!bg-primary-40/10 !text-primary-40 shrink-0"
+          {items.map((item) => {
+            const linkedNumber = item.number ?? '';
+            const currentNumber = currentNode?.number ?? '';
+            // linkType === 'START': 현재 노드 -> 상대 노드 (현재가 왼쪽)
+            // linkType === 'END': 상대 노드 -> 현재 노드 (상대가 왼쪽)
+            const leftNumber = item.linkType === 'END' ? linkedNumber : currentNumber;
+            const rightNumber = item.linkType === 'END' ? currentNumber : linkedNumber;
+            return (
+              <li
+                key={item.edgeId}
+                className="bg-fill-alternative/50 flex items-start gap-4 rounded-lg px-4 py-2"
               >
-                #{item.number}
-              </ContentBadge>
-              <div className="flex min-w-0 flex-1 flex-col">
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-body-2 text-label-normal truncate font-medium">
-                    {item.title}
-                  </span>
-                  <span className="text-caption-1 text-label-assistive shrink-0 font-normal">
+                <div className="flex min-w-0 flex-1 items-start gap-2">
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {leftNumber && <NodeNumberBadge number={leftNumber} />}
+                    <IconArrowRight
+                      className="text-label-assistive h-4 w-4 shrink-0"
+                      aria-hidden="true"
+                    />
+                    {rightNumber && <NodeNumberBadge number={rightNumber} />}
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="text-body-2 text-label-normal truncate font-medium">
+                      {item.title}
+                    </span>
+                    <p className="text-caption-1 text-label-alternative w-full truncate font-normal">
+                      {item.comment}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="text-caption-1 text-label-assistive font-normal">
                     연결한 사람: {item.createdBy?.nickname}
                   </span>
+                  {onDeleteEdge && item.edgeId !== undefined && (
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteClick(item)}
+                      aria-label="참조 연결 삭제"
+                      className="text-label-assistive hover:text-status-negative focus-visible:ring-primary-40 flex h-6 w-6 items-center justify-center rounded-md bg-transparent outline-none transition-colors focus-visible:ring-2"
+                    >
+                      <IconTrash className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  )}
                 </div>
-                <p className="text-caption-1 text-label-alternative w-full truncate font-normal">
-                  {item.comment}
-                </p>
-              </div>
-              {onDeleteEdge && item.edgeId !== undefined && (
-                <button
-                  type="button"
-                  onClick={() => handleDeleteClick(item)}
-                  aria-label="참조 연결 삭제"
-                  className="text-label-assistive hover:text-status-negative focus-visible:ring-primary-40 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent outline-none transition-colors focus-visible:ring-2"
-                >
-                  <IconTrash className="h-4 w-4" aria-hidden="true" />
-                </button>
-              )}
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/frontend/src/components/projects/project-detail/reference-node/useReferenceNodeForm.ts
+++ b/frontend/src/components/projects/project-detail/reference-node/useReferenceNodeForm.ts
@@ -67,19 +67,20 @@ export const useReferenceNodeForm = ({ startNodeId, nodeOptions }: UseReferenceN
 
   const [viewMode, setViewMode] = useState<ReferenceNodeViewMode>('list');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
 
   const nodeKeyword = useWatch({ control, name: 'nodeKeyword' });
   const comment = useWatch({ control, name: 'comment' });
   const trimmedNodeKeyword = nodeKeyword.trim();
   const trimmedComment = comment.trim();
 
+  // 타이틀이 중복되는 노드가 있을 수 있으므로, 사용자가 드롭다운에서 선택한 nodeId를 기준으로 식별한다.
   const selectedNode = useMemo(
     () =>
-      nodeOptions.find(
-        (node) =>
-          node.nodeTitle === trimmedNodeKeyword || `#${node.nodeNumber}` === trimmedNodeKeyword,
-      ) ?? null,
-    [nodeOptions, trimmedNodeKeyword],
+      selectedNodeId !== null
+        ? nodeOptions.find((node) => node.nodeId === selectedNodeId) ?? null
+        : null,
+    [nodeOptions, selectedNodeId],
   );
 
   const searchResults = useMemo(() => {
@@ -110,11 +111,13 @@ export const useReferenceNodeForm = ({ startNodeId, nodeOptions }: UseReferenceN
   const closeAddView = useCallback(() => {
     setViewMode('list');
     setIsSearchOpen(false);
+    setSelectedNodeId(null);
     reset({ nodeKeyword: '', comment: '' });
   }, [reset]);
 
   const selectNodeOption = useCallback(
     (option: ReferenceNodeOption) => {
+      setSelectedNodeId(option.nodeId);
       setValue('nodeKeyword', option.nodeTitle, {
         shouldValidate: true,
         shouldDirty: true,
@@ -125,6 +128,7 @@ export const useReferenceNodeForm = ({ startNodeId, nodeOptions }: UseReferenceN
   );
 
   const clearSelectedNode = useCallback(() => {
+    setSelectedNodeId(null);
     setValue('nodeKeyword', '', { shouldValidate: true, shouldDirty: true });
   }, [setValue]);
 

--- a/frontend/src/hooks/useNodeMenuActions.tsx
+++ b/frontend/src/hooks/useNodeMenuActions.tsx
@@ -177,8 +177,16 @@ function ConnectedReferenceNodeModal({
   const queryClient = useQueryClient();
   const showErrorToast = useErrorToast();
 
+  // 이미 (현재 노드 -> 상대) 방향의 참조가 있는 노드는 중복 생성을 막기 위해 드롭다운에서 제외한다.
+  // 반대 방향(상대 -> 현재)만 존재하는 경우는 새 참조를 만들 수 있어야 하므로 제외하지 않는다.
+  const outgoingTargetIds = new Set(
+    linkedNodes
+      .filter((link) => link.linkType === 'START' && link.linkedNodeId !== undefined)
+      .map((link) => link.linkedNodeId as number),
+  );
+
   const nodeOptions = nodeList
-    .filter((n) => n.nodeId !== nodeId)
+    .filter((n) => n.nodeId !== nodeId && (n.nodeId === undefined || !outgoingTargetIds.has(n.nodeId)))
     .map((n) => ({ nodeId: n.nodeId ?? 0, nodeNumber: n.number ?? '', nodeTitle: n.title ?? '' }));
 
   return (

--- a/frontend/src/queries/edge.ts
+++ b/frontend/src/queries/edge.ts
@@ -73,7 +73,12 @@ export function useCreateEdgeMutation(projectId: number) {
 }
 
 export function useDeleteEdgeMutation(projectId: number) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (edgeId: number) => privateApi.edge.deleteEdge(projectId, edgeId),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: nodeKeys.flowchart(projectId) });
+      void queryClient.invalidateQueries({ queryKey: [...edgeKeys.all, 'linked', projectId] });
+    },
   });
 }

--- a/frontend/src/utils/flowchartToReactFlow.ts
+++ b/frontend/src/utils/flowchartToReactFlow.ts
@@ -219,9 +219,8 @@ export function convertToReactFlow(flowchart: GetFlowchartResponse | null): {
           source: String(edge.startNodeId),
           target: String(edge.endNodeId),
           type: 'reference',
-          // 참조 관계: 시작 노드 오른쪽 → 끝 노드 왼쪽
-          sourceHandle: 'source',
-          targetHandle: 'target',
+          sourceHandle: 'ref-source',
+          targetHandle: 'ref-target',
           data: { edgeData: edge },
         });
       }


### PR DESCRIPTION
## #️⃣연관된 이슈
#371 

## 📝작업 내용
- 메인 노드 참조 점선이 UI에 그려지지 않는 문제 수정
- 참조 삭제 시 모달과 캔버스에 즉시 반영되지 않던 문제 수정
- 같은 제목의 노드가 잘못 선택되던 문제 수정
- 이미 (현재 노드 → 상대) 참조가 있는 노드를 추가 드롭다운에서 제외