### PR TITLE
[Fix/#375] 참조 코멘트 시간 표시 수정

### DIFF
--- a/frontend/src/components/projects/node-flow/DashedComment.tsx
+++ b/frontend/src/components/projects/node-flow/DashedComment.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect } from 'react';
 
 import { EXAMPLE_PROJECT_SIDEBAR_PROFILE } from '@/constants/exampleConstant';
 import type { Edge } from '@/types/FlowChartTypes';
+import { getRelativeTime } from '@/utils/timeUtils';
 
 type DashedCommentProps =
   | { isCreateMode: true; edge?: never; onCommentCreate?: (comment: string) => void }
@@ -124,7 +125,7 @@ export function DashedComment(props: DashedCommentProps) {
     <CommentDisplay
       avatarSrc={edge.createdBy.profileImageUrl}
       nickname={edge.createdBy.nickname}
-      timeText="2일 전"
+      timeText={getRelativeTime(edge.createdAt)}
       comment={edge.comment}
     />
   );

--- a/frontend/src/components/projects/node-flow/NodeFlowView.tsx
+++ b/frontend/src/components/projects/node-flow/NodeFlowView.tsx
@@ -79,7 +79,11 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
   const { data: flowChart, isFetching: loading } = useFlowchartQuery(projectId);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [sidebarNodeId, setSidebarNodeId] = useState<number | null>(null);
-  const [showDashedLines, setShowDashedLines] = useState(false);
+  const [showDashedLines, setShowDashedLines] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const saved = localStorage.getItem('showDashedLines');
+    return saved !== null ? JSON.parse(saved) : false;
+  });
   const [isCreating, setIsCreating] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [summaryMessageIndex, setSummaryMessageIndex] = useState(0);
@@ -133,16 +137,6 @@ function NodeFlowContent({ projectId }: NodeFlowViewProps) {
     },
     [nodes, setNodes],
   );
-
-  // localStorage에서 점선 표시 상태 불러오기
-  useEffect(() => {
-    const saved = localStorage.getItem('showDashedLines');
-    if (saved !== null) {
-      queueMicrotask(() => {
-        setShowDashedLines(JSON.parse(saved));
-      });
-    }
-  }, []);
 
   // 점선 토글 상태를 localStorage에 저장
   useEffect(() => {

--- a/frontend/src/types/FlowChartTypes.ts
+++ b/frontend/src/types/FlowChartTypes.ts
@@ -54,6 +54,7 @@ export interface Edge {
   endNodeId: number;
   createdBy: EdgeCreator;
   comment: string | null;
+  createdAt: string;
 }
 
 export interface FlowChart {

--- a/frontend/src/utils/timeUtils.ts
+++ b/frontend/src/utils/timeUtils.ts
@@ -31,15 +31,18 @@ export function getRelativeTime(isoString: string): string {
     return `${diffHours}시간 전`;
   }
 
-  // 7일 미만
-  if (diffDays < 7) {
+  // 30일 미만
+  if (diffDays < 30) {
     return `${diffDays}일 전`;
   }
 
-  // 7일 이상 - 날짜 표시
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  // 365일 미만 - 개월 단위
+  if (diffDays < 365) {
+    const diffMonths = Math.floor(diffDays / 30);
+    return `${diffMonths}개월 전`;
+  }
+
+  // 365일 이상 - 년 단위
+  const diffYears = Math.floor(diffDays / 365);
+  return `${diffYears}년 전`;
 }

--- a/frontend/src/utils/timeUtils.ts
+++ b/frontend/src/utils/timeUtils.ts
@@ -43,29 +43,3 @@ export function getRelativeTime(isoString: string): string {
     day: 'numeric',
   });
 }
-
-/**
- * ISO 8601 날짜 문자열을 짧은 상대 시간으로 변환 (간결한 버전)
- * @param isoString - ISO 8601 형식의 날짜 문자열
- * @returns 짧은 상대 시간 텍스트 (예: "3분", "2일")
- */
-export function getShortRelativeTime(isoString: string): string {
-  const date = new Date(isoString);
-  const now = new Date();
-
-  const diffMs = now.getTime() - date.getTime();
-  const diffMinutes = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMinutes < 1) return '지금';
-  if (diffMinutes < 60) return `${diffMinutes}분`;
-  if (diffHours < 24) return `${diffHours}시간`;
-  if (diffDays < 30) return `${diffDays}일`;
-
-  const diffMonths = Math.floor(diffDays / 30);
-  if (diffMonths < 12) return `${diffMonths}개월`;
-
-  const diffYears = Math.floor(diffDays / 365);
-  return `${diffYears}년`;
-}

--- a/frontend/src/utils/timeUtils.ts
+++ b/frontend/src/utils/timeUtils.ts
@@ -1,0 +1,71 @@
+/**
+ * ISO 8601 날짜 문자열을 상대 시간 텍스트로 변환
+ * @param isoString - ISO 8601 형식의 날짜 문자열 (예: "2026-04-15T10:30:00Z")
+ * @returns 상대 시간 텍스트 (예: "방금 전", "3분 전", "2일 전")
+ */
+export function getRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+
+  // 밀리초 차이 계산
+  const diffMs = now.getTime() - date.getTime();
+
+  // 각 단위로 변환
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  // 1분 미만
+  if (diffSeconds < 60) {
+    return '방금 전';
+  }
+
+  // 1시간 미만
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  }
+
+  // 24시간 미만
+  if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  }
+
+  // 7일 미만
+  if (diffDays < 7) {
+    return `${diffDays}일 전`;
+  }
+
+  // 7일 이상 - 날짜 표시
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * ISO 8601 날짜 문자열을 짧은 상대 시간으로 변환 (간결한 버전)
+ * @param isoString - ISO 8601 형식의 날짜 문자열
+ * @returns 짧은 상대 시간 텍스트 (예: "3분", "2일")
+ */
+export function getShortRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMinutes < 1) return '지금';
+  if (diffMinutes < 60) return `${diffMinutes}분`;
+  if (diffHours < 24) return `${diffHours}시간`;
+  if (diffDays < 30) return `${diffDays}일`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}개월`;
+
+  const diffYears = Math.floor(diffDays / 365);
+  return `${diffYears}년`;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#375 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

참조 엣지(점선) 코멘트의 시간 표시가 하드코딩되어 있던 문제를 수정했습니다.

  1. **Edge 타입 확장**
     - `FlowChartTypes.ts`: Edge 인터페이스에 `createdAt` 필드 추가

  2. **상대 시간 계산 유틸리티 추가**
      - `getRelativeTime()`: ISO 8601 날짜를 상대 시간 텍스트로 변환
      - 1분 미만: "방금 전"
      - 1~59분: "N분 전"
      - 1~23시간: "N시간 전"
      - 1~29일: "N일 전"
      - 30~364일: "N개월 전"
      - 365일 이상: "N년 전"

  3. **DashedComment 수정**
     - `getRelativeTime(edge.createdAt)`으로 실제 시간 계산


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
