### PR TITLE
[Fix/#372] 수신함 뱃지가 다른 프로젝트 알림까지 합산되던 문제 수정

### DIFF
--- a/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
+++ b/frontend/src/components/commons/project-sidebar/ProjectSidebar.tsx
@@ -17,7 +17,7 @@ import { authStorage } from '@/api/authStorage';
 import { userStorage } from '@/api/userStorage';
 import { useModal } from '@/components/commons/modal/ModalContext';
 import { notificationKeys } from '@/queries/keys/notificationKeys';
-import { prefetchNotificationSetting, useUnreadCountQuery } from '@/queries/notification';
+import { prefetchNotificationSetting, useNotificationListQuery } from '@/queries/notification';
 import { useProjectListQuery, useProjectQuery } from '@/queries/project';
 import { useCurrentUserQuery } from '@/queries/user';
 import { cn } from '@/utils/cn';
@@ -84,9 +84,12 @@ export const ProjectSidebar = ({
   const { data: currentUser } = useCurrentUserQuery();
   const storedUser = userStorage.get();
 
-  // 읽지 않은 알림 개수 — 최초 1회 fetch 후 SSE notification 이벤트의 unreadCount로 갱신.
-  // 수신함을 열면 SidebarAlarmModal이 목록 쿼리 결과로 이 캐시를 직접 동기화한다.
-  const { data: unreadCount = 0 } = useUnreadCountQuery();
+  // 읽지 않은 알림 개수 — 현재 프로젝트로 필터된 알림 목록에서 직접 파생한다.
+  // 글로벌 unread-count API는 다른 프로젝트의 알림까지 합산하므로 사용하지 않는다.
+  const { data: projectNotifications = [] } = useNotificationListQuery(
+    isProjectIdValid ? (projectId as number) : 0,
+  );
+  const unreadCount = projectNotifications.filter((n) => n.isRead === false).length;
   // SSE로 새로 수신한 알림 여부 (알림창 열면 초기화)
   const [hasNewSseNotification, setHasNewSseNotification] = useState(false);
 
@@ -162,20 +165,9 @@ export const ProjectSidebar = ({
                 // 'notification' 이벤트만 처리 (connect, heartbeat 등은 무시)
                 if (currentEventType === 'notification') {
                   setHasNewSseNotification(true);
-                  // 서버 payload의 실제 unreadCount를 그대로 반영해 카운트 드리프트 방지.
-                  try {
-                    const payload = JSON.parse(line.slice('data:'.length).trim()) as {
-                      unreadCount?: number;
-                    };
-                    if (typeof payload.unreadCount === 'number') {
-                      queryClient.setQueryData(
-                        notificationKeys.unreadCount(),
-                        payload.unreadCount,
-                      );
-                    }
-                  } catch {
-                    // payload 파싱 실패 — dot만 표시
-                  }
+                  // 목록 캐시를 무효화해 새 알림이 반영되도록 한다.
+                  // 뱃지 카운트는 목록에서 파생되므로 별도의 unread-count 캐시 갱신은 불필요.
+                  void queryClient.invalidateQueries({ queryKey: notificationKeys.list() });
                 }
               } else if (line.trim() === '') {
                 // 빈 줄은 메시지 구분자 — event 타입 초기화

--- a/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
+++ b/frontend/src/components/commons/project-sidebar/SidebarAlarmModal.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { IconChevronDoubleLeft, IconInbox } from '@wanteddev/wds-icon';
 import { motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 
 import type { NotificationSummaryResponse } from '@/api/Api';
 import { useErrorToast } from '@/hooks/useErrorToast';
-import { notificationKeys } from '@/queries/keys/notificationKeys';
 import {
   useMarkNotificationReadMutation,
   useNotificationListQuery,
@@ -83,23 +81,13 @@ export const SidebarAlarmModal = ({
   onNotificationClick,
 }: SidebarAlarmModalProps) => {
   const showErrorToast = useErrorToast();
-  const queryClient = useQueryClient();
   const [hasScrolled, setHasScrolled] = useState(false);
 
   // isPending인 동안에는 빈 상태('받은 알림이 없어요')를 그리지 않아 깜빡임을 막는다.
   // 캐시가 남아 있으면 재오픈 시 바로 목록이 보인다.
-  const { data: notifications = [], isPending, isError, error, isSuccess } =
+  const { data: notifications = [], isPending, isError, error } =
     useNotificationListQuery(projectId);
   const markAsRead = useMarkNotificationReadMutation();
-
-  const unreadInList = notifications.filter((n) => n.isRead === false).length;
-
-  // 목록 기준 실제 unread 개수로 뱃지 캐시를 직접 동기화한다(부모 콜백 대신 쿼리 캐시 사용).
-  // SSE는 unreadCount 캐시만 갱신하고 목록은 건드리지 않으므로, 이 effect는 SSE 수신 시 재실행되지 않는다.
-  useEffect(() => {
-    if (!isSuccess) return;
-    queryClient.setQueryData(notificationKeys.unreadCount(), unreadInList);
-  }, [isSuccess, unreadInList, queryClient]);
 
   useEffect(() => {
     if (isError) showErrorToast(error, '알림 목록을 불러오지 못했어요.');

--- a/frontend/src/queries/keys/notificationKeys.ts
+++ b/frontend/src/queries/keys/notificationKeys.ts
@@ -1,6 +1,5 @@
 export const notificationKeys = {
   all: ['notification'] as const,
   setting: (projectId: number) => [...notificationKeys.all, 'setting', projectId] as const,
-  unreadCount: () => [...notificationKeys.all, 'unreadCount'] as const,
   list: () => [...notificationKeys.all, 'list'] as const,
 };

--- a/frontend/src/queries/notification.ts
+++ b/frontend/src/queries/notification.ts
@@ -23,14 +23,6 @@ const fetchNotificationSetting = async (projectId: number) => {
   }
 };
 
-export function useUnreadCountQuery() {
-  return useQuery({
-    queryKey: notificationKeys.unreadCount(),
-    queryFn: () =>
-      privateApi.notification.getUnreadCount().then((res) => res.data.data?.unreadCount ?? 0),
-  });
-}
-
 /**
  * 수신함 알림 목록.
  * 전체 목록을 하나의 캐시(list)로 받아두고 select로 현재 프로젝트만 필터링한다.


### PR DESCRIPTION
## #️⃣연관된 이슈
#372 

## 📝작업 내용

- **수신함 뱃지가 다른 프로젝트의 알림까지 합산되던 문제 수정**

- **SSE 알림 이벤트 처리 방식 변경**
  - 기존: payload의 `unreadCount`를 글로벌 unread-count 캐시에 직접 기록
  - 변경: `notificationKeys.list()` invalidate → 목록 재요청 → 파생 카운트 자동 업데이트
  - 새 알림이 모달 목록에도 즉시 반영됨

- 더 이상 사용되지 않는 `useUnreadCountQuery`, `notificationKeys.unreadCount` 제거
- `SidebarAlarmModal`에서 unread-count 캐시 동기화용 effect 및 관련 `useQueryClient` import 제거