### PR TITLE
[Feat/#380] 참조 사용자 응답에 이메일 필드 추가

### DIFF
--- a/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedUserResponse.java
+++ b/backend/flowmeet-api/src/main/java/kr/flowmeet/api/chat/dto/response/ReferencedUserResponse.java
@@ -9,6 +9,8 @@ public record ReferencedUserResponse(
         Long userId,
         @Schema(description = "닉네임", example = "홍길동")
         String nickname,
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
         String profileImageUrl
 ) {
@@ -16,6 +18,7 @@ public record ReferencedUserResponse(
         return new ReferencedUserResponse(
                 member.getUserId(),
                 member.getUser().getNickname(),
+                member.getUser().getEmail(),
                 member.getUser().getProfileImageUrl()
         );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #380

## 📝작업 내용

동명이인 구분을 위해 채팅 참조 사용자 조회 API 응답에 이메일 필드를 추가했습니다.

### 참조 사용자 응답 이메일 추가

- `ReferencedUserResponse`에 `email` 필드 추가
- 기존 응답: userId, nickname, profileImageUrl
- 변경 응답: userId, nickname, email, profileImageUrl

## 변경 파일

| 파일 | 변경 |
|------|------|
| `chat/dto/response/ReferencedUserResponse.java` | 수정 — `email` 필드 추가 |

## 💬리뷰 요구사항(선택)

## 💬논의 사항(선택)
